### PR TITLE
Stabilize rpm run script execution

### DIFF
--- a/docs/specs/run-scripts.md
+++ b/docs/specs/run-scripts.md
@@ -1,0 +1,29 @@
+# Spec: Run Scripts
+
+Status: Draft
+Owner: cli/run
+Last reviewed: 2026-05-28
+
+## Purpose
+
+`rpm run` executes scripts from the root package manifest. Running a script must
+not reinstall dependencies or mutate install output as a side effect.
+
+## Contract
+
+`rpm run <script>` reads `package.json`, checks that `<script>` exists, and
+returns a clean missing-script error before touching install output.
+
+Scripts execute through the platform shell so command chaining, quoting, and
+environment assignment follow normal package-script semantics. RPM prepends the
+project's `node_modules/.bin` directory to `PATH` for the child process.
+
+The CLI returns the child process exit code when the script starts and exits
+normally. If the script process cannot be spawned, RPM returns a readable run
+error.
+
+## Error Cases
+
+Missing scripts fail without modifying `node_modules`. Missing binaries reached
+through shell execution should produce the shell's readable error and non-zero
+status. Script failures must preserve the child process status.

--- a/src/lib/command/working_process/run.rs
+++ b/src/lib/command/working_process/run.rs
@@ -1,42 +1,237 @@
-use crate::{node_linker::NodeModules, package_manifest::PackageManifest};
-use std::{os::unix::process::CommandExt, process::Command};
+use crate::package_manifest::PackageManifest;
+use std::{
+    env,
+    ffi::OsString,
+    fs,
+    io::{Error, ErrorKind},
+    path::Path,
+    process::Command,
+};
 
