### PR TITLE
docs(spec): tighten open question tracking

### DIFF
--- a/.agents/skills/spec-governance/SKILL.md
+++ b/.agents/skills/spec-governance/SKILL.md
@@ -143,6 +143,7 @@ Before finishing any contract-affecting change, verify:
 - The SPEC defines observable contract, not incidental implementation detail.
 - Tests or fixtures cover the contract.
 - If the SPEC changed, the change explains why.
+- Any `Open Questions` left in an accepted SPEC have linked tracking issues.
 - Other docs link to the authoritative SPEC instead of redefining it.
 
 ## Reporting Format

--- a/.agents/skills/spec-governance/SKILL.md
+++ b/.agents/skills/spec-governance/SKILL.md
@@ -131,7 +131,7 @@ Last reviewed: YYYY-MM-DD
 
 ## Test Fixtures
 
-## Open Questions
+## Open Questions (Optional)
 ```
 
 ## Review Checklist

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -198,7 +198,7 @@ Last reviewed: YYYY-MM-DD
 
 ## Test Fixtures
 
-## Open Questions
+## Open Questions (Optional)
 ```
 
 Documents may temporarily contain extra sections while the current SPEC set is

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -214,6 +214,9 @@ SPECs may include an `Open Questions` section.
 That section is allowed for questions that are still outside the active
 contract and are not currently blocking implementation or review.
 
+`Open Questions` is optional. Omit the section when there are no real
+unresolved follow-up questions.
+
 `Open Questions` should be used for:
 
 - deferred decisions that do not change today's contract
@@ -226,6 +229,10 @@ contract and are not currently blocking implementation or review.
 - decisions that reviewers must guess in order to approve code
 - behavior already established by code and tests
 - vague brainstorming with no contract relevance
+
+If an accepted SPEC keeps any open question, each item must have a linked issue
+for follow-up tracking. Questions that need eventual resolution but do not yet
+have an issue should not remain in an accepted SPEC.
 
 If implementation work becomes blocked by an `Open Question`, that question is
 no longer safe to leave open.

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -50,7 +50,12 @@ List the fixtures, snapshots, or targeted tests that verify this contract.
 
 If no fixture exists yet, say what verification should exist next.
 
-## Open Questions
+## Open Questions (Optional)
+
+Include this section only when there are real unresolved follow-up questions.
 
 Record only questions that are outside the active contract and do not block the
 current implementation or review.
+
+If an accepted SPEC keeps any open question, each item should link to a
+tracking issue.

--- a/docs/specs/cli/run/SPEC.md
+++ b/docs/specs/cli/run/SPEC.md
@@ -50,7 +50,3 @@ status. Script failures must preserve the child process status.
 
 Run-script verification should cover missing-script errors, child exit-code
 preservation, and PATH setup for project-local binaries.
-
-## Open Questions
-
-None currently.

--- a/docs/specs/core/install/performance/SPEC.md
+++ b/docs/specs/core/install/performance/SPEC.md
@@ -14,6 +14,7 @@ related_adrs:
   - 0002-single-crate-cli-core-boundary
 related_issues:
   - 50
+  - 60
 ---
 
 # Spec: Installer Performance Baseline
@@ -112,8 +113,8 @@ must not be reported as a successful install.
 
 ## Open Questions
 
-- Which module owns the first installer measurement harness?
+- Which module owns the first installer measurement harness? Tracked by #60.
 - Should metadata fetch counts be collected through a fake registry API or a
-  resolver event log?
+  resolver event log? Tracked by #60.
 - What integrity format is authoritative before tarball verification is
-  implemented?
+  implemented? Tracked by #60.

--- a/docs/specs/core/install/recovery/SPEC.md
+++ b/docs/specs/core/install/recovery/SPEC.md
@@ -55,7 +55,3 @@ a successful install.
 Recovery verification should cover staged replacement success plus resolve,
 extract, link, and write failures that leave the previous `node_modules`
 contents intact.
-
-## Open Questions
-
-None currently.

--- a/docs/specs/core/linker/SPEC.md
+++ b/docs/specs/core/linker/SPEC.md
@@ -70,7 +70,3 @@ Failed linking must not be reported as a successful install or script setup.
 
 Linker verification should cover unscoped and scoped dependency links plus
 destination-directory and symlink-creation failures.
-
-## Open Questions
-
-None currently.

--- a/docs/specs/core/lockfile/SPEC.md
+++ b/docs/specs/core/lockfile/SPEC.md
@@ -89,7 +89,3 @@ reported as successful dependency resolution.
 
 Lockfile verification should cover v1 format round-tripping, empty lockfile
 initialization, malformed-file parse failures, and save truncation behavior.
-
-## Open Questions
-
-None currently.

--- a/docs/specs/core/manifest/SPEC.md
+++ b/docs/specs/core/manifest/SPEC.md
@@ -40,6 +40,9 @@ manifest content.
 Saving writes the complete current manifest and truncates old content. Save
 errors must be returned to callers with the manifest path.
 
+The full npm `package.json` schema is intentionally out of scope for this
+contract today.
+
 ## Error Cases
 
 Invalid JSON is an input error and must not be reported as a successful command.
@@ -49,7 +52,3 @@ panics.
 ## Test Fixtures
 
 Manifest fixtures live under `tests/fixtures/package_manifest/`.
-
-## Open Questions
-
-- The full npm `package.json` schema is intentionally not implemented yet.

--- a/docs/specs/core/resolver/SPEC.md
+++ b/docs/specs/core/resolver/SPEC.md
@@ -14,6 +14,7 @@ related_adrs:
   - 0002-single-crate-cli-core-boundary
 related_issues:
   - 50
+  - 58
 ---
 
 # Spec: Resolver Strategy Boundary
@@ -99,7 +100,8 @@ on semver range behavior.
 ## Open Questions
 
 - Which Rust module owns the first `ResolutionStrategy` trait or equivalent
-  type?
+  type? Tracked by #58.
 - How should peer dependencies be represented before a peer-aware strategy
-  exists?
+  exists? Tracked by #58.
 - Should graph conflicts be reported as structured diagnostics before M1?
+  Tracked by #58.

--- a/docs/specs/core/semver/SPEC.md
+++ b/docs/specs/core/semver/SPEC.md
@@ -14,6 +14,7 @@ related_adrs:
   - 0002-single-crate-cli-core-boundary
 related_issues:
   - 50
+  - 59
 ---
 
 # Spec: Semver Resolution
@@ -122,6 +123,6 @@ Required fixture cases:
 
 ## Open Questions
 
-- Whether M1 supports npm dist-tags other than `latest`.
+- Whether M1 supports npm dist-tags other than `latest`. Tracked by #59.
 - Whether prerelease selection is unsupported or supported only when explicitly
-  requested.
+  requested. Tracked by #59.


### PR DESCRIPTION
## Summary
- make `Open Questions` optional in the SPEC template
- require linked tracking issues for any open questions left in accepted SPECs
- align SPEC governance guidance with the same rule

## Contract
- This PR changes SPEC documentation and governance guidance only.
- No package-manager contract behavior changes are intended.

## Validation
- `git diff --check`
