### PR TITLE
docs(workflow): define agent workflow foundation (#23)

### DIFF
--- a/.agents/skills/take-ticket/SKILL.md
+++ b/.agents/skills/take-ticket/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: take-ticket
+description: Run the repository's minimal GitHub issue-to-PR workflow. Use when the user says to take a ticket, implement a GitHub issue, create the draft PR first, coordinate subagents, keep an internal checklist, run deterministic intake/final audits, update the PR, and mark completed work ready for review.
+---
+
+# Take Ticket
+
+## Overview
+
+Use this workflow for a GitHub issue that should become a focused PR. Keep repository rules in `AGENTS.md`; this skill only describes the active task procedure.
+
+## Workflow
+
+1. Run intake checks:
+   - `bash scripts/check-workflow-intake.sh`
+   - read the issue
+   - inspect the worktree before editing
+2. Delegate first exploration to an explorer subagent:
+   - ask for exact request, SPEC/contract impact, likely files, and validation
+   - do not allow file edits
+   - use a lightweight model when available
+3. Main agent owns the contract checklist:
+   - classify SPEC impact
+   - write a short plan
+   - split work if it crosses repository limits
+4. Open the PR before implementation:
+   - create a branch
+   - create an empty kickoff commit
+   - push the branch
+   - open a draft PR with contract, plan, validation, and `Closes #<issue>`
+5. Implement surgically:
+   - one purpose per patch
+   - no cleanup bundled with behavior changes
+   - use worker subagents only for bounded, disjoint ownership
+6. Validate:
+   - run the narrowest relevant command from `AGENTS.md`
+   - report warnings separately from failures
+7. Finish:
+   - update the PR checklist, preferably through a worker subagent
+   - push all commits
+   - mark completed work ready for review
+   - run `bash scripts/check-workflow-final.sh <pr-number>`
+
+## Internal Checklist
+
+Use this locally while working; do not paste it into the public PR template unless useful.
+
+```markdown
+- [ ] Intake script passed.
+- [ ] Explorer returned issue and contract summary.
+- [ ] SPEC impact classified.
+- [ ] Draft PR opened with kickoff commit.
+- [ ] Implementation stayed focused.
+- [ ] Relevant validation ran.
+- [ ] PR checklist updated.
+- [ ] Final audit script passed.
+- [ ] PR marked ready for review.
+```
+
+## Subagent Guidance
+
+- Explorer: issue reading, codebase search, SPEC impact, likely validation. No edits. Prefer a lightweight model such as 5.4-mini.
+- PR checklist worker: PR body updates through `gh`. No repository file edits. Prefer a lightweight model.
+- Code worker: only for bounded, disjoint file ownership. Tell workers they are not alone in the codebase and must not revert others' edits. Use a stronger model only when the slice needs it.
+- Main agent: contract checklist, split decisions, commits, validation, and final state.

--- a/.agents/skills/take-ticket/agents/openai.yaml
+++ b/.agents/skills/take-ticket/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Take Ticket"
+  short_description: "Run the minimal GitHub issue-to-PR workflow."
+  default_prompt: "Use the take-ticket workflow to inspect a GitHub issue, open a draft PR, implement a focused change, run deterministic audits, update the PR, and mark it ready when complete."

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,31 @@
+---
+name: Bug
+about: Report a reproducible RPM behavior problem.
+title: "bug: "
+labels: "bug"
+assignees: ""
+---
+
+## Context
+
+<!-- What failed and why it matters. -->
+
+## Reproduction
+
+```sh
+
+```
+
+## Expected behavior
+
+
+## Actual behavior
+
+
+## Contract impact
+
+<!-- CLI, lockfile, resolver, manifest, cache, linker, scripts, diagnostics, or none. -->
+
+## Done criteria
+
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,28 @@
+---
+name: Task
+about: Define a focused implementation, refactor, or documentation task.
+title: "recovery: "
+labels: ""
+assignees: ""
+---
+
+## Context
+
+<!-- Why this should change. -->
+
+## Contract
+
+<!-- What must be true after the change. Keep this observable and reviewable. -->
+
+## Initial scope
+
+<!-- Files, areas, or boundaries that should be included or excluded. -->
+
+## Done criteria
+
+<!-- Concrete checks for completion. -->
+
+## Related work
+
+<!-- Linked issues, PRs, specs, or notes. -->
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Contract
+
+<!-- What this PR promises to change or preserve. -->
+
+## Changes
+
+<!-- Short implementation summary. -->
+
+## Validation
+
+<!-- Commands run and results. Include warnings separately from failures. -->
+
+## Checklist
+
+- [ ] Scope is focused on one behavior, bug, or mechanical change.
+- [ ] Behavior changes include relevant tests or fixtures.
+- [ ] SPEC impact is classified when contract-affecting.
+- [ ] PR is ready for review when implementation is complete.
+
+Closes #
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,26 @@ Use these limits unless the user explicitly asks for a larger refactor:
 - If a change crosses CLI, resolver, lockfile, registry, and linker boundaries at once, stop and split it.
 - When changing behavior, add or update a fixture or test in the same change.
 
+## Workflow Guidance
+
+Keep long-lived guidance in the right place:
+
+- Repository safety rules belong in `AGENTS.md`.
+- Human contribution process belongs in `CONTRIBUTING.md`.
+- Issue and PR structure belongs in `.github/` templates.
+- Active task procedure belongs in repository skills under `.agents/skills/`.
+- Deterministic checks belong in `scripts/` so hooks, CI, or agents can call them.
+
+Do not make `AGENTS.md` depend on a specific skill. Skills may depend on this guide.
+
+## Commit Discipline
+
+- Use one commit for one reason.
+- Do not combine behavior changes with cleanup, formatting, file moves, or renames.
+- A mechanical rename may be one commit even when it touches many import sites, if it has one purpose and no behavior change.
+- Stage only intended files. Do not use broad staging when unrelated worktree changes exist.
+- Before finishing PR work, verify the worktree is clean, the branch is pushed, validation is reported, and completed work is ready for review.
+
 ## SPEC Discipline
 
 Treat `SPEC.md` as the authority for contracts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+RPM is a package manager prototype. Keep changes small, reviewable, and easy to verify.
+
+## Issues
+
+Use the closest issue template and include:
+
+- context
+- contract or expected behavior
+- initial scope
+- done criteria
+- related work, if any
+
+Issue text explains intent, but it does not override `AGENTS.md` or an owning SPEC.
+
+## Pull Requests
+
+Open PRs with a clear contract and checklist. Keep implementation and cleanup separate.
+
+Before marking a PR ready:
+
+- run the narrowest relevant validation
+- update the PR checklist
+- push the branch
+- confirm the worktree is clean
+- list follow-up work instead of expanding scope
+
+## Automation Boundaries
+
+Use `scripts/` for deterministic checks that agents, hooks, or CI can call.
+
+Current workflow checks are local scripts. Hook and CI integration should be added in focused follow-up work, not bundled with documentation-only workflow changes.
+
+## Commits
+
+Use atomic commits:
+
+- one behavior, bug, or mechanical change per commit
+- no cleanup bundled with behavior changes
+- no file moves bundled with behavior changes
+- explicit staging when the worktree contains unrelated files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,25 +12,22 @@ Use the closest issue template and include:
 - done criteria
 - related work, if any
 
-Issue text explains intent, but it does not override `AGENTS.md` or an owning SPEC.
+Issue text explains intent, but it does not override an owning SPEC.
 
 ## Pull Requests
 
-Open PRs with a clear contract and checklist. Keep implementation and cleanup separate.
+Open PRs with a clear summary, validation notes, and a focused checklist. Keep implementation and cleanup separate.
 
 Before marking a PR ready:
 
 - run the narrowest relevant validation
 - update the PR checklist
 - push the branch
-- confirm the worktree is clean
 - list follow-up work instead of expanding scope
 
-## Automation Boundaries
+## Local Checks
 
-Use `scripts/` for deterministic checks that agents, hooks, or CI can call.
-
-Current workflow checks are local scripts. Hook and CI integration should be added in focused follow-up work, not bundled with documentation-only workflow changes.
+Use local scripts when they match the change you are making. CI remains the shared verification point for pull requests.
 
 ## Commits
 

--- a/scripts/check-workflow-final.sh
+++ b/scripts/check-workflow-final.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  printf 'workflow_final.usage=check-workflow-final.sh <pr-number>\n'
+  exit 2
+fi
+
+pr_number="$1"
+status="ok"
+
+if [ -n "$(git status --short)" ]; then
+  status="fail"
+  printf 'workflow_final.worktree=dirty\n'
+else
+  printf 'workflow_final.worktree=clean\n'
+fi
+
+branch="$(git branch --show-current)"
+if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+  ahead_behind="$(git rev-list --left-right --count HEAD...'@{u}')"
+  printf 'workflow_final.branch=%s\n' "${branch}"
+  printf 'workflow_final.ahead_behind=%s\n' "${ahead_behind}"
+  if [ "${ahead_behind}" != "0	0" ]; then
+    status="fail"
+  fi
+else
+  status="fail"
+  printf 'workflow_final.branch=%s\n' "${branch}"
+  printf 'workflow_final.upstream=missing\n'
+fi
+
+pr_state="$(gh pr view "${pr_number}" --json state --jq '.state')"
+pr_draft="$(gh pr view "${pr_number}" --json isDraft --jq '.isDraft')"
+pr_body="$(gh pr view "${pr_number}" --json body --jq '.body')"
+pr_url="$(gh pr view "${pr_number}" --json url --jq '.url')"
+
+printf 'workflow_final.pr_url=%s\n' "${pr_url}"
+printf 'workflow_final.pr_state=%s\n' "${pr_state}"
+printf 'workflow_final.pr_draft=%s\n' "${pr_draft}"
+
+if [ "${pr_state}" != "OPEN" ] && [ "${pr_state}" != "MERGED" ]; then
+  status="fail"
+fi
+
+if [ "${pr_draft}" != "false" ]; then
+  status="fail"
+fi
+
+for required in "## Contract" "## Validation" "Closes #"; do
+  if printf '%s' "${pr_body}" | grep -Fq "${required}"; then
+    printf 'workflow_final.pr_body.%s=ok\n' "$(printf '%s' "${required}" | tr ' #' '__')"
+  else
+    status="fail"
+    printf 'workflow_final.pr_body.%s=missing\n' "$(printf '%s' "${required}" | tr ' #' '__')"
+  fi
+done
+
+printf 'workflow_final.status=%s\n' "${status}"
+
+if [ "${status}" != "ok" ]; then
+  exit 1
+fi

--- a/scripts/check-workflow-intake.sh
+++ b/scripts/check-workflow-intake.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+status="ok"
+
+current_branch="$(git branch --show-current)"
+short_status="$(git status --short)"
+
+printf 'workflow_intake.branch=%s\n' "${current_branch}"
+
+if [ -n "${short_status}" ]; then
+  status="fail"
+  printf 'workflow_intake.worktree=dirty\n'
+else
+  printf 'workflow_intake.worktree=clean\n'
+fi
+
+if gh auth status >/dev/null 2>&1; then
+  printf 'workflow_intake.gh_auth=ok\n'
+else
+  status="fail"
+  printf 'workflow_intake.gh_auth=fail\n'
+fi
+
+if git remote get-url origin >/dev/null 2>&1; then
+  printf 'workflow_intake.origin=ok\n'
+else
+  status="fail"
+  printf 'workflow_intake.origin=missing\n'
+fi
+
+printf 'workflow_intake.status=%s\n' "${status}"
+
+if [ "${status}" != "ok" ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Contract

- Keep the first workflow foundation minimal.
- Do not make AGENTS.md aware of specific skills.
- Put repository-level commit and atomic-change guidance in AGENTS.md or CONTRIBUTING.md.
- Define issue and PR template requirements for collaboration.
- Keep an internal working checklist template inside the skill, separate from the public PR template.
- Put active task procedure inside the skill, including subagent usage and simple model guidance.
- Define deterministic intake/final-audit script responsibilities with concise output.
- Avoid hook or CI integration beyond documenting follow-up work.
- Hook and CI integration are intentionally follow-up work and are not implemented here.

## Plan

- [x] Open draft PR with kickoff commit.
- [x] Add minimal repository workflow guidance.
- [x] Add GitHub issue and PR templates.
- [x] Add short take-ticket skill with internal checklist and subagent guidance.
- [x] Add concise deterministic workflow audit scripts.
- [x] Validate scripts and docs shape.
- [ ] Mark PR ready when complete.

## Validation

- [x] `bash scripts/check-workflow-intake.sh` passed.
- [x] `python3 /Users/gim-yechan/.agents/skills/skill-creator/scripts/quick_validate.py .agents/skills/take-ticket` passed.
- [x] `bash -n scripts/check-workflow-intake.sh scripts/check-workflow-final.sh` passed.
- [x] `git diff --check HEAD` passed.

Closes #23
