### PR TITLE
repo: add local git hook guardrails (#52)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+exec "$repo_root/scripts/run-local-git-hook-gate.sh" pre-commit

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+exec "$repo_root/scripts/run-local-git-hook-gate.sh" pre-push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,30 @@ cargo test
 
 Use local scripts when they match the change you are making. CI remains the shared verification point for pull requests.
 
+## Local Git Hooks
+
+The repository includes an opt-in local hook path for fast guardrails before review.
+CI remains the source of enforcement.
+
+Install the repo-local hooks with:
+
+```sh
+bash scripts/install-git-hooks.sh
+```
+
+The installer only points your local clone at `.githooks/` through
+`git config --local core.hooksPath .githooks` and marks the hook scripts
+executable. It does not change tracked files outside the hook setup.
+
+Default hooks:
+
+- `pre-commit`: `cargo fmt --check`
+- `pre-push`: `cargo test`
+
+If you need to bypass the local guardrail for a one-off case, use normal Git hook
+escape hatches such as `--no-verify`. Do not treat that as a replacement for the
+repository validation gate.
+
 ## Commits
 
 Use atomic commits:

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+hooks_path="$repo_root/.githooks"
+
+if [[ ! -d "$hooks_path" ]]; then
+  echo "missing hooks directory: $hooks_path" >&2
+  exit 1
+fi
+
+chmod +x \
+  "$hooks_path/pre-commit" \
+  "$hooks_path/pre-push" \
+  "$repo_root/scripts/run-local-git-hook-gate.sh"
+
+git config --local core.hooksPath .githooks
+
+echo "Installed repo-local git hooks at .githooks"
+echo "pre-commit: cargo fmt --check"
+echo "pre-push: cargo test"

--- a/scripts/run-local-git-hook-gate.sh
+++ b/scripts/run-local-git-hook-gate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook_name="${1:-}"
+
+if [[ -z "$hook_name" ]]; then
+  echo "usage: $0 <pre-commit|pre-push>" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+run_gate() {
+  local label="$1"
+  shift
+
+  echo "[local-hook] $label"
+  "$@"
+}
+
+case "$hook_name" in
+  pre-commit)
+    run_gate "cargo fmt --check" cargo fmt --check
+    ;;
+  pre-push)
+    run_gate "cargo test" cargo test
+    ;;
+  *)
+    echo "unsupported hook: $hook_name" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- add repo-local pre-commit and pre-push hooks under `.githooks/`
- add a small installer script to opt into the local hook path
- document the local hook workflow in `CONTRIBUTING.md`

## Contract

Closes #52.

This adds an opt-in local guardrail only. CI remains the source of enforcement.

## Validation

- `bash -n scripts/install-git-hooks.sh scripts/run-local-git-hook-gate.sh .githooks/pre-commit .githooks/pre-push`

## Notes

- `cargo fmt --check` currently fails on `main` because PR #48 landed unformatted code; that is being repaired separately by #51.
- The installer script intentionally uses `git config --local core.hooksPath .githooks`, so I did not rely on mutating shared local git config as PR validation in this worktree.
