### PR TITLE
Fix dependency package node_modules links

### DIFF
--- a/docs/specs/node-linker.md
+++ b/docs/specs/node-linker.md
@@ -1,0 +1,49 @@
+# Spec: Node Modules Linker
+
+Status: Draft
+Owner: installer/linker
+Last reviewed: 2026-05-28
+
+## Purpose
+
+RPM links an extracted package set into a `node_modules` filesystem layout after
+dependency resolution and package extraction. The linker contract defines the
+shape that package-local dependency links must create so runtime resolution sees
+only the dependencies declared by each package.
+
+## Contract
+
+For each resolved package, RPM creates dependency links under that package's own
+`node_modules` directory. A dependency link target is calculated from the actual
+dependency package name, not from the parent package being linked.
+
+For example, if package `a` declares dependency `b`, the linker creates:
+
+```text
+node_modules/a/node_modules/b -> node_modules/b
+```
+
+Scoped package names keep their scope directory. If package `a` declares
+`@scope/b`, the linker creates:
+
+```text
+node_modules/a/node_modules/@scope/b -> node_modules/@scope/b
+```
+
+Filesystem operations are part of the contract. Directory creation and symlink
+creation failures must be returned as errors rather than ignored.
+
+Strict dependency visibility remains a design constraint: package-local
+`node_modules` entries should expose declared dependencies, not unrelated
+packages from the root package set.
+
+## Out Of Scope
+
+`.bin` generation is not defined by this contract. It should be specified and
+implemented separately.
+
+## Error Cases
+
+Linking fails if a dependency target package has not been extracted, if the
+destination directory cannot be created, or if the symlink cannot be created.
+Failed linking must not be reported as a successful install or script setup.

