### PR TITLE
docs(spec): restructure and normalize spec docs

### DIFF
--- a/.agents/skills/spec-governance/SKILL.md
+++ b/.agents/skills/spec-governance/SKILL.md
@@ -38,7 +38,8 @@ Use the narrowest authoritative SPEC for the contract.
 Current repository stage:
 
 ```text
-docs/specs/<topic>.md
+docs/specs/cli/<command>/SPEC.md
+docs/specs/core/<topic>/SPEC.md
 ```
 
 After the Cargo workspace is split, prefer crate-local specs for crate-owned contracts:
@@ -50,7 +51,14 @@ crates/<crate-name>/docs/SPEC.md
 Use root-level specs only for cross-crate contracts:
 
 ```text
-docs/specs/<cross-cutting-topic>.md
+docs/specs/<area>/.../SPEC.md
+```
+
+Repository structure and ownership rules that are not package-manager contracts
+live under:
+
+```text
+docs/conventions/
 ```
 
 Do not treat design notes, roadmap notes, or issue text as SPEC authority. They may explain intent, but they do not override SPEC.

--- a/docs/conventions/workspace_layout.md
+++ b/docs/conventions/workspace_layout.md
@@ -1,4 +1,4 @@
-# Spec: Workspace Layout
+# Convention: Workspace Layout
 
 Status: Draft
 Owner: repository
@@ -10,7 +10,7 @@ RPM needs explicit ownership boundaries before large behavior changes move code
 across CLI parsing, resolver behavior, registry access, lockfile handling, and
 `node_modules` linking.
 
-## Contract
+## Rule
 
 The repository remains a single Cargo package for now.
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -129,16 +129,50 @@ also do at least one of these:
 
 SPEC-only changes must not leave required implementation work implicit.
 
