### PR TITLE
docs(resolver): define semver baseline contract

### DIFF
--- a/docs/specs/resolver.md
+++ b/docs/specs/resolver.md
@@ -2,7 +2,7 @@
 
 Status: Draft  
 Owner: resolver/install  
-Last reviewed: 2026-05-27
+Last reviewed: 2026-05-28
 
 ## Purpose
 
@@ -28,12 +28,10 @@ preserves both the requested range and the selected version. The graph is the
 input to later installer phases that download tarballs, verify integrity,
 extract packages, link `node_modules`, and write lockfile or manifest state.
 
-Version and range satisfaction rules are owned by the semver resolution
-contract, tracked separately in issue #1. This resolver boundary does not define
-the syntax or precedence rules for `^`, `~`, `*`, comparators, prereleases, or
-tag-like input. Resolver strategies call the version selection abstraction and
-record its selected version; they must not duplicate range parsing policy in the
-traversal implementation.
+Version and range satisfaction rules are owned by
+`docs/specs/semver-resolution.md`. Resolver strategies call the version
+selection abstraction and record its selected version; they must not duplicate
+range parsing policy in the traversal implementation.
 
 Traversal policy is behind a replaceable `ResolutionStrategy` boundary, or an
 equivalent internal abstraction. The resolver must not rely on recursive calls
@@ -74,6 +72,10 @@ records with requested range and selected version. Integration fixtures may add
 expected lockfile snapshots or filesystem trees for later installer phases, but
 resolver fixtures should not mutate the repository root, `.rpm`, `rpm.lock`, or
 `node_modules`.
+
+The semver baseline fixtures are defined by
+`docs/specs/semver-resolution.md` and must be used before installer flow relies
+on semver range behavior.
 
 ## Open Questions
 

