### PR TITLE
Make install output replacement non-destructive

### DIFF
--- a/docs/specs/install-recovery.md
+++ b/docs/specs/install-recovery.md
@@ -1,0 +1,32 @@
+# Spec: Install Recovery
+
+Status: Draft
+Owner: installer/recovery
+Last reviewed: 2026-05-28
+
+## Purpose
+
+RPM must not destroy a working project while preparing replacement install
+output. Recovery behavior defines when `node_modules` can be replaced and how
+failures are reported to callers.
+
+## Contract
+
+Install output replacement is staged. RPM builds replacement `node_modules`
+content in a temporary sibling directory first, while the existing
+`node_modules` remains in place.
+
+RPM replaces the existing directory only after extraction and linking both
+complete successfully. If replacement itself fails, RPM attempts to restore the
+previous directory before returning the write failure.
+
+Failures must include the failed phase in the returned error message. This
+contract currently enforces `resolve`, `extract`, `link`, and `write` labels for
+cached package installation. Registry fetch errors will join this contract when
+the fetch path returns cache write and download failures.
+
+## Error Cases
+
+A failed resolve, fetch, extract, or link phase must leave the previous
+`node_modules` directory untouched. A failed write phase must not be reported as
+a successful install.

--- a/src/lib/lockfile/mod.rs
+++ b/src/lib/lockfile/mod.rs
@@ -1,4 +1,4 @@
-mod constraint;
+pub(crate) mod constraint;
 
 use constraint::LOCK_FILE_PATH;
 use regex::Regex;

--- a/src/lib/node_linker/mod.rs
+++ b/src/lib/node_linker/mod.rs
@@ -8,12 +8,14 @@ use std::{
 
 use crate::{
     common::constraint::CACHE_DIR,
+    lockfile::constraint::LOCK_FILE_PATH,
     lockfile::{Dependency, LockFile},
     package_manifest::PackageManifest,
 };
 use flate2::read::GzDecoder;
 use tar::Archive;
 
+#[derive(Debug)]
 pub struct NodeModules {
     pub path: PathBuf,
 }
@@ -39,16 +41,57 @@ impl NodeModules {
     }
 
     pub fn init() -> Result<Self, std::io::Error> {
-        let dir = PathBuf::from("node_modules");
-        if dir.exists() {
-            fs::remove_dir_all(&dir)?;
+        Self::init_from_paths("node_modules", LOCK_FILE_PATH, CACHE_DIR)
+    }
+
+    fn init_from_paths<P, Q, R>(
+        node_modules_path: P,
+        lockfile_path: Q,
+        cache_dir: R,
+    ) -> Result<Self, std::io::Error>
+    where
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+        R: AsRef<Path>,
+    {
+        let dir = node_modules_path.as_ref();
+        let staging_dir = staging_path(dir);
+        if staging_dir.exists() {
+            fs::remove_dir_all(&staging_dir).map_err(|error| phase_error("write", error))?;
         }
-        let mut modules = Self::new(dir);
-        let lock_file = LockFile::load()?;
+        fs::create_dir_all(&staging_dir).map_err(|error| phase_error("write", error))?;
+
+        let result = Self::build_staged(&staging_dir, lockfile_path, cache_dir)
+            .and_then(|modules| replace_node_modules(dir, &staging_dir).map(|()| modules));
+
+        if result.is_err() {
+            let _ = fs::remove_dir_all(&staging_dir);
+        }
+
+        result.map(|_| Self::new(dir.to_path_buf()))
+    }
+
+    fn build_staged<P, Q, R>(
+        staging_dir: P,
+        lockfile_path: Q,
+        cache_dir: R,
+    ) -> Result<Self, std::io::Error>
+    where
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+        R: AsRef<Path>,
+    {
+        let mut modules = Self::new(staging_dir.as_ref().to_path_buf());
+        let lock_file = LockFile::load_from_path(lockfile_path)
+            .map_err(|error| phase_error("resolve", error))?;
         let packages = lock_file.get_packages();
-        let cache_resolver = NodeResolver::new();
-        cache_resolver.resolve_deps(&mut modules, &packages)?;
-        modules.linking(packages)?;
+        let cache_resolver = NodeResolver::new(cache_dir.as_ref().to_path_buf());
+        cache_resolver
+            .resolve_deps(&mut modules, &packages)
+            .map_err(|error| phase_error("extract", error))?;
+        modules
+            .linking(packages)
+            .map_err(|error| phase_error("link", error))?;
         Ok(modules)
     }
 
@@ -69,7 +112,8 @@ impl NodeModules {
                         format!("dependency destination has no parent: {destination:?}"),
                     )
                 })?;
-                let link_path = fs::canonicalize(root.join(&dep_name))?;
+                fs::metadata(root.join(&dep_name))?;
+                let link_path = dependency_link_target(name, &dep_name);
                 if !dest_node_modules.exists() {
                     fs::create_dir_all(dest_node_modules)?;
                 }