+## Directory Layout
+
+The current SPEC set is organized by ownership boundary:
+
+```text
+docs/specs/
+  README.md
+  TEMPLATE.md
+  cli/
+    README.md
+    run/
+      SPEC.md
+  core/
+    README.md
+    manifest/
+      SPEC.md
+    semver/
+      SPEC.md
+    resolver/
+      SPEC.md
+    lockfile/
+      SPEC.md
+    install/
+      recovery/
+        SPEC.md
+      performance/
+        SPEC.md
+    linker/
+      SPEC.md
+```
+
+Repository structure and ownership conventions that are not themselves package
+manager contracts live under `docs/conventions/`.
+
 ## Suggested Structure
 
 Use this structure for new or rewritten SPECs:
 
 ```markdown
 ---
-spec_id: contract-name
+spec_id: contract_name
 title: Contract Name
 status: draft
-owner: area
+owner: core/area
 last_reviewed: YYYY-MM-DD
 authors:
   - github-handle
@@ -150,10 +184,10 @@ related_adrs: []
 related_issues: []
 ---
 
-# Spec: <Contract Name>
+# Spec: Contract Name
 
 Status: Draft
-Owner: <area>
+Owner: core/area
 Last reviewed: YYYY-MM-DD
 
 ## Purpose
@@ -216,3 +250,16 @@ M1 should start from:
 - a clear rule for when ADRs are required
 - a clear rule that contract changes are SPEC-driven
 - explicit follow-up tracking when implementation is deferred
+
+## Current Index
+
+- `docs/specs/cli/run/SPEC.md`: `rpm run` command contract
+- `docs/specs/core/manifest/SPEC.md`: `package.json` interpretation
+- `docs/specs/core/semver/SPEC.md`: npm-compatible semver selection baseline
+- `docs/specs/core/resolver/SPEC.md`: dependency graph resolution boundary
+- `docs/specs/core/lockfile/SPEC.md`: `rpm.lock` v1 contract
+- `docs/specs/core/install/recovery/SPEC.md`: staged install replacement and
+  recovery
+- `docs/specs/core/install/performance/SPEC.md`: installer bottleneck and
+  measurement baseline
+- `docs/specs/core/linker/SPEC.md`: `node_modules` linking contract

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -1,8 +1,8 @@
 ---
-spec_id: contract-name
+spec_id: contract_name
 title: Contract Name
 status: draft
-owner: area
+owner: core/area
 last_reviewed: YYYY-MM-DD
 authors:
   - github-handle
@@ -17,7 +17,7 @@ related_issues: []
 # Spec: Contract Name
 
 Status: Draft
-Owner: area
+Owner: core/area
 Last reviewed: YYYY-MM-DD
 
 ## Purpose

--- a/docs/specs/cli/README.md
+++ b/docs/specs/cli/README.md
@@ -1,0 +1,12 @@
+# CLI SPECs
+
+This directory holds CLI-owned contract documents.
+
+CLI SPECs define user-facing command behavior such as argument handling,
+exit-code mapping, and command-specific output or side effects.
+
+Current CLI contracts:
+
+- `run/SPEC.md`: `rpm run` command behavior
+
+Cross-cutting repository structure guidance lives under `docs/conventions/`.

--- a/docs/specs/cli/run/SPEC.md
+++ b/docs/specs/cli/run/SPEC.md
@@ -1,8 +1,26 @@
+---
+spec_id: run_scripts
+title: Run Scripts
+status: draft
+owner: cli/run
+last_reviewed: 2026-05-29
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_adrs:
+  - 0002-single-crate-cli-core-boundary
+related_issues:
+  - 50
+---
+
 # Spec: Run Scripts
 
 Status: Draft
 Owner: cli/run
-Last reviewed: 2026-05-28
+Last reviewed: 2026-05-29
 
 ## Purpose
 
@@ -27,3 +45,12 @@ error.
 Missing scripts fail without modifying `node_modules`. Missing binaries reached
 through shell execution should produce the shell's readable error and non-zero
 status. Script failures must preserve the child process status.
+
+## Test Fixtures
+
+Run-script verification should cover missing-script errors, child exit-code
+preservation, and PATH setup for project-local binaries.
+
+## Open Questions
+
+None currently.

--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -1,0 +1,17 @@
+# Core SPECs
+
+This directory holds core package-manager contract documents.
+
+Core SPECs define behavior that must remain callable without CLI parsing or
+terminal presentation. That includes manifest handling, semver policy,
+dependency resolution, lockfile behavior, install staging, and linking.
+
+Current core contracts:
+
+- `manifest/SPEC.md`
+- `semver/SPEC.md`
+- `resolver/SPEC.md`
+- `lockfile/SPEC.md`
+- `install/recovery/SPEC.md`
+- `install/performance/SPEC.md`
+- `linker/SPEC.md`

--- a/docs/specs/core/install/performance/SPEC.md
+++ b/docs/specs/core/install/performance/SPEC.md
@@ -1,8 +1,26 @@
+---
+spec_id: installer_performance
+title: Installer Performance Baseline
+status: draft
+owner: core/install/performance
+last_reviewed: 2026-05-29
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_adrs:
+  - 0002-single-crate-cli-core-boundary
+related_issues:
+  - 50
+---
+
 # Spec: Installer Performance Baseline
 
-Status: Draft  
-Owner: resolver/install  
-Last reviewed: 2026-05-27
+Status: Draft
+Owner: core/install/performance
+Last reviewed: 2026-05-29
 
 ## Purpose
 
@@ -63,9 +81,9 @@ Later installer work should stage installation in this order:
 9. Write `rpm.lock` and `package.json` only after install state is ready.
 
 The graph resolution stage must preserve both the requested range and selected
-version for every package record, matching `docs/specs/resolver.md`.
+version for every package record, matching `docs/specs/core/resolver/SPEC.md`.
 
-## Measurement Fixture
+## Test Fixtures
 
 Use `tests/fixtures/install-projects/performance-small/` as the first
 measurement fixture. It intentionally includes two direct dependencies that

--- a/docs/specs/core/install/recovery/SPEC.md
+++ b/docs/specs/core/install/recovery/SPEC.md
@@ -1,8 +1,26 @@
+---
+spec_id: install_recovery
+title: Install Recovery
+status: draft
+owner: core/install/recovery
+last_reviewed: 2026-05-29
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_adrs:
+  - 0002-single-crate-cli-core-boundary
+related_issues:
+  - 50
+---
+
 # Spec: Install Recovery
 
 Status: Draft
-Owner: installer/recovery
-Last reviewed: 2026-05-28
+Owner: core/install/recovery
+Last reviewed: 2026-05-29
 
 ## Purpose
 
@@ -31,3 +49,13 @@ reported as successful downloads.
 A failed resolve, fetch, extract, or link phase must leave the previous
 `node_modules` directory untouched. A failed write phase must not be reported as
 a successful install.
+
+## Test Fixtures
+
+Recovery verification should cover staged replacement success plus resolve,
+extract, link, and write failures that leave the previous `node_modules`
+contents intact.
+
+## Open Questions
+
+None currently.

--- a/docs/specs/core/linker/SPEC.md
+++ b/docs/specs/core/linker/SPEC.md
@@ -1,8 +1,26 @@
+---
+spec_id: node_modules_linker
+title: Node Modules Linker
+status: draft
+owner: core/linker
+last_reviewed: 2026-05-29
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_adrs:
+  - 0002-single-crate-cli-core-boundary
+related_issues:
+  - 50
+---
+
 # Spec: Node Modules Linker
 
 Status: Draft
-Owner: installer/linker
-Last reviewed: 2026-05-28
+Owner: core/linker
+Last reviewed: 2026-05-29
 
 ## Purpose
 
@@ -47,3 +65,12 @@ implemented separately.
 Linking fails if a dependency target package has not been extracted, if the
 destination directory cannot be created, or if the symlink cannot be created.
 Failed linking must not be reported as a successful install or script setup.
+
+## Test Fixtures
+
+Linker verification should cover unscoped and scoped dependency links plus
+destination-directory and symlink-creation failures.
+
+## Open Questions
+
+None currently.

--- a/docs/specs/core/lockfile/SPEC.md
+++ b/docs/specs/core/lockfile/SPEC.md
@@ -1,10 +1,36 @@
-# Lockfile v1
+---
+spec_id: lockfile_v1
+title: Lockfile v1
+status: draft
+owner: core/lockfile
+last_reviewed: 2026-05-29
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_adrs:
+  - 0002-single-crate-cli-core-boundary
+related_issues:
+  - 50
+---
+
+# Spec: Lockfile v1
+
+Status: Draft
+Owner: core/lockfile
+Last reviewed: 2026-05-29
+
+## Purpose
 
 `rpm.lock` is the reproducibility contract for installs. It records the
 requested package graph and the resolved package facts needed by later install
 phases.
 
-## Format
+## Contract
+
+### Format
 
 The lockfile is TOML and starts with project metadata:
 
@@ -39,7 +65,7 @@ Package entries record:
   provides a shasum.
 - `dependencies`: dependency edges as requested package references.
 
-## Loading
+### Loading
 
 An absent or empty lockfile initializes as an empty v1 lockfile. Empty loading
 must not be reported as successful dependency resolution; it only gives callers a
@@ -48,7 +74,22 @@ safe in-memory lockfile to mutate.
 Malformed TOML or malformed lockfile fields are load failures. Parse failures
 must include the lockfile path and parser context.
 
-## Saving
+### Saving
 
 Saving writes the complete current lockfile and truncates old content. Save
 errors must include the lockfile path and must not be hidden behind panics.
+
+## Error Cases
+
+Malformed TOML, malformed lockfile fields, and save failures must be returned
+with the lockfile path and parser or write context. Empty loading must not be
+reported as successful dependency resolution.
+
+## Test Fixtures
+
+Lockfile verification should cover v1 format round-tripping, empty lockfile
+initialization, malformed-file parse failures, and save truncation behavior.
+
+## Open Questions
+
+None currently.

--- a/docs/specs/core/manifest/SPEC.md
+++ b/docs/specs/core/manifest/SPEC.md
@@ -1,8 +1,26 @@
+---
+spec_id: package_manifest
+title: Package Manifest
+status: draft
+owner: core/manifest
+last_reviewed: 2026-05-29
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_adrs:
+  - 0002-single-crate-cli-core-boundary
+related_issues:
+  - 50
+---
+
 # Spec: Package Manifest
 
 Status: Draft
-Owner: package-manifest
-Last reviewed: 2026-05-28
+Owner: core/manifest
+Last reviewed: 2026-05-29
 
 ## Purpose
 

--- a/docs/specs/core/resolver/SPEC.md
+++ b/docs/specs/core/resolver/SPEC.md
@@ -1,8 +1,26 @@
+---
+spec_id: resolver_boundary
+title: Resolver Strategy Boundary
+status: draft
+owner: core/resolver
+last_reviewed: 2026-05-29
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_adrs:
+  - 0002-single-crate-cli-core-boundary
+related_issues:
+  - 50
+---
+
 # Spec: Resolver Strategy Boundary
 
-Status: Draft  
-Owner: resolver/install  
-Last reviewed: 2026-05-28
+Status: Draft
+Owner: core/resolver
+Last reviewed: 2026-05-29
 
 ## Purpose
 
@@ -29,7 +47,7 @@ input to later installer phases that download tarballs, verify integrity,
 extract packages, link `node_modules`, and write lockfile or manifest state.
 
 Version and range satisfaction rules are owned by
-`docs/specs/semver-resolution.md`. Resolver strategies call the version
+`docs/specs/core/semver/SPEC.md`. Resolver strategies call the version
 selection abstraction and record its selected version; they must not duplicate
 range parsing policy in the traversal implementation.
 
@@ -52,7 +70,8 @@ Future strategies may replace FIFO traversal with priority-based, heuristic,
 peer-aware, or backtracking behavior without changing fetch, extract, link, or
 lockfile write phases.
 
-The installer performance baseline in `docs/specs/installer-performance.md`
+The installer performance baseline in
+`docs/specs/core/install/performance/SPEC.md`
 documents the current recursive bottleneck and the measurement fixture for
 future staged installer work.
 
@@ -74,7 +93,7 @@ resolver fixtures should not mutate the repository root, `.rpm`, `rpm.lock`, or
 `node_modules`.
 
 The semver baseline fixtures are defined by
-`docs/specs/semver-resolution.md` and must be used before installer flow relies
+`docs/specs/core/semver/SPEC.md` and must be used before installer flow relies
 on semver range behavior.
 
 ## Open Questions

--- a/docs/specs/core/semver/SPEC.md
+++ b/docs/specs/core/semver/SPEC.md
@@ -1,8 +1,26 @@
+---
+spec_id: semver_resolution
+title: Semver Resolution
+status: draft
+owner: core/semver
+last_reviewed: 2026-05-29
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_adrs:
+  - 0002-single-crate-cli-core-boundary
+related_issues:
+  - 50
+---
+
 # Spec: Semver Resolution
 
 Status: Draft
-Owner: resolver/install
-Last reviewed: 2026-05-28
+Owner: core/semver
+Last reviewed: 2026-05-29
 
 ## Purpose
 
@@ -33,8 +51,8 @@ Unsatisfied ranges and invalid ranges are resolver failures. They must fail
 before tarball download, extraction, linking, lockfile writes, or manifest
 writes.
 
-Lockfile v1 already supports this contract by storing both `requested` and
-resolved `version` fields for each package record.
+The lockfile contract already supports this baseline by storing both
+`requested` and resolved `version` fields for each package record.
 
 ## Dependency Decision
 


### PR DESCRIPTION
## Summary
- restructure `docs/specs` into agreed ownership-based directories under `cli` and `core`
- move `workspace-layout` into `docs/conventions/` as a repository convention doc
- normalize touched SPEC documents toward the current template without changing contract meaning

## Contract
- SPEC status: conforms
- This PR does not intend to change CLI, manifest, semver, resolver, lockfile, install, or linker contracts.
- Scope is limited to document location, naming, template alignment, and link repair.

## Plan
- move existing flat SPEC files into the new directory structure
- add `README.md` files for `docs/specs/cli` and `docs/specs/core`
- normalize frontmatter and section layout where touched
- update internal links and verify old flat paths are removed

## Validation
- `rg --files docs/specs docs/conventions | sort`
- `rg -n "docs/specs/(run-scripts|package-manifest|semver-resolution|resolver|lockfile-v1|install-recovery|installer-performance|node-linker|workspace-layout)\\.md" docs`

Closes #50
