### PR TITLE
docs(spec): establish ADR and SPEC governance baseline

### DIFF
--- a/docs/adrs/0001-node-npm-product-boundary.md
+++ b/docs/adrs/0001-node-npm-product-boundary.md
@@ -1,0 +1,67 @@
+---
+adr_id: 0001
+title: Keep RPM Focused On The Node/npm Package Manager Boundary
+status: accepted
+date: 2026-05-29
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+---
+
+# ADR 0001: Keep RPM Focused On The Node/npm Package Manager Boundary
+
+Status: Accepted
+Date: 2026-05-29
+
+## Context
+
+RPM previously carried broader language-agnostic and agent-toolchain framing in
+private notes and planning discussions. That broader framing made it harder to
+decide what M1 must guarantee and what current work should ignore.
+
+The current repository already implements Node/npm-specific behavior:
+
+- `package.json` manifest handling
+- npm registry metadata reads
+- npm-compatible semver work
+- `node_modules` linking
+- npm-style script execution
+
+M1 also needs a trustworthy semver and install contract. Generalizing the
+product boundary before that contract is stable would increase ambiguity without
+improving current deliverables.
+
+## Decision
+
+RPM is a Node/npm package manager.
+
+RPM does not pursue a language-agnostic package-manager boundary in the current
+product direction.
+
+M1 is defined as a small but real install pipeline for the Node/npm ecosystem.
+Scope may stay narrow, but supported behavior must be correct within the stated
+contract.
+
+Semver correctness is part of the package-manager trust boundary. RPM should not
+ship an intentionally weak semver model merely to keep M1 small. Supported
+range behavior must be npm-compatible within the documented baseline.
+
+## Consequences
+
+- Public repository documents should describe RPM as a Node/npm package manager.
+- Resolver, lockfile, install, linker, and script decisions should optimize for
+  Node/npm correctness rather than future multi-ecosystem generality.
+- Long-range ideas such as agent context surfaces, non-Node ecosystems, or
+  broader toolchain orchestration are not part of the active public contract
+  unless explicitly promoted later.
+- Future public expansion beyond the Node/npm boundary requires a new ADR before
+  contract work proceeds.
+
+## Follow-Up
+
+- Keep M1 planning and issues framed around the Node/npm install contract.
+- Prefer SPEC updates for concrete behavior changes and ADRs for architectural
+  boundary changes.

--- a/docs/adrs/0002-single-crate-cli-core-boundary.md
+++ b/docs/adrs/0002-single-crate-cli-core-boundary.md
@@ -1,0 +1,107 @@
+---
+adr_id: 0002
+title: Use A Single-Crate `cli/core` Boundary Before Any Workspace Split
+status: accepted
+date: 2026-05-29
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+---
+
+# ADR 0002: Use A Single-Crate `cli/core` Boundary Before Any Workspace Split
+
+Status: Accepted
+Date: 2026-05-29
+
+## Context
+
+RPM needs clearer ownership boundaries before semver, resolver, and installer
+work grows further. Earlier planning discussed a future Cargo workspace split
+and a possible `rpm-npm` boundary.
+
+That shape is too heavy for the current stage:
+
+- semver and resolver work needs faster iteration, not packaging overhead
+- npm registry interpretation is part of the core package-manager contract
+- Cargo workspace management would add structure before extension points exist
+
+At the same time, the codebase still needs a hard boundary between command-line
+behavior and package-manager behavior.
+
+## Decision
+
+RPM stays a single Cargo package for now.
+
+The initial code boundary is:
+
+- `src/cli`
+- `src/core`
+
+`cli` owns:
+
+- argument parsing
+- command dispatch
+- terminal presentation
+- exit-code mapping
+
+`core` owns:
+
+- manifest handling
+- resolver and semver policy
+- registry metadata interpretation and network access
+- lockfile loading and saving
+- install staging and recovery
+- linker behavior
+- script execution contracts
+
+`core -> cli` dependencies are forbidden.
+
+`cli -> core` dependencies are allowed.
+
+There is no separate `rpm-npm` boundary at this stage. npm registry handling
+and npm-compatible semver behavior belong to `core` because they define RPM's
+actual package-manager contract.
+
+Cargo workspace or multi-crate splitting is deferred until RPM has concrete
+extension or independent packaging needs.
+
+## Proposed Initial Layout
+
+This layout is a boundary target, not a full file-by-file migration plan:
+
+```text
+src/
+  main.rs
+  cli/
+  core/
+    manifest/
+    resolver/
+      semver/
+    registry/
+    lockfile/
+    install/
+    linker/
+    error/
+```
+
+Exact submodule names may change, but the ownership boundary should remain the
+same.
+
+## Consequences
+
+- Refactors should move logic toward `src/cli` and `src/core` even before any
+  future crate split.
+- Semver lives under `core::resolver`, not as a CLI concern and not as a
+  separate npm crate boundary.
+- Resolver output should remain callable without CLI parsing or terminal I/O.
+- Future Cargo workspace promotion should be a mechanical packaging step on top
+  of already-stable boundaries, not the mechanism used to discover them.
+
+## Follow-Up
+
+- Align workspace-layout SPEC with this boundary.
+- Reorder M1 work so semver and resolver boundaries land before end-to-end
+  installer expansion.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -43,7 +43,7 @@ than a new contract decision.
 
 ## File Naming
 