-pub async fn run(script_key: String) -> Result<(), std::io::Error> {
+pub async fn run(script_key: String) -> Result<i32, std::io::Error> {
     let package = PackageManifest::read_file("./package.json");
+    run_script(&script_key, &package, Path::new("."))
+}
+
+fn run_script(
+    script_key: &str,
+    package: &PackageManifest,
+    project_root: &Path,
+) -> Result<i32, std::io::Error> {
     let scripts = package.get_scripts();
-    let script = scripts.get(&script_key);
-    NodeModules::init()?;
+    let script = scripts.get(script_key).ok_or_else(|| {
+        Error::new(
+            ErrorKind::NotFound,
+            format!("script not found: {script_key}"),
+        )
+    })?;
 
-    if let Some(script) = script {
-        println!("Running script: {}", script);
+    println!("Running script: {}", script);
 
-        // script like "node index.js"
-        let mut args = script.split(' ');
-        let cmd = args.next().unwrap();
-        let args: Vec<&str> = args.collect();
-        if cmd == "node" {
-            return Err(Command::new("node").args(&args).exec());
-        } else {
-            let path = getbin(cmd);
-            return Err(Command::new(path).args(&args).exec());
-        }
-    } else {
-        println!("script not found");
+    let mut command = shell_command(script);
+    command.current_dir(project_root);
+    command.env("PATH", script_path(project_root)?);
+    let status = command.status().map_err(|error| {
+        Error::new(
+            error.kind(),
+            format!("failed to run script `{script_key}`: {error}"),
+        )
+    })?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+#[cfg(unix)]
+fn shell_command(script: &str) -> Command {
+    let mut command = Command::new("/bin/sh");
+    command.arg("-c").arg(script);
+    command
+}
+
+#[cfg(windows)]
+fn shell_command(script: &str) -> Command {
+    let mut command = Command::new("cmd");
+    command.arg("/C").arg(script);
+    command
+}
+
+fn script_path(project_root: &Path) -> Result<OsString, std::io::Error> {
+    let mut paths = vec![fs::canonicalize(project_root)?
+        .join("node_modules")
+        .join(".bin")];
+    if let Some(path) = env::var_os("PATH") {
+        paths.extend(env::split_paths(&path));
     }
 
-    Ok(())
+    env::join_paths(paths).map_err(|error| Error::new(ErrorKind::InvalidInput, error))
 }
 
-fn getbin(cmd: &str) -> String {
-    let path = get_bing_path(cmd);
-    let node_modules = "./node_modules";
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        os::unix::fs::PermissionsExt,
+        path::PathBuf,
+        sync::atomic::{AtomicU64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
-    let path = format!("{}/{}/{}", node_modules, cmd, path);
-    path
-}
+    static TEMP_PROJECT_ID: AtomicU64 = AtomicU64::new(0);
 
-fn get_bing_path(cmd: &str) -> String {
-    let package = NodeModules::read_package(cmd);
-    let bin = package.get_bin().unwrap();
-    bin.get(cmd).unwrap().to_string()
+    struct TempRunProject {
+        root: PathBuf,
+    }
+
+    impl TempRunProject {
+        fn new() -> Self {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_nanos())
+                .unwrap_or(0);
+            let counter = TEMP_PROJECT_ID.fetch_add(1, Ordering::SeqCst);
+            let root = env::temp_dir().join(format!("rpm-run-{}-{nanos}", std::process::id()));
+            let root = root.with_extension(counter.to_string());
+            fs::create_dir_all(&root).unwrap();
+            Self { root }
+        }
+
+        fn write_manifest(&self, scripts: &[(&str, &str)]) -> PackageManifest {
+            let scripts = scripts
+                .iter()
+                .map(|(key, value)| format!("\"{key}\": \"{value}\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            fs::write(
+                self.root.join("package.json"),
+                format!("{{\"scripts\": {{{scripts}}}}}"),
+            )
+            .unwrap();
+            PackageManifest::read_file(self.root.join("package.json").to_str().unwrap())
+        }
+    }
+
+    impl Drop for TempRunProject {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[test]
+    fn missing_script_does_not_mutate_node_modules() {
+        let temp = TempRunProject::new();
+        let package = temp.write_manifest(&[]);
+        let existing_file = temp.root.join("node_modules").join("keep.txt");
+        fs::create_dir_all(existing_file.parent().unwrap()).unwrap();
+        fs::write(&existing_file, "existing").unwrap();
+
+        let error = run_script("missing", &package, &temp.root).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::NotFound);
+        assert_eq!(fs::read_to_string(existing_file).unwrap(), "existing");
+    }
+
+    #[test]
+    fn script_uses_shell_semantics() {
+        let temp = TempRunProject::new();
+        let package =
+            temp.write_manifest(&[("build", "echo one > out.txt && echo two >> out.txt")]);
+
+        let status = run_script("build", &package, &temp.root).unwrap();
+
+        assert_eq!(status, 0);
+        assert_eq!(
+            fs::read_to_string(temp.root.join("out.txt")).unwrap(),
+            "one\ntwo\n"
+        );
+    }
+
+    #[test]
+    fn script_path_includes_node_modules_bin() {
+        let temp = TempRunProject::new();
+        let bin = temp
+            .root
+            .join("node_modules")
+            .join(".bin")
+            .join("fixture-bin");
+        fs::create_dir_all(bin.parent().unwrap()).unwrap();
+        fs::write(&bin, "#!/bin/sh\necho bin-ok > bin.txt\n").unwrap();
+        let mut permissions = fs::metadata(&bin).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&bin, permissions).unwrap();
+        let package = temp.write_manifest(&[("bin", "fixture-bin")]);
+
+        let status = run_script("bin", &package, &temp.root).unwrap();
+
+        assert_eq!(status, 0);
+        assert_eq!(
+            fs::read_to_string(temp.root.join("bin.txt")).unwrap(),
+            "bin-ok\n"
+        );
+    }
+
+    #[test]
+    fn script_status_is_preserved() {
+        let temp = TempRunProject::new();
+        let package = temp.write_manifest(&[("fail", "exit 7")]);
+
+        let status = run_script("fail", &package, &temp.root).unwrap();
+
+        assert_eq!(status, 7);
+    }
+
+    #[test]
+    fn missing_binary_returns_shell_status() {
+        let temp = TempRunProject::new();
+        let package = temp.write_manifest(&[("missing-bin", "definitely-not-rpm-fixture-bin")]);
+
+        let status = run_script("missing-bin", &package, &temp.root).unwrap();
+
+        assert_ne!(status, 0);
+    }
+
+    #[test]
+    fn package_bin_named_sh_does_not_replace_shell() {
+        let temp = TempRunProject::new();
+        let fake_sh = temp.root.join("node_modules").join(".bin").join("sh");
+        fs::create_dir_all(fake_sh.parent().unwrap()).unwrap();
+        fs::write(&fake_sh, "#!/bin/sh\nexit 42\n").unwrap();
+        let mut permissions = fs::metadata(&fake_sh).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_sh, permissions).unwrap();
+        let package = temp.write_manifest(&[("shell", "echo shell-ok > shell.txt")]);
+
+        let status = run_script("shell", &package, &temp.root).unwrap();
+
+        assert_eq!(status, 0);
+        assert_eq!(
+            fs::read_to_string(temp.root.join("shell.txt")).unwrap(),
+            "shell-ok\n"
+        );
+    }
+
+    #[test]
+    fn script_path_stays_valid_after_cd() {
+        let temp = TempRunProject::new();
+        let bin = temp
+            .root
+            .join("node_modules")
+            .join(".bin")
+            .join("fixture-bin");
+        fs::create_dir_all(bin.parent().unwrap()).unwrap();
+        fs::create_dir_all(temp.root.join("workspace")).unwrap();
+        fs::write(&bin, "#!/bin/sh\necho cd-ok > ../cd.txt\n").unwrap();
+        let mut permissions = fs::metadata(&bin).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&bin, permissions).unwrap();
+        let package = temp.write_manifest(&[("cd-bin", "cd workspace && fixture-bin")]);
+
+        let status = run_script("cd-bin", &package, &temp.root).unwrap();
+
+        assert_eq!(status, 0);
+        assert_eq!(
+            fs::read_to_string(temp.root.join("cd.txt")).unwrap(),
+            "cd-ok\n"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,10 +25,18 @@ async fn run(opt: Opt) {
             println!("time: {:.2}s", time.elapsed().as_secs_f32());
         }
         Command::Run { script_key } => {
-            let time = std::time::Instant::now();
             let result = working_process::run(script_key).await;
-            result.expect("run failed\n");
-            println!("time: {:.2}s", time.elapsed().as_secs_f32());
+            match result {
+                Ok(status) => {
+                    if status != 0 {
+                        std::process::exit(status);
+                    }
+                }
+                Err(error) => {
+                    eprintln!("run failed: {error}");
+                    std::process::exit(1);
+                }
+            }
         }
         _ => {
             panic!("not implemented");
@@ -40,5 +48,4 @@ async fn run(opt: Opt) {
 async fn main() {
     let opt = Opt::from_args();
     run(opt).await;
-    print!("codeball test");
 }


### PR DESCRIPTION
## Contract
- Contract-affecting: rpm run filesystem side effects, script semantics, PATH behavior, stdout/stderr, and exit status.
- SPEC owner: added docs/specs/run-scripts.md for rpm run behavior.
- Closes #15

## Plan
- [x] Add a focused SPEC for rpm run behavior.
- [x] Check script existence before touching install output.
- [x] Remove node_modules initialization from rpm run.
- [x] Execute scripts through the shell with node_modules/.bin prepended to PATH.
- [x] Preserve child process exit status in CLI behavior.
- [x] Add tests for missing scripts, shell command chaining, PATH lookup, missing binary status, and child status propagation.

## Validation
- [x] cargo fmt --check
- [x] cargo check
- [x] cargo test run::
- [x] cargo test
- [x] cargo clippy --all-targets --all-features (passes; existing warnings remain outside this patch)