--- a/docs/specs/semver-resolution.md
+++ b/docs/specs/semver-resolution.md
@@ -1,0 +1,110 @@
+# Spec: Semver Resolution
+
+Status: Draft
+Owner: resolver/install
+Last reviewed: 2026-05-28
+
+## Purpose
+
+RPM must resolve dependency ranges with npm-compatible semver behavior before
+installer work depends on selected package versions. The semver contract defines
+the M1 baseline and the fixtures that future resolver implementation must pass.
+
+## Contract
+
+M0 does not implement the full resolver. M1 must implement the first supported
+semver range baseline before installer behavior depends on range selection.
+
+The M1 baseline supports these request forms:
+
+- exact versions, for example `1.2.3`
+- caret ranges, for example `^1.2.3`
+- caret ranges for zero-major versions, for example `^0.2.0`
+- tilde ranges, for example `~1.2.3`
+- wildcard ranges, for example `*`, `1.x`, and `1.2.x`
+- common comparator ranges, for example `>=1.0.0 <2.0.0`
+
+For each supported request, the version selector chooses the highest matching
+stable version from npm registry metadata. The selected version is recorded in
+lockfile `version`; the original request text is preserved in lockfile
+`requested`.
+
+Unsatisfied ranges and invalid ranges are resolver failures. They must fail
+before tarball download, extraction, linking, lockfile writes, or manifest
+writes.
+
+Lockfile v1 already supports this contract by storing both `requested` and
+resolved `version` fields for each package record.
+
+## Dependency Decision
+
+The Rust semver/range dependency is explicitly deferred to the M1 resolver
+implementation spike. The dependency must be chosen by comparing npm-compatible
+range behavior against the fixtures in
+`tests/fixtures/install-projects/semver-baseline/`, rather than by matching only
+Cargo semver behavior.
+
+A candidate dependency must preserve npm-compatible caret, tilde, wildcard, and
+comparator semantics or the implementation must add a compatibility layer around
+it. The default should be a Node/npm-compatible Rust range library, not a
+Cargo-oriented semver parser, unless fixture results prove compatibility.
+
+## Replacement Targets
+
+Current ad hoc normalization is a replacement target, not the resolver
+contract:
+
+- `src/lib/command/working_process/add.rs::registry_request_from_requested`
+  strips `^` and `~` and chooses the last disjunct after `||`.
+- `src/lib/api/mod.rs::get_registry` strips `^` and `~` and maps `*` to
+  `latest` before making a registry request.
+- `src/lib/util/mod.rs::parse_library_name` truncates comparator expressions
+  such as `>=1.0.0 <2.0.0` before resolver policy can inspect them.
+- `src/lib/lockfile/mod.rs::Dependency::get_dependencies_name` extracts names
+  with a regex that special-cases caret text.
+- `src/lib/registry/mod.rs::Registry::get_latest_version` is only a latest-tag
+  helper and must not stand in for highest matching version selection.
+
+These compatibility paths may remain during M0 only to preserve current command
+behavior. M1 resolver work must replace them with a single version selection
+boundary.
+
+## Error Cases
+
+- An exact version that is absent from metadata fails resolution.
+- A range with no matching version fails resolution.
+- An invalid range fails resolution.
+- Package metadata with no valid versions fails resolution.
+
+All resolver failures must be reported before installer side effects.
+
+## Test Fixtures
+
+The success baseline fixture is
+`tests/fixtures/install-projects/semver-baseline/`. It defines direct dependency
+requests, offline registry metadata, and expected selected package records for a
+project that should resolve completely.
+
+Failing resolver fixtures are separate project scenarios:
+
+- `tests/fixtures/install-projects/semver-unsatisfied/`
+- `tests/fixtures/install-projects/semver-invalid-range/`
+
+Required fixture cases:
+
+- exact: `1.2.3` selects `1.2.3`
+- caret: `^1.2.3` selects highest `<2.0.0`
+- caret zero-major: `^0.2.0` selects highest `<0.3.0`
+- tilde: `~1.2.3` selects highest `<1.3.0`
+- wildcard any: `*` selects highest available stable version
+- wildcard major: `1.x` selects highest `1.*.*`
+- wildcard minor: `1.2.x` selects highest `1.2.*`
+- comparator: `>=1.0.0 <2.0.0` selects highest matching version
+- unsatisfied range returns a resolver error before side effects
+- invalid range returns a resolver error before side effects
+
+## Open Questions
+
+- Whether M1 supports npm dist-tags other than `latest`.
+- Whether prerelease selection is unsupported or supported only when explicitly
+  requested.

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -369,7 +369,7 @@ fn save_tarball_to_dir<P: AsRef<Path>>(
 
 #[cfg(test)]
 mod tests {
-    use super::save_tarball_to_dir;
+    use super::{save_tarball_to_dir, Registry};
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -393,5 +393,31 @@ mod tests {
         assert!(error.to_string().contains("failed to open cached tarball"));
         assert!(error.to_string().contains("cache-file"));
         let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn semver_registry_fixtures_match_registry_metadata_shape() {
+        let fixture_roots = [
+            "tests/fixtures/install-projects/semver-baseline/registry",
+            "tests/fixtures/install-projects/semver-unsatisfied/registry",
+            "tests/fixtures/install-projects/semver-invalid-range/registry",
+        ];
+
+        for root in fixture_roots {
+            let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(root);
+            for entry in fs::read_dir(&root).expect("semver registry fixture directory exists") {
+                let entry = entry.expect("semver registry fixture entry is readable");
+                let path = entry.path();
+                if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                    continue;
+                }
+
+                let fixture =
+                    fs::read_to_string(&path).expect("semver registry fixture is readable");
+                serde_json::from_str::<Registry>(&fixture).unwrap_or_else(|error| {
+                    panic!("{} did not deserialize: {error}", path.display())
+                });
+            }
+        }
     }
 }

--- a/tests/fixtures/install-projects/semver-baseline/expected/resolved-packages.txt
+++ b/tests/fixtures/install-projects/semver-baseline/expected/resolved-packages.txt
@@ -1,0 +1,8 @@
+@rpm-fixture/exact@1.2.3 requested 1.2.3
+@rpm-fixture/caret@1.9.9 requested ^1.2.3
+@rpm-fixture/caret-zero@0.2.9 requested ^0.2.0
+@rpm-fixture/tilde@1.2.9 requested ~1.2.3
+@rpm-fixture/wildcard@3.0.0 requested *
+@rpm-fixture/wildcard-major@1.9.0 requested 1.x
+@rpm-fixture/wildcard-minor@1.2.9 requested 1.2.x
+@rpm-fixture/comparator@1.5.0 requested >=1.0.0 <2.0.0

--- a/tests/fixtures/install-projects/semver-baseline/package.json
+++ b/tests/fixtures/install-projects/semver-baseline/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "semver-baseline-app",
+  "version": "0.0.0",
+  "dependencies": {
+    "@rpm-fixture/exact": "1.2.3",
+    "@rpm-fixture/caret": "^1.2.3",
+    "@rpm-fixture/caret-zero": "^0.2.0",
+    "@rpm-fixture/tilde": "~1.2.3",
+    "@rpm-fixture/wildcard": "*",
+    "@rpm-fixture/wildcard-major": "1.x",
+    "@rpm-fixture/wildcard-minor": "1.2.x",
+    "@rpm-fixture/comparator": ">=1.0.0 <2.0.0"
+  }
+}