-- Copy [TEMPLATE.md](/Users/gim-yechan/opensource/rpm/docs/adrs/TEMPLATE.md)
+- Copy [TEMPLATE.md](TEMPLATE.md)
 - Replace `XXXX` with the next four-digit ADR id
 - Use a short kebab-case filename after the id
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,95 @@
+# ADRs
+
+This directory stores Architecture Decision Records for repository-level
+technical and product-boundary decisions.
+
+Use an ADR when a change decides:
+
+- product boundary
+- repository or module ownership boundaries
+- crate or package split direction
+- long-lived architectural constraints
+- decisions that future SPECs and implementations should inherit
+
+Do not use an ADR for routine feature behavior. Feature and contract behavior
+belongs in the owning SPEC under `docs/specs/`.
+
+## ADR And SPEC Relationship
+
+ADRs and SPECs serve different roles:
+
+- ADRs justify architectural and long-lived boundary decisions.
+- SPECs define the active package-manager contract.
+
+In this repository, contract work is SPEC-driven.
+
+That means:
+
+- SPEC is the SSOT for repository contracts
+- code is the implementation of the active SPEC set, not the contract source of
+  truth
+- code should not silently outrun an active SPEC
+- SPEC changes should happen before or with contract-changing implementation
+- if a SPEC change depends on a boundary decision, the ADR should land before
+  or with that SPEC change
+- if a SPEC change intentionally leads implementation, the required follow-up
+  work must be recorded in the same PR or linked issues
+
+The main exception is a stale SPEC: prior human or AI changes may have merged
+without the required SPEC update, leaving the written contract behind the
+already-established code behavior. In that case the PR should explicitly
+classify the SPEC as stale and explain why the update is a correction rather
+than a new contract decision.
+
+## File Naming
+
+- Copy [TEMPLATE.md](/Users/gim-yechan/opensource/rpm/docs/adrs/TEMPLATE.md)
+- Replace `XXXX` with the next four-digit ADR id
+- Use a short kebab-case filename after the id
+
+Example:
+
+```text
+0003-some-decision.md
+```
+
+## Frontmatter
+
+Every ADR should include this frontmatter:
+
+- `adr_id`
+- `title`
+- `status`
+- `date`
+- `authors`
+- `deciders`
+- `consulted`
+- `informed`
+
+Optional fields:
+
+- `supersedes`
+- `superseded_by`
+- `related_specs`
+- `related_issues`
+
+## Status Values
+
+- `proposed`
+- `accepted`
+- `superseded`
+- `rejected`
+
+## Process
+
+1. Write the decision context and the exact decision.
+2. Record consequences and immediate follow-up.
+3. Update any conflicting SPECs in the same change.
+4. Keep implementation details out unless they are part of the actual
+   architectural constraint.
+
+## Repository Rule
+
+When an ADR changes an active repository boundary, public product framing, or a
+long-lived ownership rule, related SPECs must be aligned in the same change so
+the repository does not publish conflicting guidance.

