### PR TITLE
Define lockfile v1 schema

### DIFF
--- a/docs/specs/lockfile-v1.md
+++ b/docs/specs/lockfile-v1.md
@@ -1,0 +1,54 @@
+# Lockfile v1
+
+`rpm.lock` is the reproducibility contract for installs. It records the
+requested package graph and the resolved package facts needed by later install
+phases.
+
+## Format
+
+The lockfile is TOML and starts with project metadata:
+
+```toml
+lockfile_version = 1
+name = "app"
+version = "0.1.0"
+```
+
+Each package entry is keyed by `<package-name>@<resolved-version>`.
+
+```toml
+["react@18.2.0"]
+name = "react"
+requested = "^18.0.0"
+version = "18.2.0"
+relationship = "direct"
+tarball = "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
+integrity = "sha512-..."
+dependencies = ["loose-envify@^1.1.0"]
+```
+
+Package entries record:
+
+- `name`: package name, including scope when present.
+- `requested`: the range or tag requested by the parent manifest or package.
+- `version`: resolved package version.
+- `relationship`: one of `direct`, `dev`, or `transitive`.
+- `tarball`: resolved tarball URL when registry metadata provides it.
+- `integrity`: Subresource Integrity value when provided.
+- `shasum`: legacy shasum when `integrity` is absent or when the registry only
+  provides a shasum.
+- `dependencies`: dependency edges as requested package references.
+
+## Loading
+
+An absent or empty lockfile initializes as an empty v1 lockfile. Empty loading
+must not be reported as successful dependency resolution; it only gives callers a
+safe in-memory lockfile to mutate.
+
+Malformed TOML or malformed lockfile fields are load failures. Parse failures
+must include the lockfile path and parser context.
+
+## Saving
+
+Saving writes the complete current lockfile and truncates old content. Save
+errors must include the lockfile path and must not be hidden behind panics.

--- a/src/lib/command/working_process/add.rs
+++ b/src/lib/command/working_process/add.rs
@@ -1,6 +1,11 @@
 use std::io::Write;
 
-use crate::{api, lockfile::LockFile, package_manifest::PackageManifest, util::parse_library_name};
+use crate::{
+    api,
+    lockfile::{LockFile, Relationship},
+    package_manifest::PackageManifest,
+    util::parse_library_name,
+};
 use async_recursion::async_recursion;
 use tokio::time::sleep;
 