--- a/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__caret-zero.json
+++ b/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__caret-zero.json
@@ -1,0 +1,49 @@
+{
+  "name": "@rpm-fixture/caret-zero",
+  "dist-tags": {
+    "latest": "0.3.0"
+  },
+  "versions": {
+    "0.2.0": {
+      "name": "@rpm-fixture/caret-zero",
+      "version": "0.2.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/caret-zero/-/caret-zero-0.2.0.tgz",
+        "integrity": "sha512-caretzero020",
+        "shasum": "fixture-rpm-fixture-caret-zero-0-2-0"
+      },
+      "description": "@rpm-fixture/caret-zero 0.2.0 semver fixture"
+    },
+    "0.2.9": {
+      "name": "@rpm-fixture/caret-zero",
+      "version": "0.2.9",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/caret-zero/-/caret-zero-0.2.9.tgz",
+        "integrity": "sha512-caretzero029",
+        "shasum": "fixture-rpm-fixture-caret-zero-0-2-9"
+      },
+      "description": "@rpm-fixture/caret-zero 0.2.9 semver fixture"
+    },
+    "0.3.0": {
+      "name": "@rpm-fixture/caret-zero",
+      "version": "0.3.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/caret-zero/-/caret-zero-0.3.0.tgz",
+        "integrity": "sha512-caretzero030",
+        "shasum": "fixture-rpm-fixture-caret-zero-0-3-0"
+      },
+      "description": "@rpm-fixture/caret-zero 0.3.0 semver fixture"
+    }
+  },
+  "_id": "@rpm-fixture/caret-zero",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/caret-zero semver fixture"
+}

--- a/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__caret.json
+++ b/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__caret.json
@@ -1,0 +1,49 @@
+{
+  "name": "@rpm-fixture/caret",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.2.3": {
+      "name": "@rpm-fixture/caret",
+      "version": "1.2.3",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/caret/-/caret-1.2.3.tgz",
+        "integrity": "sha512-caret123",
+        "shasum": "fixture-rpm-fixture-caret-1-2-3"
+      },
+      "description": "@rpm-fixture/caret 1.2.3 semver fixture"
+    },
+    "1.9.9": {
+      "name": "@rpm-fixture/caret",
+      "version": "1.9.9",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/caret/-/caret-1.9.9.tgz",
+        "integrity": "sha512-caret199",
+        "shasum": "fixture-rpm-fixture-caret-1-9-9"
+      },
+      "description": "@rpm-fixture/caret 1.9.9 semver fixture"
+    },
+    "2.0.0": {
+      "name": "@rpm-fixture/caret",
+      "version": "2.0.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/caret/-/caret-2.0.0.tgz",
+        "integrity": "sha512-caret200",
+        "shasum": "fixture-rpm-fixture-caret-2-0-0"
+      },
+      "description": "@rpm-fixture/caret 2.0.0 semver fixture"
+    }
+  },
+  "_id": "@rpm-fixture/caret",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/caret semver fixture"
+}

--- a/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__comparator.json
+++ b/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__comparator.json
@@ -1,0 +1,49 @@
+{
+  "name": "@rpm-fixture/comparator",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.9.9": {
+      "name": "@rpm-fixture/comparator",
+      "version": "0.9.9",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/comparator/-/comparator-0.9.9.tgz",
+        "integrity": "sha512-comparator099",
+        "shasum": "fixture-rpm-fixture-comparator-0-9-9"
+      },
+      "description": "@rpm-fixture/comparator 0.9.9 semver fixture"
+    },
+    "1.5.0": {
+      "name": "@rpm-fixture/comparator",
+      "version": "1.5.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/comparator/-/comparator-1.5.0.tgz",
+        "integrity": "sha512-comparator150",
+        "shasum": "fixture-rpm-fixture-comparator-1-5-0"
+      },
+      "description": "@rpm-fixture/comparator 1.5.0 semver fixture"
+    },
+    "2.0.0": {
+      "name": "@rpm-fixture/comparator",
+      "version": "2.0.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/comparator/-/comparator-2.0.0.tgz",
+        "integrity": "sha512-comparator200",
+        "shasum": "fixture-rpm-fixture-comparator-2-0-0"
+      },
+      "description": "@rpm-fixture/comparator 2.0.0 semver fixture"
+    }
+  },
+  "_id": "@rpm-fixture/comparator",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/comparator semver fixture"
+}

