### PR TITLE
Specify tarball cache naming

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -152,6 +152,8 @@ docs/specs/
     lockfile/
       SPEC.md
     install/
+      cache/
+        SPEC.md
       recovery/
         SPEC.md
       performance/
@@ -265,6 +267,8 @@ M1 should start from:
 - `docs/specs/core/semver/SPEC.md`: npm-compatible semver selection baseline
 - `docs/specs/core/resolver/SPEC.md`: dependency graph resolution boundary
 - `docs/specs/core/lockfile/SPEC.md`: `rpm.lock` v1 contract
+- `docs/specs/core/install/cache/SPEC.md`: install tarball cache filename and
+  registry tarball write boundary
 - `docs/specs/core/install/recovery/SPEC.md`: staged install replacement and
   recovery
 - `docs/specs/core/install/performance/SPEC.md`: installer bottleneck and

--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -12,6 +12,7 @@ Current core contracts:
 - `semver/SPEC.md`
 - `resolver/SPEC.md`
 - `lockfile/SPEC.md`
+- `install/cache/SPEC.md`
 - `install/recovery/SPEC.md`
 - `install/performance/SPEC.md`
 - `linker/SPEC.md`

--- a/docs/specs/core/install/cache/SPEC.md
+++ b/docs/specs/core/install/cache/SPEC.md
@@ -1,0 +1,81 @@
+---
+spec_id: install_cache
+title: Install Cache
+status: draft
+owner: core/install/cache
+last_reviewed: 2026-06-16
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_adrs:
+  - 0002-single-crate-cli-core-boundary
+related_issues:
+  - 44
+---
+
+# Spec: Install Cache
+
+Status: Draft
+Owner: core/install/cache
+Last reviewed: 2026-06-16
+
+## Purpose
+
+RPM stores downloaded package tarballs in the local install cache before the
+linker extracts them into `node_modules`. This contract defines the cache
+filename shared by tarball download and linker code, and keeps registry metadata
+reads separate from cache writes.
+
+## Contract
+
+Each downloaded package tarball is cached under `.rpm/.cache` with this
+filename:
+
+```text
+<sanitized-package-name>@<resolved-version>.tgz
+```
+
+The sanitized package name is the npm package name with every `/` replaced by
+`-`. For example:
+
+```text
+axios@0.21.1.tgz
+@babel-core@2.3.1.tgz
+```
+
+The cache filename is derived from the selected package name and resolved
+version. It is not derived from the registry tarball URL basename, because
+registry URLs can repeat the package name and already include the `.tgz`
+extension.
+
+Registry metadata reads may return tarball URLs, dependency declarations, and
+version metadata, but they must not write files into `.rpm/.cache`. Cache writes
+belong to the tarball download phase.
+
+The cache writer must append exactly one `.tgz` extension. Passing an input that
+already ends in `.tgz` must not create a `*.tgz.tgz` path.
+
+The linker must resolve cached tarballs using the same filename contract.
+
+## Error Cases
+
+If the selected registry metadata has no tarball URL, the download phase must
+return an error instead of writing a placeholder cache file.
+
+Cache directory creation, file opening, file writing, and file flushing failures
+must be returned to callers with the failed cache path in the error message.
+
+Metadata reads must remain side-effect free even when registry metadata contains
+tarball URLs.
+
+## Test Fixtures
+
+Unit tests in `src/lib/registry/mod.rs` verify cache filename derivation for
+unscoped and scoped package names, and verify that cache writes do not create
+`*.tgz.tgz` paths.
+
+Linker tests in `src/lib/node_linker/mod.rs` verify that extraction reads the
+same cache filename shape.

--- a/src/lib/node_linker/mod.rs
+++ b/src/lib/node_linker/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     lockfile::constraint::LOCK_FILE_PATH,
     lockfile::{Dependency, LockFile},
     package_manifest::PackageManifest,
+    registry::tarball_cache_file_name,
 };
 use flate2::read::GzDecoder;
 use tar::Archive;
@@ -239,10 +240,9 @@ impl NodeResolver {
     ) -> Result<(), std::io::Error> {
         let name = package_name_from_lock_key(&key)?;
         let cached_version = dependency.get_version();
-        let tgz_name = name.replace("/", "-");
         let tgz_path = self
             .cache_dir
-            .join(format!("{}@{}.tgz", &tgz_name, cached_version));
+            .join(tarball_cache_file_name(name, &cached_version));
         let tgz = File::open(tgz_path)?;
         let gz = GzDecoder::new(tgz);
         let mut archive = Archive::new(gz);

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -288,20 +288,8 @@ impl Registry {
     }
 
     pub fn get_tarball_name(&self) -> Option<String> {
-        self.get_tarball_url().map(|url| {
-            //ex https://registry.npmjs.org/axios/-/axios-0.21.1.tgz
-            let url = url.replace("https://registry.npmjs.org/", "");
-            let url: Vec<&str> = url.split("/-/").collect::<Vec<&str>>();
-            // left name, right version
-            // if socket-store sotcket-store-0.1.0.tgz
-            // to socket-store@0.1.0.tgz
-            // if @babel/core core-2.3.1.tgz
-            // to @babel/core@2.3.1.tgz
-
-            let tarball_name = format!("{}-{}.tgz", url[0], url[1]);
-
-            tarball_name
-        })
+        self.get_latest_version()
+            .map(|version| tarball_cache_file_name(&self.name, version))
     }
 
     pub fn get_tarball_url(&self) -> Option<String> {
@@ -364,12 +352,25 @@ fn save_tarball(tarball_name: &str, bytes_file: &mut [u8]) -> Result<(), Error> 
     save_tarball_to_dir(CACHE_DIR, tarball_name, bytes_file)
 }
 
+pub(crate) fn tarball_cache_file_name(package_name: &str, version: &str) -> String {
+    normalized_tarball_cache_file_name(&format!("{package_name}@{version}"))
+}
+
+fn normalized_tarball_cache_file_name(cache_key: &str) -> String {
+    let file_name = cache_key.replace("/", "-");
+    if file_name.ends_with(".tgz") {
+        file_name
+    } else {
+        format!("{file_name}.tgz")
+    }
+}
+
 fn save_tarball_to_dir<P: AsRef<Path>>(
     cache_dir: P,
     tarball_name: &str,
     bytes_file: &mut [u8],
 ) -> Result<(), Error> {
-    let file_name = tarball_name.replace("/", "-");
+    let file_name = normalized_tarball_cache_file_name(tarball_name);
 
     let dir = cache_dir.as_ref();
 
@@ -385,7 +386,7 @@ fn save_tarball_to_dir<P: AsRef<Path>>(
         })?;
     }
 