@@ -10,40 +15,124 @@ pub async fn add(
     lockfile: &mut LockFile,
     libs: Vec<String>,
     dev: bool,
-    direct_dependency: bool,
+    write_manifest: bool,
+) -> Result<(), reqwest::Error> {
+    lockfile.set_project_metadata(pkg.get_name(), pkg.get_version());
+    add_with_context(pkg, lockfile, libs, dev, write_manifest, true).await
+}
+
+#[async_recursion]
+async fn add_with_context(
+    pkg: &mut PackageManifest,
+    lockfile: &mut LockFile,
+    libs: Vec<String>,
+    dev: bool,
+    write_manifest: bool,
+    root_dependency: bool,
 ) -> Result<(), reqwest::Error> {
     for lib in libs {
         print!("installing {}...", lib);
         std::io::stdout().flush().unwrap();
         sleep(std::time::Duration::from_millis(1)).await;
         print!("\r\x1b[K");
-        let (library_name, version) = parse_library_name(lib.clone());
-        let registry = api::get_registry(&library_name, &version).await?;
-        let version = if version == "" {
-            registry.get_latest_version().unwrap().to_owned()
+        let (library_name, requested_range) = parse_library_name(lib.clone());
+        let registry_range = registry_request_from_requested(&requested_range);
+        let registry = api::get_registry(&library_name, &registry_range).await?;
+        let requested = if requested_range.is_empty() {
+            "latest".to_string()
         } else {
-            version
+            requested_range.clone()
         };
+        let version = registry
+            .get_latest_version()
+            .map(|version| version.to_owned())
+            .unwrap_or_else(|| requested_range.clone());
         let key = format!("{}@{}", library_name, version);
-        let version = if version == "*" {
-            registry.get_latest_version().unwrap().to_owned()
-        } else {
-            version
-        };
 
         registry.download_tarball(&key, &version).await?;
-        let dependencies = registry.get_dependencies();
-
-        lockfile.add_dependency(&key, version.clone(), &mut dependencies.clone());
-        if direct_dependency {
+        let dependencies = registry.get_dependencies_for_version(&version);
+        let dist = registry.get_dist_for_version(&version);
+        let manifest_version = manifest_version_from_requested(&requested, &version);
+        let relationship = if root_dependency {
             if dev {
-                pkg.add_dev_dependency(library_name, version);
+                Relationship::Dev
             } else {
-                pkg.add_dependency(library_name, version);
+                Relationship::Direct
+            }
+        } else {
+            Relationship::Transitive
+        };
+
+        lockfile.add_dependency_entry(
+            &key,
+            library_name.clone(),
+            requested,
+            version.clone(),
+            relationship,
+            dist.map(|dist| dist.tarball.clone()),
+            dist.and_then(|dist| dist.integrity.clone()),
+            dist.map(|dist| dist.shasum.clone()),
+            &dependencies,
+        );
+        if write_manifest {
+            if dev {
+                pkg.add_dev_dependency(library_name, manifest_version);
+            } else {
+                pkg.add_dependency(library_name, manifest_version);
             }
         }
 
-        add(pkg, lockfile, dependencies, dev, false).await?;
+        add_with_context(pkg, lockfile, dependencies, dev, false, false).await?;
     }
     Ok(())
+}
+
+fn registry_request_from_requested(requested: &str) -> String {
+    let mut version = requested.to_string();
+    if version.contains("||") {
+        version = version
+            .split("||")
+            .last()
+            .map(|version| version.trim().to_string())
+            .unwrap_or_default();
+    }
+    if version.starts_with('^') || version.starts_with('~') {
+        version.remove(0);
+    }
+    version
+}
+
+fn manifest_version_from_requested(requested: &str, resolved: &str) -> String {
+    if requested == "latest" {
+        resolved.to_string()
+    } else {
+        requested.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::registry_request_from_requested;
+
+    #[test]
+    fn registry_request_preserves_legacy_manifest_range_normalization() {
+        assert_eq!(registry_request_from_requested("^18.0.0"), "18.0.0");
+        assert_eq!(registry_request_from_requested("~5.2.0"), "5.2.0");
+        assert_eq!(
+            registry_request_from_requested("^17.0.0 || ^18.0.0"),
+            "18.0.0"
+        );
+    }
+
+    #[test]
+    fn manifest_version_preserves_requested_range_for_direct_adds() {
+        assert_eq!(
+            super::manifest_version_from_requested("^1.2.0", "1.4.0"),
+            "^1.2.0"
+        );
+        assert_eq!(
+            super::manifest_version_from_requested("latest", "1.4.0"),
+            "1.4.0"
+        );
+    }
 }

--- a/src/lib/lockfile/mod.rs
+++ b/src/lib/lockfile/mod.rs
@@ -11,17 +11,48 @@ use std::{
 };
 use toml::Value;
 
+const LOCKFILE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Relationship {
+    Direct,
+    Dev,
+    #[default]
+    Transitive,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Dependency {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    requested: String,
+    #[serde(rename = "version")]
     version: String,
-    dependencies: Option<HashSet<String>>,
+    #[serde(default)]
+    relationship: Relationship,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tarball: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    integrity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    shasum: Option<String>,
+    #[serde(default)]
+    dependencies: HashSet<String>,
 }
 
 impl Dependency {
     pub fn new(version: String, dependencies: Option<HashSet<String>>) -> Self {
         Self {
+            name: String::new(),
+            requested: version.clone(),
             version,
-            dependencies,
+            relationship: Relationship::Transitive,
+            tarball: None,
+            integrity: None,
+            shasum: None,
+            dependencies: dependencies.unwrap_or_default(),
         }
     }
 
@@ -29,12 +60,19 @@ impl Dependency {
         self.version.clone()
     }
 
+    pub fn get_requested(&self) -> String {
+        self.requested.clone()
+    }
+
+    pub fn get_relationship(&self) -> Relationship {
+        self.relationship.clone()
+    }
+
     pub fn get_dependencies_name(&self) -> HashSet<String> {
         let regex = Regex::new(r"^(?P<package_name>@?[^@]*)(@\^?(?P<version>.*))?$").unwrap();
         let mut dependencies = HashSet::new();
-        if let Some(deps) = &self.dependencies {
-            for dep in deps.iter() {
-                let pkg_name = regex.captures(&dep).unwrap();
+        for dep in self.dependencies.iter() {
+            if let Some(pkg_name) = regex.captures(dep) {
                 let name = pkg_name.name("package_name").map(|m| m.as_str()).unwrap();
                 dependencies.insert(name.to_string());
             }
@@ -43,74 +81,26 @@ impl Dependency {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LockFile {
+    lockfile_version: u32,
+    #[serde(default)]
     name: String,
+    #[serde(default)]
     version: String,
     #[serde(flatten)]
     dependencies: HashMap<String, Dependency>,
 }
 
-impl<'de> Deserialize<'de> for LockFile {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let value = Value::deserialize(deserializer)?;
-        let mut name = String::new();
-        let mut version = String::new();
-        let mut deps = HashMap::new();
-        for (key, value) in value.as_table().unwrap() {
-            if key == "name" {
-                name = value.as_str().unwrap().to_string();
-            } else if key == "version" {
-                version = value.as_str().unwrap().to_string();
-            } else {
-                let mut dependencies = HashSet::new();
-                let mut dep_version = String::new();
-                for (key, value) in value.as_table().unwrap() {
-                    if key == "version" {
-                        dep_version = value.as_str().unwrap().to_string();
-                    } else if key == "dependencies" {
-                        for dep in value.as_array().unwrap() {
-                            dependencies.insert(dep.as_str().unwrap().to_string());
-                        }
-                    }
-                }
-                deps.insert(
-                    key.to_string(),
-                    Dependency {
-                        version: dep_version,
-                        dependencies: Some(dependencies),
-                    },
-                );
-            }
-        }
-
-        Ok(Self {
-            name,
-            version,
-            dependencies: deps,
-        })
-    }
-}
-
 impl LockFile {
-    // fn new(name: String, version: String, dependencies: HashMap<String, Dependency>) -> Self {
-    //     Self {
-    //         name,
-    //         version,
-    //         dependencies,
-    //     }
-    // }
-
-    // fn save(&self) -> Result<()> {
-    //     let lockfile = serde_json::to_string(&self)?;
-    //     let mut file = File::create("rpm-lock.toml")?;
-
-    //     file.write_all(lockfile.as_bytes())?;
-    //     Ok(())
-    // }
+    fn empty() -> Self {
+        Self {
+            lockfile_version: LOCKFILE_VERSION,
+            name: String::new(),
+            version: String::new(),
+            dependencies: HashMap::new(),
+        }
+    }
 
     pub fn load() -> Result<Self> {
         Self::load_from_path(LOCK_FILE_PATH)
@@ -122,71 +112,197 @@ impl LockFile {
             .read(true)
             .write(true)
             .create(true)
+            .truncate(false)
             .open(path.as_ref())?;
         file.read_to_string(&mut buffer)?;
         if buffer.trim().is_empty() {
-            return Err(Error::new(ErrorKind::InvalidData, "lockfile is empty"));
+            return Ok(Self::empty());
         }
-        let lock: Self = toml::from_str(&buffer).map_err(|error| {
+        let parsed: Value = toml::from_str(&buffer).map_err(|error| {
             Error::new(
                 ErrorKind::InvalidData,
-                format!("failed to parse lockfile: {error}"),
+                format!(
+                    "failed to parse lockfile {}: {error}",
+                    path.as_ref().display()
+                ),
             )
         })?;
+        let Some(parsed_version) = parsed
+            .get("lockfile_version")
+            .and_then(|version| version.as_integer())
+        else {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!("missing lockfile_version in {}", path.as_ref().display()),
+            ));
+        };
+        if parsed_version != LOCKFILE_VERSION as i64 {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "unsupported lockfile version {} in {}",
+                    parsed_version,
+                    path.as_ref().display()
+                ),
+            ));
+        }
+        let mut lock: Self = parsed.try_into().map_err(|error| {
+            Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "failed to parse lockfile {}: {error}",
+                    path.as_ref().display()
+                ),
+            )
+        })?;
+        lock.normalize_entries();
 
         Ok(lock)
+    }
+
+    fn normalize_entries(&mut self) {
+        self.lockfile_version = LOCKFILE_VERSION;
+        for (key, dependency) in self.dependencies.iter_mut() {
+            if dependency.name.is_empty() {
+                dependency.name = package_name_from_lock_key(key);
+            }
+            if dependency.requested.is_empty() {
+                dependency.requested = dependency.version.clone();
+            }
+        }
     }
 
     pub fn get_packages(&self) -> Vec<(&String, &Dependency)> {
         self.dependencies.iter().collect::<Vec<_>>()
     }
 
-    pub fn add_dependency(
+    pub fn set_project_metadata(&mut self, name: String, version: String) {
+        self.name = name;
+        self.version = version;
+    }
+
+    pub fn add_dependency(&mut self, name: &String, version: String, dependencies: &[String]) {
+        let package_name = package_name_from_lock_key(name);
+        self.add_dependency_entry(
+            name,
+            package_name,
+            version.clone(),
+            version,
+            Relationship::Transitive,
+            None,
+            None,
+            None,
+            dependencies,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_dependency_entry(
         &mut self,
-        name: &String,
+        key: &String,
+        package_name: String,
+        requested: String,
         version: String,
-        dependencies: &mut Vec<String>,
+        relationship: Relationship,
+        tarball: Option<String>,
+        integrity: Option<String>,
+        shasum: Option<String>,
+        dependencies: &[String],
     ) {
-        if let Some(dep) = self.dependencies.get_mut(name) {
+        if let Some(dep) = self.dependencies.get_mut(key) {
+            let merged_relationship = merge_relationship(&dep.relationship, relationship.clone());
+            dep.name = package_name;
+            if should_replace_requested(&dep.relationship, &relationship) {
+                dep.requested = requested;
+            }
             dep.version = version;
+            dep.relationship = merged_relationship;
+            dep.tarball = tarball;
+            dep.integrity = integrity;
+            dep.shasum = shasum;
             dependencies.iter().for_each(|value| {
-                dep.dependencies.as_mut().unwrap().insert(value.clone());
+                dep.dependencies.insert(value.clone());
             });
         } else {
             self.dependencies.insert(
-                name.clone(),
+                key.clone(),
                 Dependency {
+                    name: package_name,
+                    requested,
                     version,
-                    dependencies: Some(HashSet::from_iter(dependencies.iter().cloned())),
+                    relationship,
+                    tarball,
+                    integrity,
+                    shasum,
+                    dependencies: HashSet::from_iter(dependencies.iter().cloned()),
                 },
             );
         }
     }
 
     pub fn save(&self) -> Result<()> {
-        let lockfile = toml::to_string(&self).unwrap();
+        self.save_to_path(LOCK_FILE_PATH)
+    }
+
+    pub fn save_to_path<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        let lockfile = toml::to_string(&self).map_err(|error| {
+            Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "failed to serialize lockfile {}: {error}",
+                    path.as_ref().display()
+                ),
+            )
+        })?;
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
-            .open(LOCK_FILE_PATH)?;
+            .truncate(true)
+            .open(path.as_ref())
+            .map_err(|error| {
+                Error::new(
+                    error.kind(),
+                    format!(
+                        "failed to open lockfile {}: {error}",
+                        path.as_ref().display()
+                    ),
+                )
+            })?;
 
-        // file initial
-        file.set_len(0)?;
-
-        // file write
-        match file.write_all(lockfile.as_bytes()) {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                println!("error: {:?}", e);
-                return Err(e);
-            }
-        }
+        file.write_all(lockfile.as_bytes()).map_err(|error| {
+            Error::new(
+                error.kind(),
+                format!(
+                    "failed to write lockfile {}: {error}",
+                    path.as_ref().display()
+                ),
+            )
+        })
     }
 
     pub fn get_dependency(&self, name: &str) -> Option<&Dependency> {
         self.dependencies.get(name)
     }
+}
+
+fn package_name_from_lock_key(key: &str) -> String {
+    match key.rsplit_once('@') {
+        Some((name, _)) if !name.is_empty() => name.to_string(),
+        _ => key.to_string(),
+    }
+}
+
+fn merge_relationship(existing: &Relationship, incoming: Relationship) -> Relationship {
+    match (existing, incoming) {
+        (Relationship::Direct, _) | (_, Relationship::Direct) => Relationship::Direct,
+        (Relationship::Dev, _) | (_, Relationship::Dev) => Relationship::Dev,
+        _ => Relationship::Transitive,
+    }
+}
+
+fn should_replace_requested(existing: &Relationship, incoming: &Relationship) -> bool {
+    matches!(existing, Relationship::Transitive) || !matches!(incoming, Relationship::Transitive)
 }
 
 #[cfg(test)]
@@ -202,19 +318,23 @@ mod lock_file_test {
         assert_eq!(lock.name, "fixture-app");
         assert_eq!(lock.version, "0.1.0");
         assert_eq!(
-            lock.get_dependency("react")
+            lock.get_dependency("react@18.2.0")
                 .map(|dependency| dependency.get_version()),
             Some("18.2.0".to_owned())
+        );
+        assert_eq!(
+            lock.get_dependency("react@18.2.0")
+                .map(|dependency| dependency.get_requested()),
+            Some("^18.0.0".to_owned())
         );
     }
 
     #[test]
-    fn load_rejects_empty_lockfile() {
-        let error =
-            LockFile::load_from_path(fixture_path(&["lockfile", "empty.rpm.lock"])).unwrap_err();
+    fn load_initializes_empty_lockfile() {
+        let lock = LockFile::load_from_path(fixture_path(&["lockfile", "empty.rpm.lock"])).unwrap();
 
-        assert_eq!(error.kind(), ErrorKind::InvalidData);
-        assert_eq!(error.to_string(), "lockfile is empty");
+        assert_eq!(lock.lockfile_version, LOCKFILE_VERSION);
+        assert!(lock.get_packages().is_empty());
     }
 
     #[test]
@@ -224,5 +344,96 @@ mod lock_file_test {
 
         assert_eq!(error.kind(), ErrorKind::InvalidData);
         assert!(error.to_string().contains("failed to parse lockfile"));
+        assert!(error.to_string().contains("invalid.rpm.lock"));
+    }
+
+    #[test]
+    fn load_rejects_unsupported_lockfile_version() {
+        let error =
+            LockFile::load_from_path(fixture_path(&["lockfile", "unsupported-version.rpm.lock"]))
+                .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+        assert!(error.to_string().contains("unsupported lockfile version 2"));
+        assert!(error.to_string().contains("unsupported-version.rpm.lock"));
+    }
+
+    #[test]
+    fn merging_entries_preserves_root_relationship() {
+        let mut lock = LockFile::empty();
+        let key = "shared@1.0.0".to_string();
+        lock.add_dependency_entry(
+            &key,
+            "shared".to_string(),
+            "^1.0.0".to_string(),
+            "1.0.0".to_string(),
+            Relationship::Direct,
+            None,
+            None,
+            None,
+            &[],
+        );
+        lock.add_dependency_entry(
+            &key,
+            "shared".to_string(),
+            "1.0.0".to_string(),
+            "1.0.0".to_string(),
+            Relationship::Transitive,
+            None,
+            None,
+            None,
+            &[],
+        );
+
+        assert_eq!(
+            lock.get_dependency(&key)
+                .map(|dependency| dependency.get_relationship()),
+            Some(Relationship::Direct)
+        );
+        assert_eq!(
+            lock.get_dependency(&key)
+                .map(|dependency| dependency.get_requested()),
+            Some("^1.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn set_project_metadata_populates_empty_lockfile() {
+        let mut lock = LockFile::empty();
+
+        lock.set_project_metadata("fixture-app".to_string(), "0.1.0".to_string());
+
+        assert_eq!(lock.name, "fixture-app");
+        assert_eq!(lock.version, "0.1.0");
+    }
+
+    #[test]
+    fn load_rejects_non_empty_lockfile_without_version_marker() {
+        let error =
+            LockFile::load_from_path(fixture_path(&["lockfile", "missing-version.rpm.lock"]))
+                .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+        assert!(error.to_string().contains("missing lockfile_version"));
+        assert!(error.to_string().contains("missing-version.rpm.lock"));
+    }
+
+    #[test]
+    fn save_to_path_truncates_old_content() {
+        let temp = crate::util::test_support::TempProject::new("lockfile-save").unwrap();
+        let path = temp
+            .copy_fixture(
+                fixture_path(&["lockfile", "long-existing.rpm.lock"]),
+                "rpm.lock",
+            )
+            .unwrap();
+        let mut lock = LockFile::empty();
+        lock.add_dependency(&"tiny@1.0.0".to_string(), "1.0.0".to_string(), &[]);
+
+        lock.save_to_path(&path).unwrap();
+
+        let saved = std::fs::read_to_string(path).unwrap();
+        assert!(saved.contains("[\"tiny@1.0.0\"]"));
+        assert!(!saved.contains("stale-package"));
     }
 }

--- a/src/lib/node_linker/mod.rs
+++ b/src/lib/node_linker/mod.rs
@@ -85,6 +85,12 @@ impl NodeModules {
         let lock_file = LockFile::load_from_path(lockfile_path)
             .map_err(|error| phase_error("resolve", error))?;
         let packages = lock_file.get_packages();
+        if packages.is_empty() {
+            return Err(phase_error(
+                "resolve",
+                Error::new(ErrorKind::InvalidData, "lockfile has no packages to link"),
+            ));
+        }
         let cache_resolver = NodeResolver::new(cache_dir.as_ref().to_path_buf());
         cache_resolver
             .resolve_deps(&mut modules, &packages)
@@ -330,7 +336,7 @@ mod tests {
         fs::write(
             path,
             format!(
-                "name = \"fixture-app\"\nversion = \"0.1.0\"\n\n[\"{package}@1.0.0\"]\nversion = \"1.0.0\"\ndependencies = [{dependencies}]\n"
+                "lockfile_version = 1\nname = \"fixture-app\"\nversion = \"0.1.0\"\n\n[\"{package}@1.0.0\"]\nversion = \"1.0.0\"\ndependencies = [{dependencies}]\n"
             ),
         )
         .unwrap();
@@ -428,6 +434,25 @@ mod tests {
     }
 
     #[test]
+    fn init_keeps_existing_node_modules_when_lockfile_is_empty() {
+        let temp = TempNodeModules::new();
+        let existing_file = temp.node_modules().join("keep.txt");
+        fs::write(&existing_file, "existing").unwrap();
+        fs::write(temp.lockfile_path(), "").unwrap();
+
+        let error = NodeModules::init_from_paths(
+            temp.node_modules(),
+            temp.lockfile_path(),
+            temp.cache_dir(),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("resolve failed"));
+        assert!(error.to_string().contains("lockfile has no packages"));
+        assert_eq!(fs::read_to_string(existing_file).unwrap(), "existing");
+    }
+
+    #[test]
     fn init_keeps_existing_node_modules_when_link_fails() {
         let temp = TempNodeModules::new();
         let existing_file = temp.node_modules().join("keep.txt");
@@ -451,7 +476,7 @@ mod tests {
         let temp = TempNodeModules::new();
         fs::write(
             temp.lockfile_path(),
-            "name = \"fixture-app\"\nversion = \"0.1.0\"\n\n[\"a@1.0.0\"]\nversion = \"1.0.0\"\ndependencies = [\"b@1.0.0\"]\n\n[\"b@1.0.0\"]\nversion = \"1.0.0\"\ndependencies = []\n",
+            "lockfile_version = 1\nname = \"fixture-app\"\nversion = \"0.1.0\"\n\n[\"a@1.0.0\"]\nversion = \"1.0.0\"\ndependencies = [\"b@1.0.0\"]\n\n[\"b@1.0.0\"]\nversion = \"1.0.0\"\ndependencies = []\n",
         )
         .unwrap();
         write_package_tgz(&temp.cache_dir(), "a", "1.0.0");

--- a/src/lib/package_manifest/mod.rs
+++ b/src/lib/package_manifest/mod.rs
@@ -10,30 +10,7 @@ use std::{
 #[derive(Debug, Deserialize, Serialize)]
 pub struct VersionString(String);
 
-impl VersionString {
-    fn to_specific_version(&self) -> String {
-        let mut version = self.0.to_owned();
-        if version.contains("||") {
-            version = version
-                .split("||")
-                .collect::<Vec<&str>>()
-                .last_mut()
-                .unwrap()
-                .trim()
-                .to_owned();
-        }
-        if version.starts_with("^") {
-            version = version.replace("^", "");
-        }
-        if version.starts_with("~") {
-            version = version.replace("~", "");
-        }
-        version
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize)]
-
 pub struct Author {
     name: String,
     email: String,
@@ -42,7 +19,6 @@ pub struct Author {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
-
 pub enum AuthorType {
     String(String),
     Object(Author),
@@ -103,6 +79,17 @@ impl PackageManifest {
         package
     }
 
+    pub fn get_name(&self) -> String {
+        self.name.clone().unwrap_or_default()
+    }
+
+    pub fn get_version(&self) -> String {
+        self.version
+            .as_ref()
+            .map(|version| version.0.clone())
+            .unwrap_or_default()
+    }
+
     pub fn get_bin(&self) -> Option<HashMap<String, String>> {
         self.bin.as_ref().map(|bin| bin.to_owned())
     }
@@ -142,7 +129,7 @@ impl PackageManifest {
     pub fn get_dependencies(&self) -> Vec<(String, String)> {
         let mut deps = Vec::new();
         for (key, version) in &self.dependencies {
-            deps.push((key.to_owned(), version.to_specific_version()))
+            deps.push((key.to_owned(), version.0.to_owned()))
         }
         deps
     }
@@ -151,7 +138,7 @@ impl PackageManifest {
         let mut deps = Vec::new();
         if let Some(dev_deps) = &self.dev_dependecies {
             for (key, version) in dev_deps {
-                deps.push((key.to_owned(), version.to_specific_version()))
+                deps.push((key.to_owned(), version.0.to_owned()))
             }
         }
         deps
@@ -178,9 +165,11 @@ mod package_json_test {
         let scripts = package.get_scripts();
 
         assert_eq!(package.name.as_deref(), Some("fixture-app"));
-        assert!(dependencies.contains(&("react".to_owned(), "18.2.0".to_owned())));
-        assert!(dependencies.contains(&("vite".to_owned(), "5.2.0".to_owned())));
-        assert!(dev_dependencies.contains(&("typescript".to_owned(), "5.4.0".to_owned())));
+        assert_eq!(package.get_name(), "fixture-app");
+        assert_eq!(package.get_version(), "0.1.0");
+        assert!(dependencies.contains(&("react".to_owned(), "^18.2.0".to_owned())));
+        assert!(dependencies.contains(&("vite".to_owned(), "~5.2.0".to_owned())));
+        assert!(dev_dependencies.contains(&("typescript".to_owned(), "^5.4.0".to_owned())));
         assert_eq!(scripts.get("test").map(String::as_str), Some("cargo test"));
     }
 
@@ -211,6 +200,6 @@ mod package_json_test {
 
         let saved = PackageManifest::read_file(temp_manifest_path.to_str().unwrap());
         let dependencies = saved.get_dependencies();
-        assert!(dependencies.contains(&("socket-store".to_owned(), "0.1.0".to_owned())));
+        assert!(dependencies.contains(&("socket-store".to_owned(), "^0.1.0".to_owned())));
     }
 }

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -218,6 +218,31 @@ pub struct Registry {
 }
 
 impl Registry {
+    fn version_metadata(&self, version: &str) -> Option<&Version> {
+        self.versions
+            .as_ref()
+            .and_then(|versions| versions.get(version))
+    }
+
+    pub fn get_dist_for_version(&self, version: &str) -> Option<&Dist> {
+        self.version_metadata(version)
+            .map(|metadata| &metadata.dist)
+            .or(self.dist.as_ref())
+    }
+
+    pub fn get_dependencies_for_version(&self, version: &str) -> Vec<String> {
+        self.version_metadata(version)
+            .map(|metadata| metadata.get_dependencies())
+            .unwrap_or_else(|| {
+                self.dependencies
+                    .as_ref()
+                    .iter()
+                    .flat_map(|x| x.iter())
+                    .map(|(k, v)| format!("{}@{}", k, v))
+                    .collect()
+            })
+    }
+
     pub fn get_tarball_name(&self) -> Option<String> {
         self.get_tarball_url().map(|url| {
             //ex https://registry.npmjs.org/axios/-/axios-0.21.1.tgz
@@ -248,7 +273,6 @@ impl Registry {
     }
 
     /// download tarball from registry and return tarball bytes
-
     pub async fn download_tarball(&self, key: &str, version: &str) -> Result<(), reqwest::Error> {
         let url = &self.get_tarball_url().unwrap();
         let response = api::get_tarball(url).await;
@@ -269,25 +293,12 @@ impl Registry {
     /// example: ["socket-store@0.0.1", "socket.io-client@1.22.3"]
     pub fn get_dependencies(&self) -> Vec<String> {
         // if versions is "" then version to latest
-        if self.versions.is_some() && self.dist_tags.is_some() {
-            let lastests = &self.dist_tags.as_ref().unwrap().get_latest().unwrap();
-            let version = self
-                .versions
-                .as_ref()
-                .unwrap()
-                .get(lastests.to_owned())
-                .unwrap();
-            let dependencies = version.get_dependencies();
-
-            dependencies
-        } else {
-            self.dependencies
-                .as_ref()
-                .iter()
-                .flat_map(|x| x.iter())
-                .map(|(k, v)| format!("{}@{}", k, v))
-                .collect()
+        if let (Some(_), Some(dist_tags)) = (&self.versions, &self.dist_tags) {
+            if let Some(latest) = dist_tags.get_latest() {
+                return self.get_dependencies_for_version(latest);
+            }
         }
+        self.get_dependencies_for_version("")
     }
 
     pub fn get_latest_version(&self) -> Option<&String> {

--- a/tests/fixtures/lockfile/long-existing.rpm.lock
+++ b/tests/fixtures/lockfile/long-existing.rpm.lock
@@ -1,0 +1,17 @@
+lockfile_version = 1
+name = "fixture-app-with-stale-content"
+version = "0.1.0"
+
+["stale-package@1.0.0"]
+name = "stale-package"
+requested = "1.0.0"
+version = "1.0.0"
+relationship = "direct"
+dependencies = []
+
+["another-stale-package@1.0.0"]
+name = "another-stale-package"
+requested = "1.0.0"
+version = "1.0.0"
+relationship = "transitive"
+dependencies = []

--- a/tests/fixtures/lockfile/missing-version.rpm.lock
+++ b/tests/fixtures/lockfile/missing-version.rpm.lock
@@ -1,0 +1,9 @@
+name = "fixture-app"
+version = "0.1.0"
+
+["react@18.2.0"]
+name = "react"
+requested = "^18.0.0"
+version = "18.2.0"
+relationship = "direct"
+dependencies = []

--- a/tests/fixtures/lockfile/unsupported-version.rpm.lock
+++ b/tests/fixtures/lockfile/unsupported-version.rpm.lock
@@ -1,0 +1,10 @@
+lockfile_version = 2
+name = "fixture-app"
+version = "0.1.0"
+
+["react@18.2.0"]
+name = "react"
+requested = "^18.0.0"
+version = "18.2.0"
+relationship = "direct"
+dependencies = []

--- a/tests/fixtures/lockfile/valid.rpm.lock
+++ b/tests/fixtures/lockfile/valid.rpm.lock
@@ -1,6 +1,12 @@
+lockfile_version = 1
 name = "fixture-app"
 version = "0.1.0"
 
-[react]
+["react@18.2.0"]
+name = "react"
+requested = "^18.0.0"
 version = "18.2.0"
+relationship = "direct"
+tarball = "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
+integrity = "sha512-fixture"
 dependencies = ["loose-envify@1.4.0"]


### PR DESCRIPTION
## Contract

Defines the `rpm.lock` v1 contract for reproducible installs. This is contract-affecting because it covers lockfile fields, compatibility, safe empty-lock handling, save behavior, manifest range preservation, and parse/save diagnostics.

## Changes

- Added `docs/specs/lockfile-v1.md` as the owning lockfile contract.
- Updated lockfile entries to carry package name, requested range, resolved version, relationship, tarball URL, integrity/shasum, dependency edges, and project metadata.
- Made empty lockfiles initialize as an empty v1 lockfile for mutation, while non-mutating node_modules linking rejects empty package plans before replacing an existing tree.
- Made non-empty lockfiles missing `lockfile_version = 1` or declaring unsupported versions fail with path-aware errors.
- Persisted selected registry dist metadata and direct/dev/transitive relationships from `rpm add`/`rpm install` into lockfile entries without demoting root dependencies or replacing root requested ranges during merges.
- Preserved manifest dependency ranges in `requested` and direct `package.json` updates while preserving the legacy normalized registry request for current resolver behavior.
- Added lockfile/package manifest/node linker/add fixtures/tests for v1 fields, project metadata, empty load, missing/unsupported versions, path-aware parse errors, relationship/requested merge behavior, range preservation, empty-link rejection, registry request normalization, and save truncation.

## Validation

- `cargo fmt --check` passed.
- `cargo test lock_file_test` passed.
- `cargo test package_json_test` passed.
- `cargo test node_linker` passed.
- `cargo test registry_request_preserves_legacy_manifest_range_normalization` passed.
- `cargo test manifest_version_preserves_requested_range_for_direct_adds` passed.
- `cargo check` passed.
- `cargo test` passed. The expected shell message for the missing-binary run test was printed. One earlier overlapped validation run raced with a simultaneous targeted cargo test, so the full suite was rerun by itself and passed.
- `cargo clippy --all-targets --all-features` passed with existing warnings in `lockfile/constraint.rs`, `package_manifest`, `api`, and older `registry` code.

## Checklist

- [x] Scope is focused on one behavior, bug, or mechanical change.
- [x] Behavior changes include relevant tests or fixtures.
- [x] SPEC impact is classified when contract-affecting.
- [ ] PR is ready for review when implementation is complete.

Closes #11