--- a/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__exact.json
+++ b/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__exact.json
@@ -1,0 +1,49 @@
+{
+  "name": "@rpm-fixture/exact",
+  "dist-tags": {
+    "latest": "1.2.4"
+  },
+  "versions": {
+    "1.2.2": {
+      "name": "@rpm-fixture/exact",
+      "version": "1.2.2",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/exact/-/exact-1.2.2.tgz",
+        "integrity": "sha512-exact122",
+        "shasum": "fixture-rpm-fixture-exact-1-2-2"
+      },
+      "description": "@rpm-fixture/exact 1.2.2 semver fixture"
+    },
+    "1.2.3": {
+      "name": "@rpm-fixture/exact",
+      "version": "1.2.3",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/exact/-/exact-1.2.3.tgz",
+        "integrity": "sha512-exact123",
+        "shasum": "fixture-rpm-fixture-exact-1-2-3"
+      },
+      "description": "@rpm-fixture/exact 1.2.3 semver fixture"
+    },
+    "1.2.4": {
+      "name": "@rpm-fixture/exact",
+      "version": "1.2.4",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/exact/-/exact-1.2.4.tgz",
+        "integrity": "sha512-exact124",
+        "shasum": "fixture-rpm-fixture-exact-1-2-4"
+      },
+      "description": "@rpm-fixture/exact 1.2.4 semver fixture"
+    }
+  },
+  "_id": "@rpm-fixture/exact",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/exact semver fixture"
+}

--- a/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__tilde.json
+++ b/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__tilde.json
@@ -1,0 +1,49 @@
+{
+  "name": "@rpm-fixture/tilde",
+  "dist-tags": {
+    "latest": "1.3.0"
+  },
+  "versions": {
+    "1.2.3": {
+      "name": "@rpm-fixture/tilde",
+      "version": "1.2.3",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/tilde/-/tilde-1.2.3.tgz",
+        "integrity": "sha512-tilde123",
+        "shasum": "fixture-rpm-fixture-tilde-1-2-3"
+      },
+      "description": "@rpm-fixture/tilde 1.2.3 semver fixture"
+    },
+    "1.2.9": {
+      "name": "@rpm-fixture/tilde",
+      "version": "1.2.9",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/tilde/-/tilde-1.2.9.tgz",
+        "integrity": "sha512-tilde129",
+        "shasum": "fixture-rpm-fixture-tilde-1-2-9"
+      },
+      "description": "@rpm-fixture/tilde 1.2.9 semver fixture"
+    },
+    "1.3.0": {
+      "name": "@rpm-fixture/tilde",
+      "version": "1.3.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/tilde/-/tilde-1.3.0.tgz",
+        "integrity": "sha512-tilde130",
+        "shasum": "fixture-rpm-fixture-tilde-1-3-0"
+      },
+      "description": "@rpm-fixture/tilde 1.3.0 semver fixture"
+    }
+  },
+  "_id": "@rpm-fixture/tilde",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/tilde semver fixture"
+}

--- a/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__wildcard-major.json
+++ b/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__wildcard-major.json
@@ -1,0 +1,49 @@
+{
+  "name": "@rpm-fixture/wildcard-major",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/wildcard-major",
+      "version": "1.0.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/wildcard-major/-/wildcard-major-1.0.0.tgz",
+        "integrity": "sha512-wildcardmajor100",
+        "shasum": "fixture-rpm-fixture-wildcard-major-1-0-0"
+      },
+      "description": "@rpm-fixture/wildcard-major 1.0.0 semver fixture"
+    },
+    "1.9.0": {
+      "name": "@rpm-fixture/wildcard-major",
+      "version": "1.9.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/wildcard-major/-/wildcard-major-1.9.0.tgz",
+        "integrity": "sha512-wildcardmajor190",
+        "shasum": "fixture-rpm-fixture-wildcard-major-1-9-0"
+      },
+      "description": "@rpm-fixture/wildcard-major 1.9.0 semver fixture"
+    },
+    "2.0.0": {
+      "name": "@rpm-fixture/wildcard-major",
+      "version": "2.0.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/wildcard-major/-/wildcard-major-2.0.0.tgz",
+        "integrity": "sha512-wildcardmajor200",
+        "shasum": "fixture-rpm-fixture-wildcard-major-2-0-0"
+      },
+      "description": "@rpm-fixture/wildcard-major 2.0.0 semver fixture"
+    }
+  },
+  "_id": "@rpm-fixture/wildcard-major",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/wildcard-major semver fixture"
+}

