### PR TITLE
recovery: add baseline Cargo verification in CI

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,13 +10,16 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  verify:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
+    - uses: actions/checkout@v4
+    - name: Check formatting
+      run: cargo fmt --check
+    - name: Check compilation
+      run: cargo check
+    - name: Lint
+      run: cargo clippy --all-targets --all-features
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,16 @@ Before marking a PR ready:
 
 ## Local Checks
 
+Run the narrowest relevant check first. Before marking a PR ready, make sure the
+same baseline Cargo checks that run in CI pass locally:
+
+```sh
+cargo fmt --check
+cargo check
+cargo clippy --all-targets --all-features
+cargo test
+```
+
 Use local scripts when they match the change you are making. CI remains the shared verification point for pull requests.
 
 ## Commits

--- a/src/lib/lockfile/mod.rs
+++ b/src/lib/lockfile/mod.rs
@@ -210,8 +210,8 @@ mod lock_file_test {
 
     #[test]
     fn load_rejects_empty_lockfile() {
-        let error = LockFile::load_from_path(fixture_path(&["lockfile", "empty.rpm.lock"]))
-            .unwrap_err();
+        let error =
+            LockFile::load_from_path(fixture_path(&["lockfile", "empty.rpm.lock"])).unwrap_err();
 
         assert_eq!(error.kind(), ErrorKind::InvalidData);
         assert_eq!(error.to_string(), "lockfile is empty");
@@ -219,8 +219,8 @@ mod lock_file_test {
 
     #[test]
     fn load_rejects_invalid_lockfile() {
-        let error = LockFile::load_from_path(fixture_path(&["lockfile", "invalid.rpm.lock"]))
-            .unwrap_err();
+        let error =
+            LockFile::load_from_path(fixture_path(&["lockfile", "invalid.rpm.lock"])).unwrap_err();
 
         assert_eq!(error.kind(), ErrorKind::InvalidData);
         assert!(error.to_string().contains("failed to parse lockfile"));

--- a/src/lib/util/mod.rs
+++ b/src/lib/util/mod.rs
@@ -27,8 +27,7 @@ pub fn parse_library_name(lib: String) -> (String, String) {
 #[cfg(test)]
 pub(crate) mod test_support {
     use std::{
-        fs,
-        io,
+        fs, io,
         path::{Path, PathBuf},
         time::{SystemTime, UNIX_EPOCH},
     };


### PR DESCRIPTION
## Contract

- Local and CI verification commands match for the baseline Cargo checks requested by issue #19.
- SPEC classification: not RPM runtime contract-affecting under AGENTS.md; no SPEC.md exists or is required for CI/documentation workflow changes.

## Changes

- Implemented the baseline CI verification workflow for the repository.
- Updated the documented and automated checks to run `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets --all-features`, and `cargo test`.
- Kept the change scoped to CI/documentation workflow updates without altering runtime package-manager behavior.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo clippy --all-targets --all-features`
- `cargo test`

Warnings:
- `cargo check` and `cargo test` each report 3 existing `unused-result` warnings.
- `cargo clippy --all-targets --all-features` reports existing warnings but exits 0.

## Checklist

- [x] Scope is focused on one behavior, bug, or mechanical change.
- [x] Behavior changes include relevant tests or fixtures. N/A - CI/documentation-only change; no runtime behavior changed.
- [x] SPEC impact is classified when contract-affecting.
- [x] PR is ready for review when implementation is complete.

Closes #19
