### PR TITLE
docs: define milestone contract issue rules (#49)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,30 @@ Use the closest issue template and include:
 
 Issue text explains intent, but it does not override an owning SPEC.
 
+## Milestones
+
+Use GitHub milestones for milestone-level tracking, not as the detailed source
+of truth for scope.
+
+Each active milestone should have one first issue that acts as the milestone
+contract issue.
+
+That issue should:
+
+- stay open until the milestone itself is complete
+- be labeled so it is distinguishable from implementation issues
+- remain pinned while the milestone is active
+- hold the current summary of:
+  - purpose
+  - in scope
+  - out of scope
+  - owning SPECs and ADRs known so far
+  - delivery order or dependency chain
+  - exit criteria
+
+If new ADRs or SPECs become relevant during the milestone, update the milestone
+contract issue body. Do not rely on comments alone as the current summary.
+
 ## Pull Requests
 
 Open PRs with a clear summary, validation notes, and a focused checklist. Keep implementation and cleanup separate.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -62,6 +62,11 @@ ADRs justify architectural and long-lived boundary decisions.
 
 SPECs define concrete repository contracts.
 
+Milestone contract issues coordinate the scope and ordering of milestone work,
+but they do not replace SPEC authority. If a milestone issue, issue comment, or
+milestone description conflicts with an owning SPEC, the SPEC still wins until
+the SPEC is deliberately updated.
+
 Use an ADR when deciding:
 
 - product boundary

--- a/docs/specs/installer-performance.md
+++ b/docs/specs/installer-performance.md
@@ -6,15 +6,15 @@ Last reviewed: 2026-05-27
 
 ## Purpose
 
-RPM's current installer is intentionally still a prototype, but the M0 recovery
+RPM's current installer is intentionally still a prototype, but the active M1
 track needs a stable description of the bottleneck before changing behavior.
 This document records where the recursive install flow lives, what future
-staging should look like, and which fixture should be used to measure later
+staging should look like, and which fixture should be used to measure staged
 changes.
 
-This document does not authorize an installer rewrite. It is the baseline for a
-later milestone that can change scheduling, concurrency, deduplication, and
-transaction safety with tests.
+This document does not authorize an installer rewrite by itself. It is the
+baseline for staged M1 work and later milestones that can change scheduling,
+concurrency, deduplication, and transaction safety with tests.
 
 ## Current Bottleneck
 

--- a/docs/specs/semver-resolution.md
+++ b/docs/specs/semver-resolution.md
@@ -12,8 +12,8 @@ the M1 baseline and the fixtures that future resolver implementation must pass.
 
 ## Contract
 
-M0 does not implement the full resolver. M1 must implement the first supported
-semver range baseline before installer behavior depends on range selection.
+M1 must implement the first supported semver range baseline before installer
+behavior depends on range selection.
 
 The M1 baseline supports these request forms:
 
@@ -65,9 +65,8 @@ contract:
 - `src/lib/registry/mod.rs::Registry::get_latest_version` is only a latest-tag
   helper and must not stand in for highest matching version selection.
 
-These compatibility paths may remain during M0 only to preserve current command
-behavior. M1 resolver work must replace them with a single version selection
-boundary.
+These compatibility paths may remain only until the active M1 resolver work
+replaces them with a single version selection boundary.
 
 ## Error Cases
 


### PR DESCRIPTION
## Summary

- add repository rules for milestone contract issues to `CONTRIBUTING.md`
- state in `docs/specs/README.md` that milestone contract issues coordinate scope but do not override SPEC authority
- align M1-owning SPEC wording so it refers to the active M1 track instead of stale M0 phrasing

## Contract

Closes #49.

This is a docs/process-only PR. It does not implement semver, resolver, or installer behavior.

## Validation

- `cargo fmt --check`

## Notes

- The GitHub issue metadata for #49 already carries the milestone-contract role, pin, sub-issues, and dependency chain.
- Broad SPEC normalization stays in #50; this PR only removes wording conflicts that would confuse the active M1 contract issue.