--- a/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__wildcard-minor.json
+++ b/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__wildcard-minor.json
@@ -1,0 +1,49 @@
+{
+  "name": "@rpm-fixture/wildcard-minor",
+  "dist-tags": {
+    "latest": "1.3.0"
+  },
+  "versions": {
+    "1.2.0": {
+      "name": "@rpm-fixture/wildcard-minor",
+      "version": "1.2.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/wildcard-minor/-/wildcard-minor-1.2.0.tgz",
+        "integrity": "sha512-wildcardminor120",
+        "shasum": "fixture-rpm-fixture-wildcard-minor-1-2-0"
+      },
+      "description": "@rpm-fixture/wildcard-minor 1.2.0 semver fixture"
+    },
+    "1.2.9": {
+      "name": "@rpm-fixture/wildcard-minor",
+      "version": "1.2.9",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/wildcard-minor/-/wildcard-minor-1.2.9.tgz",
+        "integrity": "sha512-wildcardminor129",
+        "shasum": "fixture-rpm-fixture-wildcard-minor-1-2-9"
+      },
+      "description": "@rpm-fixture/wildcard-minor 1.2.9 semver fixture"
+    },
+    "1.3.0": {
+      "name": "@rpm-fixture/wildcard-minor",
+      "version": "1.3.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/wildcard-minor/-/wildcard-minor-1.3.0.tgz",
+        "integrity": "sha512-wildcardminor130",
+        "shasum": "fixture-rpm-fixture-wildcard-minor-1-3-0"
+      },
+      "description": "@rpm-fixture/wildcard-minor 1.3.0 semver fixture"
+    }
+  },
+  "_id": "@rpm-fixture/wildcard-minor",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/wildcard-minor semver fixture"
+}

--- a/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__wildcard.json
+++ b/tests/fixtures/install-projects/semver-baseline/registry/@rpm-fixture__wildcard.json
@@ -1,0 +1,49 @@
+{
+  "name": "@rpm-fixture/wildcard",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/wildcard",
+      "version": "1.0.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/wildcard/-/wildcard-1.0.0.tgz",
+        "integrity": "sha512-wildcard100",
+        "shasum": "fixture-rpm-fixture-wildcard-1-0-0"
+      },
+      "description": "@rpm-fixture/wildcard 1.0.0 semver fixture"
+    },
+    "2.0.0": {
+      "name": "@rpm-fixture/wildcard",
+      "version": "2.0.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/wildcard/-/wildcard-2.0.0.tgz",
+        "integrity": "sha512-wildcard200",
+        "shasum": "fixture-rpm-fixture-wildcard-2-0-0"
+      },
+      "description": "@rpm-fixture/wildcard 2.0.0 semver fixture"
+    },
+    "3.0.0": {
+      "name": "@rpm-fixture/wildcard",
+      "version": "3.0.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/wildcard/-/wildcard-3.0.0.tgz",
+        "integrity": "sha512-wildcard300",
+        "shasum": "fixture-rpm-fixture-wildcard-3-0-0"
+      },
+      "description": "@rpm-fixture/wildcard 3.0.0 semver fixture"
+    }
+  },
+  "_id": "@rpm-fixture/wildcard",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/wildcard semver fixture"
+}

--- a/tests/fixtures/install-projects/semver-invalid-range/expected/errors.txt
+++ b/tests/fixtures/install-projects/semver-invalid-range/expected/errors.txt
@@ -1,0 +1,1 @@
+@rpm-fixture/invalid-range requested =>1.0.0 error invalid range

--- a/tests/fixtures/install-projects/semver-invalid-range/package.json
+++ b/tests/fixtures/install-projects/semver-invalid-range/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "semver-invalid-range-app",
+  "version": "0.0.0",
+  "dependencies": {
+    "@rpm-fixture/invalid-range": "=>1.0.0"
+  }
+}

--- a/tests/fixtures/install-projects/semver-invalid-range/registry/@rpm-fixture__invalid-range.json
+++ b/tests/fixtures/install-projects/semver-invalid-range/registry/@rpm-fixture__invalid-range.json
@@ -1,0 +1,27 @@
+{
+  "name": "@rpm-fixture/invalid-range",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/invalid-range",
+      "version": "1.0.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/invalid-range/-/invalid-range-1.0.0.tgz",
+        "integrity": "sha512-invalidrange100",
+        "shasum": "fixture-rpm-fixture-invalid-range-1-0-0"
+      },
+      "description": "@rpm-fixture/invalid-range 1.0.0 semver fixture"
+    }
+  },
+  "_id": "@rpm-fixture/invalid-range",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/invalid-range semver fixture"
+}