--- a/docs/adrs/TEMPLATE.md
+++ b/docs/adrs/TEMPLATE.md
@@ -1,0 +1,48 @@
+---
+adr_id: XXXX
+title: Short Decision Title
+status: proposed
+date: YYYY-MM-DD
+authors:
+  - github-handle
+deciders:
+  - github-handle
+consulted: []
+informed: []
+supersedes: []
+superseded_by: null
+related_specs: []
+related_issues: []
+---
+
+# ADR XXXX: Short Decision Title
+
+Status: Proposed
+Date: YYYY-MM-DD
+
+## Context
+
+Describe the situation that requires a decision. Focus on the concrete product,
+architectural, or repository pressure that makes the choice necessary now.
+
+## Decision
+
+State the decision plainly. Prefer short, testable statements over broad
+vision language.
+
+## Consequences
+
+- Describe the immediate implications of the decision.
+- Include what future work becomes easier or harder.
+- Note any boundaries that are now explicitly out of scope.
+
+## Follow-Up
+
+- List the next documents, specs, or implementation tasks that should align to
+  this decision.
+- Link owning SPECs or issues when they exist.
+
+## Alternatives Considered
+
+- Alternative 1: Why it was not chosen.
+- Alternative 2: Why it was not chosen.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,213 @@
+# SPECs
+
+This directory stores the repository's authoritative contract documents.
+
+For contract behavior, SPEC is the SSOT.
+
+Code is not the source of truth for package-manager contracts. Code is the
+implementation of the active SPEC set.
+
+RPM is currently developed in a spec-driven way for contract-affecting work.
+When behavior changes affect the package-manager contract, the owning SPEC
+should be identified and updated before or with code changes.
+
+## What A SPEC Is In This Repository
+
+In the current codebase, a SPEC is the source of truth for active contract
+behavior.
+
+That includes contracts for:
+
+- manifest interpretation
+- semver range behavior
+- resolver behavior
+- lockfile format and compatibility
+- install staging and recovery
+- `node_modules` linker behavior
+- script execution behavior
+- repository ownership boundaries when they affect behavior
+
+Current SPEC documents are not yet perfectly uniform or fully reduced to pure
+executable-style specifications. Some still mix:
+
+- active behavior contracts
+- boundary rules
+- staged implementation constraints
+- open questions
+
+Even so, they remain authoritative. Code must not silently drift past an active
+SPEC.
+
+## SPEC-Driven Rule
+
+For contract-affecting work:
+
+1. Find the owning SPEC first.
+2. Classify the current state:
+   - code conforms to SPEC
+   - code violates SPEC
+   - SPEC is stale
+   - no SPEC exists yet
+3. Update the SPEC before or with implementation when the intended contract is
+   changing.
+4. Keep tests and fixtures aligned with the stated contract.
+
+In normal flow, SPEC changes come before implementation changes or in the same
+PR. A contract-changing code change should not land first and hope the SPEC
+will catch up later.
+
+## Relationship To ADRs
+
+ADRs justify architectural and long-lived boundary decisions.
+
+SPECs define concrete repository contracts.
+
+Use an ADR when deciding:
+
+- product boundary
+- repository or module ownership boundary
+- split direction such as `cli/core`
+- long-lived architectural constraints future SPECs should inherit
+
+Use a SPEC when defining:
+
+- what the system must do
+- what inputs are supported
+- what outputs or side effects are allowed
+- what errors are contractually required
+
+If a SPEC change depends on an architectural decision, the ADR should land
+before or with the SPEC update.
+
+## SSOT Rule And Stale-SPEC Exception
+
+SPEC is the single source of truth for repository contracts.
+
+That means:
+
+- reviewers should not treat current code behavior as automatically correct just
+  because it already exists
+- implementation and code review should start by checking the owning SPEC
+- a PR that changes contract behavior should update the owning SPEC first or in
+  the same change
+
+There is one explicit exception: a stale SPEC.
+
+A stale SPEC means the intended or already-established repository behavior is no
+longer reflected in the written SPEC because prior human or AI changes were
+merged without the required SPEC update, and the drift accumulated.
+
+In that case, the SPEC may be updated to match the code, but only as an
+exception path. That exception should be treated as a repair of repository
+governance, not as the default workflow.
+
+When using the stale-SPEC exception, the PR should say so explicitly and
+classify the change as:
+
+- `SPEC is stale`
+- the current code path that demonstrates the drift
+- why the update is a correction of established behavior rather than a new
+  contract decision
+
+## Deferred Implementation Rule
+
+Some SPEC changes will intentionally lead implementation.
+
+That is allowed in this repository, but only if the follow-up is explicit.
+
+When a SPEC change is not fully implemented in the same PR, the same PR must
+also do at least one of these:
+
+- link the follow-up issue
+- create the follow-up issue
+- explain why the change is only a clarification of existing behavior
+
+SPEC-only changes must not leave required implementation work implicit.
+
+## Suggested Structure
+
+Use this structure for new or rewritten SPECs:
+
+```markdown
+---
+spec_id: contract-name
+title: Contract Name
+status: draft
+owner: area
+last_reviewed: YYYY-MM-DD
+authors:
+  - github-handle
+deciders:
+  - github-handle
+consulted: []
+informed: []
+related_adrs: []
+related_issues: []
+---
+
+# Spec: <Contract Name>
+
+Status: Draft
+Owner: <area>
+Last reviewed: YYYY-MM-DD
+
+## Purpose
+
+## Contract
+
+## Error Cases
+
+## Test Fixtures
+
+## Open Questions
+```
+
+Documents may temporarily contain extra sections while the current SPEC set is
+being cleaned up, but new work should move toward this shape.
+
+New or rewritten SPECs should also include frontmatter. Existing SPECs may be
+converted incrementally as they are touched.
+
+## Open Questions
+
+SPECs may include an `Open Questions` section.
+
+That section is allowed for questions that are still outside the active
+contract and are not currently blocking implementation or review.
+
+`Open Questions` should be used for:
+
+- deferred decisions that do not change today's contract
+- bounded uncertainty that readers should be aware of
+- follow-up design questions owned by later work
+
+`Open Questions` should not be used for:
+
+- active contract gaps needed by the current implementation
+- decisions that reviewers must guess in order to approve code
+- behavior already established by code and tests
+- vague brainstorming with no contract relevance
+
+If implementation work becomes blocked by an `Open Question`, that question is
+no longer safe to leave open.
+
+At that point, the team should resolve it through:
+
+- an ADR, when the blocker is architectural or about ownership boundaries
+- a SPEC update, when the blocker is concrete behavior contract
+- both ADR and SPEC updates, when the behavior depends on a boundary decision
+
+Implementation should not proceed past a real `Open Question` blocker by making
+the decision only in code.
+
+## M1 Baseline
+
+Cleaning up the current SPEC set is part of M1.
+
+M1 should start from:
+
+- a clear Node/npm product boundary
+- a clear `cli/core` ownership boundary
+- a clear rule for when ADRs are required
+- a clear rule that contract changes are SPEC-driven
+- explicit follow-up tracking when implementation is deferred

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -1,0 +1,56 @@
+---
+spec_id: contract-name
+title: Contract Name
+status: draft
+owner: area
+last_reviewed: YYYY-MM-DD
+authors:
+  - github-handle
+deciders:
+  - github-handle
+consulted: []
+informed: []
+related_adrs: []
+related_issues: []
+---
+
+# Spec: Contract Name
+
+Status: Draft
+Owner: area
+Last reviewed: YYYY-MM-DD
+
+## Purpose
+
+Describe why this contract exists and what repository behavior it governs.
+
+## Contract
+
+State the active behavior contract plainly.
+
+Include:
+
+- supported inputs
+- required outputs or side effects
+- boundaries that callers may rely on
+
+## Error Cases
+
+List the contractually required failure behavior.
+
+Include:
+
+- validation failures
+- unsupported input behavior
+- required recovery or non-mutation guarantees when relevant
+
+## Test Fixtures
+
+List the fixtures, snapshots, or targeted tests that verify this contract.
+
+If no fixture exists yet, say what verification should exist next.
+
+## Open Questions
+
+Record only questions that are outside the active contract and do not block the
+current implementation or review.