@@ -83,6 +127,62 @@ impl NodeModules {
     }
 }
 
+fn phase_error(phase: &str, error: std::io::Error) -> std::io::Error {
+    Error::new(error.kind(), format!("{phase} failed: {error}"))
+}
+
+fn staging_path(node_modules_path: &Path) -> PathBuf {
+    let parent = node_modules_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    parent.join(format!(".node_modules.rpm-staging-{}", std::process::id()))
+}
+
+fn backup_path(node_modules_path: &Path) -> PathBuf {
+    let parent = node_modules_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    parent.join(format!(".node_modules.rpm-backup-{}", std::process::id()))
+}
+
+fn replace_node_modules(target: &Path, staging_dir: &Path) -> Result<(), std::io::Error> {
+    let backup_dir = backup_path(target);
+    if backup_dir.exists() {
+        fs::remove_dir_all(&backup_dir).map_err(|error| phase_error("write", error))?;
+    }
+
+    if target.exists() {
+        fs::rename(target, &backup_dir).map_err(|error| phase_error("write", error))?;
+    }
+
+    match fs::rename(staging_dir, target) {
+        Ok(()) => {
+            if backup_dir.exists() {
+                fs::remove_dir_all(&backup_dir).map_err(|error| phase_error("write", error))?;
+            }
+            Ok(())
+        }
+        Err(error) => {
+            if backup_dir.exists() {
+                let _ = fs::rename(&backup_dir, target);
+            }
+            Err(phase_error("write", error))
+        }
+    }
+}
+
+fn dependency_link_target(parent_name: &str, dependency_name: &str) -> PathBuf {
+    let up_levels = Path::new(parent_name).components().count()
+        + Path::new(dependency_name).components().count();
+    let mut target = PathBuf::new();
+    for _ in 0..up_levels {
+        target.push("..");
+    }
+    target.join(dependency_name)
+}
+
 fn package_name_from_lock_key(key: &str) -> Result<&str, std::io::Error> {
     key.rsplit_once('@')
         .map(|(name, _version)| name)
@@ -91,14 +191,12 @@ fn package_name_from_lock_key(key: &str) -> Result<&str, std::io::Error> {
 }
 
 struct NodeResolver {
-    cache_dir: String,
+    cache_dir: PathBuf,
 }
 
 impl NodeResolver {
-    fn new() -> Self {
-        Self {
-            cache_dir: CACHE_DIR.to_string(),
-        }
+    fn new(cache_dir: PathBuf) -> Self {
+        Self { cache_dir }
     }
 
     fn resolve_deps(
@@ -128,9 +226,9 @@ impl NodeResolver {
         let name = package_name_from_lock_key(&key)?;
         let cached_version = dependency.get_version();
         let tgz_name = name.replace("/", "-");
-        let tgz_path = &format!("{}/{}@{}.tgz", self.cache_dir, &tgz_name, cached_version);
-
-        let tgz_path = Path::new(&tgz_path);
+        let tgz_path = self
+            .cache_dir
+            .join(format!("{}@{}.tgz", &tgz_name, cached_version));
         let tgz = File::open(tgz_path)?;
         let gz = GzDecoder::new(tgz);
         let mut archive = Archive::new(gz);
@@ -174,10 +272,12 @@ impl NodeResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use flate2::{write::GzEncoder, Compression};
     use std::{
         fs,
         time::{SystemTime, UNIX_EPOCH},
     };
+    use tar::{Builder, Header};
 
     struct TempNodeModules {
         path: PathBuf,
@@ -198,6 +298,14 @@ mod tests {
         fn node_modules(&self) -> PathBuf {
             self.path.join("node_modules")
         }
+
+        fn cache_dir(&self) -> PathBuf {
+            self.path.join("cache")
+        }
+
+        fn lockfile_path(&self) -> PathBuf {
+            self.path.join("rpm.lock")
+        }
     }
 
     impl Drop for TempNodeModules {
@@ -213,6 +321,37 @@ mod tests {
         )
     }
 
+    fn write_lockfile(path: &Path, package: &str, dependencies: &[&str]) {
+        let dependencies = dependencies
+            .iter()
+            .map(|dependency| format!("\"{dependency}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        fs::write(
+            path,
+            format!(
+                "name = \"fixture-app\"\nversion = \"0.1.0\"\n\n[\"{package}@1.0.0\"]\nversion = \"1.0.0\"\ndependencies = [{dependencies}]\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    fn write_package_tgz(cache_dir: &Path, package: &str, version: &str) {
+        fs::create_dir_all(cache_dir).unwrap();
+        let tarball_name = format!("{}@{}.tgz", package.replace("/", "-"), version);
+        let tarball = fs::File::create(cache_dir.join(tarball_name)).unwrap();
+        let encoder = GzEncoder::new(tarball, Compression::default());
+        let mut builder = Builder::new(encoder);
+        let package_json = br#"{"name":"fixture"}"#;
+        let mut header = Header::new_gnu();
+        header.set_path("package/package.json").unwrap();
+        header.set_size(package_json.len() as u64);
+        header.set_cksum();
+        builder.append(&header, &package_json[..]).unwrap();
+        builder.finish().unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+    }
+
     #[test]
     fn linking_points_dependency_to_actual_package() {
         let temp = TempNodeModules::new();
@@ -226,7 +365,7 @@ mod tests {
         node_modules.linking(vec![(&parent_key, &parent)]).unwrap();
 
         let link = fs::read_link(root.join("a").join("node_modules").join("b")).unwrap();
-        assert_eq!(link, fs::canonicalize(root.join("b")).unwrap());
+        assert_eq!(link, PathBuf::from("../../b"));
     }
 
     #[test]
@@ -243,10 +382,7 @@ mod tests {
 
         let link =
             fs::read_link(root.join("a").join("node_modules").join("@scope").join("b")).unwrap();
-        assert_eq!(
-            link,
-            fs::canonicalize(root.join("@scope").join("b")).unwrap()
-        );
+        assert_eq!(link, PathBuf::from("../../../@scope/b"));
     }
 
     #[test]
@@ -271,5 +407,61 @@ mod tests {
             package_name_from_lock_key("@scope/pkg@1.2.3").unwrap(),
             "@scope/pkg"
         );
+    }
+
+    #[test]
+    fn init_keeps_existing_node_modules_when_extract_fails() {
+        let temp = TempNodeModules::new();
+        let existing_file = temp.node_modules().join("keep.txt");
+        fs::write(&existing_file, "existing").unwrap();
+        write_lockfile(&temp.lockfile_path(), "a", &[]);
+
+        let error = NodeModules::init_from_paths(
+            temp.node_modules(),
+            temp.lockfile_path(),
+            temp.cache_dir(),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("extract failed"));
+        assert_eq!(fs::read_to_string(existing_file).unwrap(), "existing");
+    }
+
+    #[test]
+    fn init_keeps_existing_node_modules_when_link_fails() {
+        let temp = TempNodeModules::new();
+        let existing_file = temp.node_modules().join("keep.txt");
+        fs::write(&existing_file, "existing").unwrap();
+        write_lockfile(&temp.lockfile_path(), "a", &["missing@1.0.0"]);
+        write_package_tgz(&temp.cache_dir(), "a", "1.0.0");
+
+        let error = NodeModules::init_from_paths(
+            temp.node_modules(),
+            temp.lockfile_path(),
+            temp.cache_dir(),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("link failed"));
+        assert_eq!(fs::read_to_string(existing_file).unwrap(), "existing");
+    }
+
+    #[test]
+    fn init_keeps_dependency_links_valid_after_replacement() {
+        let temp = TempNodeModules::new();
+        fs::write(
+            temp.lockfile_path(),
+            "name = \"fixture-app\"\nversion = \"0.1.0\"\n\n[\"a@1.0.0\"]\nversion = \"1.0.0\"\ndependencies = [\"b@1.0.0\"]\n\n[\"b@1.0.0\"]\nversion = \"1.0.0\"\ndependencies = []\n",
+        )
+        .unwrap();
+        write_package_tgz(&temp.cache_dir(), "a", "1.0.0");
+        write_package_tgz(&temp.cache_dir(), "b", "1.0.0");
+
+        NodeModules::init_from_paths(temp.node_modules(), temp.lockfile_path(), temp.cache_dir())
+            .unwrap();
+
+        let link =
+            fs::read_link(temp.node_modules().join("a").join("node_modules").join("b")).unwrap();
+        assert_eq!(link, PathBuf::from("../../b"));
     }
 }


### PR DESCRIPTION
## Contract
- Contract-affecting: node_modules replacement timing, install failure behavior, and phase diagnostics.
- SPEC owner: added docs/specs/install-recovery.md for recovery semantics.
- Stacked on PR #33 because link failure propagation is introduced there.
- Closes #16

## Plan
- [x] Add a focused install recovery SPEC before changing code.
- [x] Build replacement node_modules in a temporary sibling before touching existing output.
- [x] Keep existing node_modules intact when cached tarball extraction fails.
- [x] Keep existing node_modules intact when dependency linking fails.
- [x] Return phase-labelled errors for resolve, extract, link, and write paths in the linker setup.
- [x] Keep registry/API fetch error plumbing split out to avoid crossing repository limits in this patch.

## Validation
- [x] cargo fmt --check
- [x] cargo check
- [x] cargo test node_linker
- [x] cargo test
- [x] cargo clippy --all-targets --all-features (passes; existing warnings remain outside this patch)