--- a/tests/fixtures/install-projects/semver-unsatisfied/expected/errors.txt
+++ b/tests/fixtures/install-projects/semver-unsatisfied/expected/errors.txt
@@ -1,0 +1,1 @@
+@rpm-fixture/unsatisfied requested >=9.0.0 <10.0.0 error unsatisfied range

--- a/tests/fixtures/install-projects/semver-unsatisfied/package.json
+++ b/tests/fixtures/install-projects/semver-unsatisfied/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "semver-unsatisfied-app",
+  "version": "0.0.0",
+  "dependencies": {
+    "@rpm-fixture/unsatisfied": ">=9.0.0 <10.0.0"
+  }
+}

--- a/tests/fixtures/install-projects/semver-unsatisfied/registry/@rpm-fixture__unsatisfied.json
+++ b/tests/fixtures/install-projects/semver-unsatisfied/registry/@rpm-fixture__unsatisfied.json
@@ -1,0 +1,38 @@
+{
+  "name": "@rpm-fixture/unsatisfied",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/unsatisfied",
+      "version": "1.0.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/unsatisfied/-/unsatisfied-1.0.0.tgz",
+        "integrity": "sha512-unsatisfied100",
+        "shasum": "fixture-rpm-fixture-unsatisfied-1-0-0"
+      },
+      "description": "@rpm-fixture/unsatisfied 1.0.0 semver fixture"
+    },
+    "2.0.0": {
+      "name": "@rpm-fixture/unsatisfied",
+      "version": "2.0.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/unsatisfied/-/unsatisfied-2.0.0.tgz",
+        "integrity": "sha512-unsatisfied200",
+        "shasum": "fixture-rpm-fixture-unsatisfied-2-0-0"
+      },
+      "description": "@rpm-fixture/unsatisfied 2.0.0 semver fixture"
+    }
+  },
+  "_id": "@rpm-fixture/unsatisfied",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/unsatisfied semver fixture"
+}


### PR DESCRIPTION
## Contract

This is contract-affecting for semver range interpretation, selected package versions, and lockfile requested/resolved version behavior. The PR defines the M1 resolver baseline and fixtures before implementation depends on it.

SPEC status: missing -> added
SPEC paths:
- `docs/specs/semver-resolution.md` is the new authoritative semver baseline.
- `docs/specs/resolver.md` now delegates version/range satisfaction to the semver spec.

## Changes

- Added the M1 npm-compatible semver baseline: exact, caret, zero-major caret, tilde, wildcard, wildcard major/minor, and common comparator ranges.
- Documented that selected versions choose the highest matching stable version from npm metadata while preserving the original requested range in lockfile `requested`.
- Explicitly deferred the Rust semver/range dependency decision to the M1 implementation spike, with fixture compatibility as the selection criterion and Node/npm-compatible behavior preferred over Cargo-only semantics.
- Documented existing ad hoc normalization/replacement targets in `add.rs`, `api.rs`, `util.rs`, `lockfile/mod.rs`, and `registry/mod.rs`.
- Added deterministic offline install fixtures for semver success, unsatisfied range failure, and invalid range failure expectations.
- Added a test that verifies the semver registry fixture JSON files deserialize through the current registry metadata shape.

## Validation

- `find tests/fixtures/install-projects/semver-baseline tests/fixtures/install-projects/semver-unsatisfied tests/fixtures/install-projects/semver-invalid-range -name "*.json" -print -exec jq empty {} \;` passed.
- `cargo fmt --check` passed after formatting.
- `cargo check` passed.
- `cargo test` passed: 38 tests. The expected shell message for the missing-binary run test was printed.
- `cargo clippy --all-targets --all-features` passed with the existing `lockfile/constraint.rs` redundant static lifetime warning.
- `bash scripts/check-workflow-final.sh 40` passed.

## Checklist

- [x] Intake script passed.
- [x] Explorer returned issue and contract summary.
- [x] SPEC impact classified.
- [x] Draft PR opened with kickoff commit.
- [x] Implementation stayed focused on contract and fixture definition.
- [x] Relevant validation ran.
- [x] Codex review loop completed.
- [x] Final audit script passed.
- [x] PR marked ready for review.

Closes #1