--- a/docs/specs/workspace-layout.md
+++ b/docs/specs/workspace-layout.md
@@ -2,59 +2,63 @@
 
 Status: Draft
 Owner: repository
-Last reviewed: 2026-05-28
+Last reviewed: 2026-05-29
 
 ## Purpose
 
 RPM needs explicit ownership boundaries before large behavior changes move code
-across CLI parsing, core install behavior, npm registry access, lockfile
-handling, and `node_modules` linking.
+across CLI parsing, resolver behavior, registry access, lockfile handling, and
+`node_modules` linking.
 
 ## Contract
 
-The repository is a Cargo workspace. The first workspace member is the current
-root `rpm` package.
+The repository remains a single Cargo package for now.
 
-The first crate split is deferred. The current codebase remains in one package
-until the next split can be done as a mechanical move with no behavior changes.
+The current codebase should move toward a `src/cli` and `src/core` boundary
+before any future Cargo workspace or multi-crate split.
 
-The intended crate boundaries are:
+The ownership boundary is:
 
-- `rpm-cli`: owns argument parsing, process exit codes, and user-facing command
-  output.
-- `rpm-core`: owns package-manager workflows, project filesystem mutation,
+- `cli`: owns argument parsing, command dispatch, process exit codes, and
+  user-facing output.
+- `core`: owns package-manager workflows, manifest handling, resolver and
+  semver behavior, registry metadata interpretation, tarball/cache behavior,
   lockfile loading/saving, install recovery, and `node_modules` linking.
