### PR TITLE
docs: define resolver strategy boundary

### DIFF
--- a/docs/specs/resolver.md
+++ b/docs/specs/resolver.md
@@ -1,0 +1,70 @@
+# Spec: Resolver Strategy Boundary
+
+Status: Draft  
+Owner: resolver/install  
+Last reviewed: 2026-05-27
+
+## Purpose
+
+RPM resolves dependency requests before it fetches tarballs, extracts packages,
+links `node_modules`, or writes `rpm.lock` and `package.json`. The resolver
+boundary defines the internal contract for that phase so the first traversal
+implementation can stay simple without becoming the long-term installer shape.
+
+## Contract
+
+The resolver consumes dependency requests and package metadata through explicit
+abstractions. A dependency request includes the package name, the requested
+range or version text, and whether the request is a direct production or direct
+development dependency. Package metadata access supplies available versions,
+dist metadata, and dependency declarations without downloading or extracting
+tarballs as part of traversal.
+
+The resolver produces a resolved dependency graph. Each resolved package record
+preserves both the requested range and the selected version. The graph is the
+input to later installer phases that download tarballs, verify integrity,
+extract packages, link `node_modules`, and write lockfile or manifest state.
+
+Traversal policy is behind a replaceable `ResolutionStrategy` boundary, or an
+equivalent internal abstraction. The resolver must not rely on recursive calls
+for correctness, and callers must not depend on the concrete queue or worklist
+type used by a strategy.
+
+The first strategy is an iterative FIFO worklist:
+
+1. Seed the worklist with direct dependency requests.
+2. Pop the oldest pending request.
+3. Read package metadata through the metadata abstraction.
+4. Select a version according to RPM's version and range contract.
+5. Add or merge the resolved package into the graph.
+6. Enqueue that package's dependency requests.
+7. Continue until the worklist is empty or resolution fails.
+
+Future strategies may replace FIFO traversal with priority-based, heuristic,
+peer-aware, or backtracking behavior without changing fetch, extract, link, or
+lockfile write phases.
+
+## Error Cases
+
+Resolution fails before installer side effects when package metadata is missing,
+a requested range cannot be satisfied, dependency metadata is invalid, or the
+strategy detects an unsupported graph condition. Failed resolution must not be
+reported as a successful install, and it must not cause partial lockfile or
+manifest writes.
+
+## Test Fixtures
+
+Resolver tests should use offline registry metadata fixtures. Each fixture
+should represent one graph scenario and include expected resolved package
+records with requested range and selected version. Integration fixtures may add
+expected lockfile snapshots or filesystem trees for later installer phases, but
+resolver fixtures should not mutate the repository root, `.rpm`, `rpm.lock`, or
+`node_modules`.
+
+## Open Questions
+
+- Which Rust module owns the first `ResolutionStrategy` trait or equivalent
+  type?
+- How should peer dependencies be represented before a peer-aware strategy
+  exists?
+- Should graph conflicts be reported as structured diagnostics before M1?

--- a/docs/specs/resolver.md
+++ b/docs/specs/resolver.md
@@ -25,6 +25,13 @@ preserves both the requested range and the selected version. The graph is the
 input to later installer phases that download tarballs, verify integrity,
 extract packages, link `node_modules`, and write lockfile or manifest state.
 
+Version and range satisfaction rules are owned by the semver resolution
+contract, tracked separately in issue #1. This resolver boundary does not define
+the syntax or precedence rules for `^`, `~`, `*`, comparators, prereleases, or
+tag-like input. Resolver strategies call the version selection abstraction and
+record its selected version; they must not duplicate range parsing policy in the
+traversal implementation.
+
 Traversal policy is behind a replaceable `ResolutionStrategy` boundary, or an
 equivalent internal abstraction. The resolver must not rely on recursive calls
 for correctness, and callers must not depend on the concrete queue or worklist
@@ -35,7 +42,7 @@ The first strategy is an iterative FIFO worklist:
 1. Seed the worklist with direct dependency requests.
 2. Pop the oldest pending request.
 3. Read package metadata through the metadata abstraction.
-4. Select a version according to RPM's version and range contract.
+4. Select a version through the version selection abstraction.
 5. Add or merge the resolved package into the graph.
 6. Enqueue that package's dependency requests.
 7. Continue until the worklist is empty or resolution fails.


### PR DESCRIPTION
## Contract

SPEC status: missing. No owning resolver SPEC existed before this ticket, and issue #21 is contract-affecting design work for the resolver/install boundary. This PR adds the minimal authoritative resolver SPEC under docs/specs/.

## Plan

- [x] Define resolver inputs, outputs, and phase boundaries.
- [x] Define a replaceable resolution strategy boundary.
- [x] Specify the first strategy as an iterative FIFO worklist.
- [x] Leave future room for priority, heuristic, peer-aware, or backtracking strategies.

## Validation

- [x] `test -f docs/specs/resolver.md`
- [x] `cargo check` passed with existing warnings in `src/lib/command/working_process/run.rs` and `src/lib/node_linker/mod.rs`.
- [x] Codex review loop attempted: bot reacted with eyes; no review output, issue comments, inline comments, or review records appeared after polling.
- [x] `bash scripts/check-workflow-final.sh 29`

Closes #21