### PR TITLE
test: add offline registry fixtures

### DIFF
--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -382,11 +382,13 @@ mod tests {
     fn load_registry_fixture(root: &Path, package_name: &str, version: &str) -> Registry {
         let path = root.join(registry_fixture_file_name(package_name));
         let fixture = fs::read_to_string(&path).unwrap_or_else(|error| {
-            panic!("failed to read registry fixture {}: {error}", path.display())
+            panic!(
+                "failed to read registry fixture {}: {error}",
+                path.display()
+            )
         });
-        let registry: Registry = serde_json::from_str(&fixture).unwrap_or_else(|error| {
-            panic!("{} did not deserialize: {error}", path.display())
-        });
+        let registry: Registry = serde_json::from_str(&fixture)
+            .unwrap_or_else(|error| panic!("{} did not deserialize: {error}", path.display()));
         assert!(
             registry.version_metadata(version).is_some(),
             "{} is missing {package_name}@{version}",

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -370,8 +370,30 @@ fn save_tarball_to_dir<P: AsRef<Path>>(
 #[cfg(test)]
 mod tests {
     use super::{save_tarball_to_dir, Registry};
+    use crate::util::test_support::fixture_path;
     use std::fs;
+    use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn registry_fixture_file_name(package_name: &str) -> String {
+        format!("{}.json", package_name.replace('/', "__"))
+    }
+
+    fn load_registry_fixture(root: &Path, package_name: &str, version: &str) -> Registry {
+        let path = root.join(registry_fixture_file_name(package_name));
+        let fixture = fs::read_to_string(&path).unwrap_or_else(|error| {
+            panic!("failed to read registry fixture {}: {error}", path.display())
+        });
+        let registry: Registry = serde_json::from_str(&fixture).unwrap_or_else(|error| {
+            panic!("{} did not deserialize: {error}", path.display())
+        });
+        assert!(
+            registry.version_metadata(version).is_some(),
+            "{} is missing {package_name}@{version}",
+            path.display()
+        );
+        registry
+    }
 
     #[test]
     fn save_tarball_reports_cache_write_errors() {
@@ -398,6 +420,8 @@ mod tests {
     #[test]
     fn semver_registry_fixtures_match_registry_metadata_shape() {
         let fixture_roots = [
+            "tests/fixtures/registry/shared-transitive/metadata",
+            "tests/fixtures/install-projects/performance-small/registry",
             "tests/fixtures/install-projects/semver-baseline/registry",
             "tests/fixtures/install-projects/semver-unsatisfied/registry",
             "tests/fixtures/install-projects/semver-invalid-range/registry",
@@ -419,5 +443,31 @@ mod tests {
                 });
             }
         }
+    }
+
+    #[test]
+    fn registry_fixture_loader_loads_shared_transitive_graph() {
+        let root = fixture_path(&["registry", "shared-transitive", "metadata"]);
+
+        let alpha = load_registry_fixture(&root, "@rpm-fixture/alpha", "1.0.0");
+        let beta = load_registry_fixture(&root, "@rpm-fixture/beta", "1.0.0");
+        let shared = load_registry_fixture(&root, "@rpm-fixture/shared", "1.0.0");
+
+        assert_eq!(
+            alpha.get_dependencies_for_version("1.0.0"),
+            vec!["@rpm-fixture/shared@^1.0.0"]
+        );
+        assert_eq!(
+            beta.get_dependencies_for_version("1.0.0"),
+            vec!["@rpm-fixture/shared@^1.0.0"]
+        );
+        assert!(shared.get_dependencies_for_version("1.0.0").is_empty());
+
+        let alpha_dist = alpha.get_dist_for_version("1.0.0").unwrap();
+        assert_eq!(
+            alpha_dist.tarball,
+            "https://registry.example.invalid/@rpm-fixture/alpha/-/alpha-1.0.0.tgz"
+        );
+        assert_eq!(alpha_dist.shasum, "fixture-alpha-1.0.0");
     }
 }

--- a/tests/fixtures/registry/shared-transitive/expected/resolved-packages.txt
+++ b/tests/fixtures/registry/shared-transitive/expected/resolved-packages.txt
@@ -1,0 +1,3 @@
+@rpm-fixture/alpha@1.0.0 requested ^1.0.0
+@rpm-fixture/beta@1.0.0 requested ^1.0.0
+@rpm-fixture/shared@1.0.0 requested ^1.0.0

--- a/tests/fixtures/registry/shared-transitive/metadata/@rpm-fixture__alpha.json
+++ b/tests/fixtures/registry/shared-transitive/metadata/@rpm-fixture__alpha.json
@@ -1,0 +1,24 @@
+{
+  "_id": "@rpm-fixture/alpha",
+  "name": "@rpm-fixture/alpha",
+  "description": "Fixture package alpha",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/alpha",
+      "version": "1.0.0",
+      "description": "Fixture package alpha",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/alpha/-/alpha-1.0.0.tgz",
+        "shasum": "fixture-alpha-1.0.0",
+        "integrity": "sha512-fixture-alpha-1.0.0"
+      },
+      "dependencies": {
+        "@rpm-fixture/shared": "^1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/registry/shared-transitive/metadata/@rpm-fixture__beta.json
+++ b/tests/fixtures/registry/shared-transitive/metadata/@rpm-fixture__beta.json
@@ -1,0 +1,24 @@
+{
+  "_id": "@rpm-fixture/beta",
+  "name": "@rpm-fixture/beta",
+  "description": "Fixture package beta",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/beta",
+      "version": "1.0.0",
+      "description": "Fixture package beta",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/beta/-/beta-1.0.0.tgz",
+        "shasum": "fixture-beta-1.0.0",
+        "integrity": "sha512-fixture-beta-1.0.0"
+      },
+      "dependencies": {
+        "@rpm-fixture/shared": "^1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/registry/shared-transitive/metadata/@rpm-fixture__shared.json
+++ b/tests/fixtures/registry/shared-transitive/metadata/@rpm-fixture__shared.json
@@ -1,0 +1,22 @@
+{
+  "_id": "@rpm-fixture/shared",
+  "name": "@rpm-fixture/shared",
+  "description": "Fixture package shared",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/shared",
+      "version": "1.0.0",
+      "description": "Fixture package shared",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/shared/-/shared-1.0.0.tgz",
+        "shasum": "fixture-shared-1.0.0",
+        "integrity": "sha512-fixture-shared-1.0.0"
+      },
+      "dependencies": {}
+    }
+  }
+}


### PR DESCRIPTION
## Contract

- Classification: test fixture infrastructure for resolver work.
- Adds deterministic offline npm-style registry metadata fixtures and a targeted loader test.
- Does not change production resolution behavior, CLI behavior, lockfile format, registry network behavior, install flow, cache layout, or node_modules layout.
- No SPEC update is required because this implements the existing resolver SPEC fixture guidance without changing package-manager behavior.

## Plan

- Add one small registry fixture scenario with two direct dependencies sharing one transitive dependency.
- Add expected resolved package records for later graph dedupe tests.
- Add a targeted test helper that loads package metadata from fixture files by package name and version without network access.

## Validation

- [x] cargo fmt --check
- [x] cargo test --lib registry_fixture_loader_loads_shared_transitive_graph
- [x] cargo test --lib semver_registry_fixtures_match_registry_metadata_shape

Closes #41