-- `rpm-npm`: owns npm package metadata interpretation, registry HTTP access,
-  tarball cache writes, and npm ecosystem compatibility rules.
 
-Until those crates exist, the current module boundaries are authoritative:
+`core` must remain callable without CLI parsing or terminal output.
 
-- `src/main.rs`, `src/lib/opt`, and `src/lib/command/mod.rs` are the CLI
-  boundary.
+`core -> cli` dependencies are forbidden.
+
+`cli -> core` dependencies are allowed.
+
+Until the source tree is reorganized, these current modules map to the intended
+boundary:
+
+- `src/main.rs`, `src/lib/opt`, and `src/lib/command/mod.rs` are the current
+  CLI boundary.
 - `src/lib/command/working_process`, `src/lib/lockfile`,
-  `src/lib/package_manifest`, and `src/lib/node_linker` are the core install
-  boundary. The nested `working_process` modules are not owned by the CLI
-  boundary despite living under `src/lib/command` today.
-- `src/lib/api` and `src/lib/registry` are the npm registry boundary.
+  `src/lib/package_manifest`, `src/lib/node_linker`, `src/lib/api`, and
+  `src/lib/registry` are current core-owned areas even when their paths still
+  reflect earlier structure.
 
-Core install logic must remain callable from the library without depending on
-CLI argument parsing. Registry/network code must not directly mutate project
-filesystem state outside its tarball cache responsibility.
+There is no separate `rpm-npm` boundary in the current layout. npm registry
+handling and npm-compatible semver behavior belong to `core` because they are
+part of RPM's package-manager contract.
 
 ## Error Cases
 
-Workspace layout changes must not change command behavior, lockfile format,
-manifest interpretation, registry selection, tarball cache layout, or
-`node_modules` layout unless the owning SPEC is updated in the same change.
+Layout changes must not change command behavior, lockfile format, manifest
+interpretation, registry selection, tarball cache layout, or `node_modules`
+layout unless the owning SPEC is updated in the same change.
 
 ## Test Fixtures
 
-No fixtures are required for the workspace decision. Build validation must
-cover the workspace root.
+No fixtures are required for the layout decision. Build validation must cover
+the current single-package root.
 
 ## Open Questions
 
-- Whether `rpm-core` should own package manifest parsing or delegate it to a
-  future ecosystem crate.
-- Whether cache storage should live in `rpm-core` or the future `rpm-npm`
-  crate.
+- When the `src/cli` and `src/core` boundary should be reflected as actual
+  directories in the source tree.
+- What concrete extension or packaging need should trigger a future Cargo
+  workspace split.


### PR DESCRIPTION
## Summary
- add ADRs for the Node/npm product boundary and single-crate cli/core boundary
- add ADR and SPEC templates plus README guidance
- align workspace layout SPEC with the accepted boundary and document spec-driven governance

## Validation
- cargo test