### PR TITLE
recovery: add shared hermetic test fixture helpers

### DIFF
--- a/src/lib/lockfile/mod.rs
+++ b/src/lib/lockfile/mod.rs
@@ -193,19 +193,11 @@ impl LockFile {
 mod lock_file_test {
 
     use super::*;
-    use std::path::PathBuf;
-
-    fn fixture_path(file: &str) -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("fixtures")
-            .join("lockfile")
-            .join(file)
-    }
+    use crate::util::test_support::fixture_path;
 
     #[test]
     fn load_reads_fixture_without_touching_repo_root() {
-        let lock = LockFile::load_from_path(fixture_path("valid.rpm.lock")).unwrap();
+        let lock = LockFile::load_from_path(fixture_path(&["lockfile", "valid.rpm.lock"])).unwrap();
 
         assert_eq!(lock.name, "fixture-app");
         assert_eq!(lock.version, "0.1.0");
@@ -218,7 +210,8 @@ mod lock_file_test {
 
     #[test]
     fn load_rejects_empty_lockfile() {
-        let error = LockFile::load_from_path(fixture_path("empty.rpm.lock")).unwrap_err();
+        let error = LockFile::load_from_path(fixture_path(&["lockfile", "empty.rpm.lock"]))
+            .unwrap_err();
 
         assert_eq!(error.kind(), ErrorKind::InvalidData);
         assert_eq!(error.to_string(), "lockfile is empty");
@@ -226,7 +219,8 @@ mod lock_file_test {
 
     #[test]
     fn load_rejects_invalid_lockfile() {
-        let error = LockFile::load_from_path(fixture_path("invalid.rpm.lock")).unwrap_err();
+        let error = LockFile::load_from_path(fixture_path(&["lockfile", "invalid.rpm.lock"]))
+            .unwrap_err();
 
         assert_eq!(error.kind(), ErrorKind::InvalidData);
         assert!(error.to_string().contains("failed to parse lockfile"));

--- a/src/lib/package_manifest/mod.rs
+++ b/src/lib/package_manifest/mod.rs
@@ -166,34 +166,12 @@ impl PackageManifest {
 mod package_json_test {
 
     use super::PackageManifest;
-    use std::{
-        fs,
-        path::PathBuf,
-        time::{SystemTime, UNIX_EPOCH},
-    };
-
-    fn fixture_path(file: &str) -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("fixtures")
-            .join("package_manifest")
-            .join(file)
-    }
-
-    fn temp_manifest_path() -> PathBuf {
-        let unique_id = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let temp_dir = std::env::temp_dir().join(format!("rpm-package-manifest-{unique_id}"));
-        fs::create_dir_all(&temp_dir).unwrap();
-        temp_dir.join("package.json")
-    }
+    use crate::util::test_support::{fixture_path, TempProject};
 
     #[test]
     fn read_file_uses_fixture_data() {
-        let package =
-            PackageManifest::read_file(fixture_path("manifest-with-fields.json").to_str().unwrap());
+        let fixture = fixture_path(&["package_manifest", "manifest-with-fields.json"]);
+        let package = PackageManifest::read_file(fixture.to_str().unwrap());
 
         let dependencies = package.get_dependencies();
         let dev_dependencies = package.get_dev_dependencies();
@@ -208,8 +186,8 @@ mod package_json_test {
 
     #[test]
     fn read_file_handles_missing_optional_fields() {
-        let package =
-            PackageManifest::read_file(fixture_path("manifest-minimal.json").to_str().unwrap());
+        let fixture = fixture_path(&["package_manifest", "manifest-minimal.json"]);
+        let package = PackageManifest::read_file(fixture.to_str().unwrap());
 
         assert_eq!(package.name.as_deref(), Some("minimal-app"));
         assert!(package.get_dependencies().is_empty());
@@ -219,12 +197,13 @@ mod package_json_test {
 
     #[test]
     fn save_writes_only_to_temp_fixture_copy() {
-        let temp_manifest_path = temp_manifest_path();
-        fs::copy(
-            fixture_path("manifest-with-fields.json"),
-            &temp_manifest_path,
-        )
-        .unwrap();
+        let temp_project = TempProject::new("package-manifest").unwrap();
+        let temp_manifest_path = temp_project
+            .copy_fixture(
+                fixture_path(&["package_manifest", "manifest-with-fields.json"]),
+                "package.json",
+            )
+            .unwrap();
 
         let mut package = PackageManifest::read_file(temp_manifest_path.to_str().unwrap());
         package.add_dependency("socket-store".to_owned(), "^0.1.0".to_owned());
@@ -233,6 +212,5 @@ mod package_json_test {
         let saved = PackageManifest::read_file(temp_manifest_path.to_str().unwrap());
         let dependencies = saved.get_dependencies();
         assert!(dependencies.contains(&("socket-store".to_owned(), "0.1.0".to_owned())));
-        fs::remove_dir_all(temp_manifest_path.parent().unwrap()).unwrap();
     }
 }

--- a/src/lib/util/mod.rs
+++ b/src/lib/util/mod.rs
@@ -25,6 +25,63 @@ pub fn parse_library_name(lib: String) -> (String, String) {
 }
 
 #[cfg(test)]
+pub(crate) mod test_support {
+    use std::{
+        fs,
+        io,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    /// Shared helpers for hermetic tests. Keep all fixture reads explicit and
+    /// copy mutable inputs into unique temp directories before editing them.
+    pub(crate) fn fixture_path(parts: &[&str]) -> PathBuf {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures");
+        for part in parts {
+            path.push(part);
+        }
+        path
+    }
+
+    pub(crate) struct TempProject {
+        root: PathBuf,
+    }
+
+    impl TempProject {
+        pub(crate) fn new(prefix: &str) -> io::Result<Self> {
+            let unique_id = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!("rpm-{prefix}-{unique_id}"));
+            fs::create_dir_all(&root)?;
+            Ok(Self { root })
+        }
+
+        pub(crate) fn copy_fixture<P: AsRef<Path>, Q: AsRef<Path>>(
+            &self,
+            fixture: P,
+            destination: Q,
+        ) -> io::Result<PathBuf> {
+            let destination = self.root.join(destination.as_ref());
+            if let Some(parent) = destination.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(fixture.as_ref(), &destination)?;
+            Ok(destination)
+        }
+    }
+
+    impl Drop for TempProject {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Summary

Add a shared hermetic test helper for copying immutable fixtures into temporary project directories, then use it from the existing manifest and lockfile tests.

## Contract

- No contract change intended.
- This ticket is limited to test infrastructure and a brief reuse pattern for future hermetic tests.

## Plan

- [x] add a shared test helper for fixture paths and temp project copies
- [x] migrate existing manifest and lockfile tests to the shared helper
- [x] run narrow Rust validation first, then broader cargo validation if needed

## Validation

- `cargo test package_json_test -- --nocapture`
- `cargo test lock_file_test -- --nocapture`
- `cargo test`

## Warnings

- existing warnings remain in `src/lib/command/working_process/run.rs` and `src/lib/node_linker/mod.rs`; this ticket does not change them

Closes #26