--- a/src/lib/command/working_process/run.rs
+++ b/src/lib/command/working_process/run.rs
@@ -5,7 +5,7 @@ pub async fn run(script_key: String) -> Result<(), std::io::Error> {
     let package = PackageManifest::read_file("./package.json");
     let scripts = package.get_scripts();
     let script = scripts.get(&script_key);
-    NodeModules::init();
+    NodeModules::init()?;
 
     if let Some(script) = script {
         println!("Running script: {}", script);
@@ -15,10 +15,10 @@ pub async fn run(script_key: String) -> Result<(), std::io::Error> {
         let cmd = args.next().unwrap();
         let args: Vec<&str> = args.collect();
         if cmd == "node" {
-            Command::new("node").args(&args).exec();
+            return Err(Command::new("node").args(&args).exec());
         } else {
             let path = getbin(cmd);
-            Command::new(path).args(&args).exec();
+            return Err(Command::new(path).args(&args).exec());
         }
     } else {
         println!("script not found");

--- a/src/lib/node_linker/mod.rs
+++ b/src/lib/node_linker/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::{self, File},
-    io::Write,
+    io::{Error, ErrorKind, Write},
     os::unix::fs::symlink,
     path::{Path, PathBuf},
     thread::sleep,
@@ -12,7 +12,6 @@ use crate::{
     package_manifest::PackageManifest,
 };
 use flate2::read::GzDecoder;
-use regex::Regex;
 use tar::Archive;
 
 pub struct NodeModules {
@@ -39,48 +38,56 @@ impl NodeModules {
         self.path.join(name)
     }
 
-    pub fn init() -> Self {
+    pub fn init() -> Result<Self, std::io::Error> {
         let dir = PathBuf::from("node_modules");
         if dir.exists() {
-            fs::remove_dir_all(&dir).unwrap();
+            fs::remove_dir_all(&dir)?;
         }
         let mut modules = Self::new(dir);
-        let lock_file = LockFile::load().unwrap();
+        let lock_file = LockFile::load()?;
         let packages = lock_file.get_packages();
         let cache_resolver = NodeResolver::new();
-        cache_resolver.resolve_deps(&mut modules, &packages);
-        modules.linking(packages);
-        modules
+        cache_resolver.resolve_deps(&mut modules, &packages)?;
+        modules.linking(packages)?;
+        Ok(modules)
     }
 
     // symbolic_linking
-    pub fn linking(&self, deps: Vec<(&String, &Dependency)>) {
+    pub fn linking(&self, deps: Vec<(&String, &Dependency)>) -> Result<(), std::io::Error> {
         for (key, dependency) in deps {
             print!("linking: {} ", key);
-            std::io::stdout().flush().unwrap();
+            std::io::stdout().flush()?;
             sleep(std::time::Duration::from_millis(1));
             print!("\r\x1B[K");
-            let pkg_name_regex = Regex::new(r"^(?P<name>.*)@(?P<version>.*)$").unwrap();
-            let pkg_name = pkg_name_regex.captures(&key).unwrap();
-            let name = pkg_name.name("name").unwrap().as_str();
+            let name = package_name_from_lock_key(key)?;
             let root = self.get_path();
-            // ex react
             for dep_name in dependency.get_dependencies_name() {
-                let dest_node_modules =
-                    PathBuf::from(format!("{}/{}/node_modules", root.to_str().unwrap(), name));
-                let destination = dest_node_modules.join(dep_name);
-                let dest_node_modules = destination.parent().unwrap();
-                let link_path = root.join(name);
+                let destination = root.join(name).join("node_modules").join(&dep_name);
+                let dest_node_modules = destination.parent().ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::InvalidInput,
+                        format!("dependency destination has no parent: {destination:?}"),
+                    )
+                })?;
+                let link_path = fs::canonicalize(root.join(&dep_name))?;
                 if !dest_node_modules.exists() {
-                    fs::create_dir_all(&dest_node_modules).unwrap();
+                    fs::create_dir_all(dest_node_modules)?;
                 }
 
                 if !destination.exists() {
-                    symlink(link_path, destination);
+                    symlink(link_path, destination)?;
                 }
             }
         }
+        Ok(())
     }
+}
+
+fn package_name_from_lock_key(key: &str) -> Result<&str, std::io::Error> {
+    key.rsplit_once('@')
+        .map(|(name, _version)| name)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, format!("invalid lock key: {key}")))
 }
 
 struct NodeResolver {
@@ -98,18 +105,18 @@ impl NodeResolver {
         &self,
         node_module: &mut NodeModules,
         dependencies: &Vec<(&String, &Dependency)>,
-    ) {
+    ) -> Result<(), std::io::Error> {
         for (key, dependency) in dependencies {
             print!("resolving: {} ", key);
-            std::io::stdout().flush().unwrap();
+            std::io::stdout().flush()?;
             sleep(std::time::Duration::from_millis(1));
             print!("\r\x1B[K");
 
-            self.resolve_tgz(node_module, key.to_string(), &dependency.to_owned())
-                .expect("resolve tgz error");
+            self.resolve_tgz(node_module, key.to_string(), dependency.to_owned())?;
 
             // .expect(format!("resolve tgz error {}", key).as_str());
         }
+        Ok(())
     }
 
     fn resolve_tgz(
@@ -118,9 +125,7 @@ impl NodeResolver {
         key: String,
         dependency: &Dependency,
     ) -> Result<(), std::io::Error> {
-        let pkg_name_regex = Regex::new(r"^(?P<name>.*)@(?P<version>.*)$").unwrap();
-        let pkg_name = pkg_name_regex.captures(&key).unwrap();
-        let name = pkg_name.name("name").unwrap().as_str();
+        let name = package_name_from_lock_key(&key)?;
         let cached_version = dependency.get_version();
         let tgz_name = name.replace("/", "-");
         let tgz_path = &format!("{}/{}@{}.tgz", self.cache_dir, &tgz_name, cached_version);
@@ -133,7 +138,7 @@ impl NodeResolver {
         let destination = node_module.get_destination(name.to_string());
 
         if !destination.exists() {
-            archive.unpack(&destination).expect("[Error] unpack error");
+            archive.unpack(&destination)?;
         };
         let pkg_path = destination.join("package");
 
@@ -148,7 +153,12 @@ impl NodeResolver {
             // 만약 파일을 resolve했을때, nodemodules/pkg/pkg 이렇게 되어있는 경우
             // node_module/pkg을 pkg로 옮겨준다.
             for entry in destination
-                .join(name.split('/').last().unwrap())
+                .join(name.rsplit('/').next().ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::InvalidData,
+                        format!("invalid package name: {name}"),
+                    )
+                })?)
                 .read_dir()?
             {
                 let entry = entry?;
@@ -158,5 +168,108 @@ impl NodeResolver {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    struct TempNodeModules {
+        path: PathBuf,
+    }
+
+    impl TempNodeModules {
+        fn new() -> Self {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_nanos())
+                .unwrap_or(0);
+            let path = std::env::temp_dir()
+                .join(format!("rpm-node-linker-{}-{nanos}", std::process::id()));
+            fs::create_dir_all(path.join("node_modules")).unwrap();
+            Self { path }
+        }
+
+        fn node_modules(&self) -> PathBuf {
+            self.path.join("node_modules")
+        }
+    }
+
+    impl Drop for TempNodeModules {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn dependency(version: &str, dependencies: &[&str]) -> Dependency {
+        Dependency::new(
+            version.to_string(),
+            Some(dependencies.iter().map(|dep| dep.to_string()).collect()),
+        )
+    }
+
+    #[test]
+    fn linking_points_dependency_to_actual_package() {
+        let temp = TempNodeModules::new();
+        let root = temp.node_modules();
+        fs::create_dir_all(root.join("a")).unwrap();
+        fs::create_dir_all(root.join("b")).unwrap();
+        let node_modules = NodeModules::new(root.clone());
+        let parent_key = "a@1.0.0".to_string();
+        let parent = dependency("1.0.0", &["b@1.0.0"]);
+
+        node_modules.linking(vec![(&parent_key, &parent)]).unwrap();
+
+        let link = fs::read_link(root.join("a").join("node_modules").join("b")).unwrap();
+        assert_eq!(link, fs::canonicalize(root.join("b")).unwrap());
+    }
+
+    #[test]
+    fn linking_preserves_scoped_dependency_path() {
+        let temp = TempNodeModules::new();
+        let root = temp.node_modules();
+        fs::create_dir_all(root.join("a")).unwrap();
+        fs::create_dir_all(root.join("@scope").join("b")).unwrap();
+        let node_modules = NodeModules::new(root.clone());
+        let parent_key = "a@1.0.0".to_string();
+        let parent = dependency("1.0.0", &["@scope/b@^1.0.0"]);
+
+        node_modules.linking(vec![(&parent_key, &parent)]).unwrap();
+
+        let link =
+            fs::read_link(root.join("a").join("node_modules").join("@scope").join("b")).unwrap();
+        assert_eq!(
+            link,
+            fs::canonicalize(root.join("@scope").join("b")).unwrap()
+        );
+    }
+
+    #[test]
+    fn linking_returns_error_when_dependency_target_is_missing() {
+        let temp = TempNodeModules::new();
+        let root = temp.node_modules();
+        fs::create_dir_all(root.join("a")).unwrap();
+        let node_modules = NodeModules::new(root);
+        let parent_key = "a@1.0.0".to_string();
+        let parent = dependency("1.0.0", &["missing@1.0.0"]);
+
+        let error = node_modules
+            .linking(vec![(&parent_key, &parent)])
+            .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn package_name_from_lock_key_handles_scoped_names() {
+        assert_eq!(
+            package_name_from_lock_key("@scope/pkg@1.2.3").unwrap(),
+            "@scope/pkg"
+        );
     }
 }


### PR DESCRIPTION
## Contract
- Contract-affecting: node_modules layout and symlink targets.
- SPEC owner: added docs/specs/node-linker.md for dependency link behavior.
- Issue: Closes #17

## Plan
- [x] Add a focused SPEC for dependency linking behavior.
- [x] Fix dependency links so each declared dependency points to the actual dependency package, including scoped packages.
- [x] Return symlink and filesystem failures instead of silently ignoring them.
- [x] Add fixture-style temp filesystem tests for resulting node_modules shape.
- [x] Split .bin generation out of this focused patch.

## Validation
- [x] cargo fmt --check
- [x] cargo check
- [x] cargo test
- [x] cargo clippy --all-targets --all-features (passes; existing warnings remain outside this patch)