-    let path: PathBuf = dir.join(format!("{file_name}.tgz"));
+    let path: PathBuf = dir.join(file_name);
     let mut file = OpenOptions::new()
         .write(true)
         .create(true)
@@ -442,6 +443,10 @@ mod tests {
         registry
     }
 
+    fn registry_from_json(fixture: &str) -> Registry {
+        serde_json::from_str(fixture).expect("inline registry fixture should deserialize")
+    }
+
     #[test]
     fn save_tarball_reports_cache_write_errors() {
         let nanos = SystemTime::now()
@@ -461,6 +466,89 @@ mod tests {
 
         assert!(error.to_string().contains("failed to open cached tarball"));
         assert!(error.to_string().contains("cache-file"));
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn tarball_cache_name_uses_package_and_version_for_unscoped_packages() {
+        let registry = registry_from_json(
+            r#"{
+              "_id": "axios",
+              "name": "axios",
+              "description": "axios fixture",
+              "maintainers": [],
+              "dist-tags": {
+                "latest": "0.21.1"
+              },
+              "versions": {
+                "0.21.1": {
+                  "name": "axios",
+                  "version": "0.21.1",
+                  "description": "axios fixture",
+                  "dist": {
+                    "tarball": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+                    "shasum": "fixture-axios-0.21.1"
+                  },
+                  "dependencies": {}
+                }
+              }
+            }"#,
+        );
+
+        assert_eq!(
+            registry.get_tarball_name().as_deref(),
+            Some("axios@0.21.1.tgz")
+        );
+    }
+
+    #[test]
+    fn tarball_cache_name_uses_sanitized_scoped_package_name() {
+        let registry = registry_from_json(
+            r#"{
+              "_id": "@babel/core",
+              "name": "@babel/core",
+              "description": "@babel/core fixture",
+              "maintainers": [],
+              "dist-tags": {
+                "latest": "2.3.1"
+              },
+              "versions": {
+                "2.3.1": {
+                  "name": "@babel/core",
+                  "version": "2.3.1",
+                  "description": "@babel/core fixture",
+                  "dist": {
+                    "tarball": "https://registry.npmjs.org/@babel/core/-/core-2.3.1.tgz",
+                    "shasum": "fixture-babel-core-2.3.1"
+                  },
+                  "dependencies": {}
+                }
+              }
+            }"#,
+        );
+
+        assert_eq!(
+            registry.get_tarball_name().as_deref(),
+            Some("@babel-core@2.3.1.tgz")
+        );
+    }
+
+    #[test]
+    fn save_tarball_does_not_duplicate_tgz_extension() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let temp = std::env::temp_dir().join(format!(
+            "rpm-registry-cache-name-{}-{nanos}",
+            std::process::id()
+        ));
+
+        save_tarball_to_dir(&temp, "axios@0.21.1.tgz", &mut b"tarball".to_vec())
+            .expect("tarball save should succeed");
+
+        assert_eq!(fs::read(temp.join("axios@0.21.1.tgz")).unwrap(), b"tarball");
+        assert!(!temp.join("axios@0.21.1.tgz.tgz").exists());
         let _ = fs::remove_dir_all(temp);
     }
 


### PR DESCRIPTION
## Contract

SPEC status: missing. Tarball cache filename behavior affects the package-manager cache/store layout, but no existing SPEC owned the cache filename contract.

This PR adds `docs/specs/core/install/cache/SPEC.md` as the authoritative contract for the active cache naming behavior:

- cache tarballs are named `<sanitized-package-name>@<resolved-version>.tgz`
- package name sanitization replaces `/` with `-`
- registry tarball URL basenames are not used as cache names
- cache writes must not create `*.tgz.tgz`
- linker reads use the same filename helper

Refs #44. This PR does not close #44 because the broader registry metadata/read and download/write phase split remains.

## Changes

- Added the install cache SPEC and indexed it from the SPEC READMEs.
- Replaced URL-derived `Registry::get_tarball_name()` behavior with package/version cache naming.
- Added a shared cache filename helper used by both registry cache writes and linker reads.
- Made cache write path extension handling idempotent.
- Added regression tests for unscoped package names, scoped package names, and `.tgz.tgz` prevention.

## Validation

- `cargo test --locked registry::tests`
- `cargo check --locked --all-targets`
- `cargo test --locked --all-targets`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --locked --no-deps`

`just validate` was not available on this branch because `main` does not contain a `justfile`.