### PR TITLE
fix(install): preserve lockfile requests during resolution

### DIFF
--- a/docs/adrs/0005-installer-performance-measurement-boundary.md
+++ b/docs/adrs/0005-installer-performance-measurement-boundary.md
@@ -1,0 +1,89 @@
+---
+adr_id: 0005
+title: Keep Installer Measurement Under The Install Boundary
+status: accepted
+date: 2026-06-18
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_specs:
+  - docs/specs/core/install/performance/SPEC.md
+  - docs/specs/core/lockfile/SPEC.md
+related_issues:
+  - 60
+---
+
+# ADR 0005: Keep Installer Measurement Under The Install Boundary
+
+Status: Accepted
+Date: 2026-06-18
+
+## Context
+
+The installer performance baseline SPEC defines the first shared-transitive
+measurement fixture, but issue #60 left three accepted questions unresolved:
+who owns the first measurement harness, how metadata fetch counts should be
+collected, and which integrity field is authoritative before tarball
+verification exists.
+
+Those questions affect installer ownership and future test shape. They should
+be resolved once and referenced by the SPEC instead of staying as open
+questions in the active contract.
+
+## Decision
+
+The first installer measurement harness is owned by the install domain under
+`core`, not by CLI, resolver, registry, or linker modules. When the install
+domain is promoted into `src/core/install`, performance measurement helpers
+belong under an install-owned performance module or its tests. Until then, the
+current fixture remains the shared input and production code should not add a
+new permanent harness under legacy command modules.
+
+Metadata fetch and tarball download counts should be collected through a fake
+registry API used by installer tests. The fake registry records calls by package
+name and selected version while serving deterministic fixture metadata and
+tarball responses. Resolver event logs may be added later for diagnostics, but
+they are not the first measurement mechanism and should not become required to
+prove installer network deduplication.
+
+Before tarball verification is implemented, npm registry `dist.integrity` is
+the authoritative integrity source when present. If metadata omits
+`dist.integrity`, registry `dist.shasum` is the legacy fallback. Lockfile and
+measurement records may preserve both values, but pre-verification tests treat
+the metadata value as recorded package fact only; they must not report the
+tarball as cryptographically verified.
+
+## Consequences
+
+- Installer performance tests can measure package-manager side effects without
+  making resolver diagnostics part of the required contract.
+- Resolver graph tests can stay focused on graph output and requested/resolved
+  version preservation.
+- The registry abstraction used by installer tests needs enough surface to
+  serve metadata, tarballs, and call counts deterministically.
+- Integrity recording remains aligned with the lockfile SPEC before the later
+  tarball verification phase adds cryptographic checks.
+
+## Follow-Up
+
+- Update `docs/specs/core/install/performance/SPEC.md` to reference this ADR
+  and remove the resolved open questions.
+- Keep future installer harness code under the install-owned core boundary when
+  that boundary exists.
+- Add tarball verification behavior in a later SPEC or SPEC update before
+  claiming downloaded tarballs are integrity-verified.
+
+## Alternatives Considered
+
+- Put the first harness under resolver: rejected because the measurement target
+  is installer side effects, including metadata fetches, tarball downloads, and
+  writes that happen after graph resolution.
+- Use a resolver event log for fetch counts: rejected for the first baseline
+  because event logs are diagnostics, while a fake registry API directly
+  observes the network/cache calls the installer must dedupe.
+- Treat `dist.shasum` as authoritative until verification exists: rejected
+  because `dist.integrity` is the stronger npm metadata field and the lockfile
+  SPEC already treats `shasum` as legacy fallback data.

--- a/docs/adrs/0006-resolver-strategy-boundary.md
+++ b/docs/adrs/0006-resolver-strategy-boundary.md
@@ -1,0 +1,93 @@
+---
+adr_id: 0006
+title: Keep Resolver Strategy Ownership In Core Resolver
+status: accepted
+date: 2026-06-18
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_specs:
+  - docs/specs/core/resolver/SPEC.md
+related_issues:
+  - 58
+---
+
+# ADR 0006: Keep Resolver Strategy Ownership In Core Resolver
+
+Status: Accepted
+Date: 2026-06-18
+
+## Context
+
+The first resolver boundary SPEC accepted a replaceable traversal strategy, but
+left three M1 follow-up questions unresolved: which Rust module owns the first
+strategy type, how peer dependencies are represented before a peer-aware
+strategy exists, and whether graph conflicts need structured diagnostics before
+M1.
+
+These decisions need a stable tracked artifact so resolver implementation can
+proceed without making reviewers infer ownership or pre-M1 behavior from issue
+discussion.
+
+## Decision
+
+The `src/core/resolver` root owns the first `ResolutionStrategy` trait or
+equivalent internal abstraction.
+
+Concrete strategy implementations may live in private child modules under
+`src/core/resolver`, but callers should depend on the resolver root facade
+rather than importing concrete traversal modules. Semver behavior remains owned
+by `src/core/resolver/semver` and is called through its facade; traversal
+strategies must not absorb semver range parsing or selection policy.
+
+Before RPM has a peer-aware strategy, peer dependencies are represented as peer
+requirement metadata on resolved package records or metadata records. They are
+not direct dependency requests, transitive dependency requests, manifest update
+inputs, or `node_modules` link targets by themselves. A non-peer-aware strategy
+must not silently enqueue peer dependencies as ordinary dependencies.
+
+M1 does not require public structured diagnostics for graph conflicts. Resolver
+failures must still be typed internally enough for callers to distinguish
+missing metadata, invalid metadata, unsatisfied ranges, invalid ranges, and
+unsupported graph conditions, and they must remain side-effect free. A public
+machine-readable diagnostic format for graph conflicts is deferred until RPM
+has a diagnostics contract that covers CLI presentation and future API output.
+
+## Consequences
+
+- Resolver ownership stays aligned with ADR 0002's single-crate `cli/core`
+  boundary.
+- The first strategy can be implemented without creating a separate resolver
+  crate, workspace package, or CLI-owned traversal type.
+- Peer dependency data may be preserved without pretending the M1 resolver is
+  peer-aware.
+- Implementations that need peer-aware behavior later can add strategy support
+  without reclassifying peer dependencies as ordinary transitive edges.
+- M1 conflict errors can remain focused on side-effect-free failure instead of
+  freezing a public diagnostic schema too early.
+
+## Follow-Up
+
+- Keep `docs/specs/core/resolver/SPEC.md` as the resolver contract and link it
+  to this ADR for the resolved #58 boundary decisions.
+- When peer-aware resolution is implemented, update the resolver SPEC with the
+  active peer conflict and placement contract.
+- When public structured diagnostics are introduced, add or update the owning
+  diagnostics SPEC before exposing a machine-readable graph-conflict format.
+
+## Alternatives Considered
+
+- Put `ResolutionStrategy` in a separate resolver crate now: rejected because
+  ADR 0002 keeps RPM as a single Cargo package until extension or packaging
+  needs are concrete.
+- Let each strategy module define its own public trait: rejected because it
+  would make concrete traversal layout part of the repository-wide API.
+- Treat peer dependencies as ordinary transitive dependencies until peer-aware
+  resolution exists: rejected because it would encode incorrect npm dependency
+  semantics into the first graph contract.
+- Require public structured graph-conflict diagnostics before M1: rejected
+  because the diagnostics schema is broader than the first resolver boundary
+  and should not be frozen by this issue alone.

--- a/docs/specs/core/install/performance/SPEC.md
+++ b/docs/specs/core/install/performance/SPEC.md
@@ -3,7 +3,7 @@ spec_id: installer_performance
 title: Installer Performance Baseline
 status: draft
 owner: core/install/performance
-last_reviewed: 2026-05-29
+last_reviewed: 2026-06-18
 authors:
   - nerdchanii
 deciders:
@@ -12,6 +12,7 @@ consulted: []
 informed: []
 related_adrs:
   - 0002-single-crate-cli-core-boundary
+  - 0005-installer-performance-measurement-boundary
 related_issues:
   - 50
   - 60
@@ -21,7 +22,7 @@ related_issues:
 
 Status: Draft
 Owner: core/install/performance
-Last reviewed: 2026-05-29
+Last reviewed: 2026-06-18
 
 ## Purpose
 
@@ -104,17 +105,31 @@ The initial success criterion for later implementation is not raw speed. The
 first criterion is that shared transitive packages are represented once in the
 resolved graph and downloaded once for a selected version.
 
+## Measurement Decisions
+
+ADR 0005 resolves the installer measurement ownership and pre-verification data
+sources for this baseline.
+
+The first measurement harness belongs to the install domain under `core`. It
+should not be owned by CLI, resolver, registry, linker, or legacy command
+modules. When `src/core/install` exists, install performance helpers should
+live under an install-owned performance module or its tests.
+
+Metadata fetch counts and tarball download counts should be collected through a
+fake registry API used by installer tests. The fake registry should serve
+deterministic fixture metadata and tarball responses while recording calls by
+package name and selected version. Resolver event logs may be added later for
+diagnostics, but they are not required for the first installer measurement
+harness.
+
+Before tarball verification is implemented, registry `dist.integrity` is the
+authoritative integrity field when present. Registry `dist.shasum` is the
+legacy fallback when `dist.integrity` is absent. Recording either value before
+verification does not mean RPM has cryptographically verified the tarball.
+
 ## Error Cases
 
 Pipeline work must keep failed graph resolution side-effect free. A missing
 package, invalid metadata document, unsatisfied range, failed tarball download,
 failed integrity check, failed extraction, failed link, or failed lockfile write
 must not be reported as a successful install.
-
-## Open Questions
-
-- Which module owns the first installer measurement harness? Tracked by #60.
-- Should metadata fetch counts be collected through a fake registry API or a
-  resolver event log? Tracked by #60.
-- What integrity format is authoritative before tarball verification is
-  implemented? Tracked by #60.

--- a/docs/specs/core/resolver/SPEC.md
+++ b/docs/specs/core/resolver/SPEC.md
@@ -3,7 +3,7 @@ spec_id: resolver_boundary
 title: Resolver Strategy Boundary
 status: draft
 owner: core/resolver
-last_reviewed: 2026-05-29
+last_reviewed: 2026-06-18
 authors:
   - nerdchanii
 deciders:
@@ -12,6 +12,7 @@ consulted: []
 informed: []
 related_adrs:
   - 0002-single-crate-cli-core-boundary
+  - 0006-resolver-strategy-boundary
 related_issues:
   - 50
   - 58
@@ -21,7 +22,7 @@ related_issues:
 
 Status: Draft
 Owner: core/resolver
-Last reviewed: 2026-05-29
+Last reviewed: 2026-06-18
 
 ## Purpose
 
@@ -53,9 +54,10 @@ selection abstraction and record its selected version; they must not duplicate
 range parsing policy in the traversal implementation.
 
 Traversal policy is behind a replaceable `ResolutionStrategy` boundary, or an
-equivalent internal abstraction. The resolver must not rely on recursive calls
-for correctness, and callers must not depend on the concrete queue or worklist
-type used by a strategy.
+equivalent internal abstraction, owned by the `src/core/resolver` root module.
+Concrete strategies may live in private child modules, but callers depend on
+the resolver facade rather than a concrete queue or worklist type. The resolver
+must not rely on recursive calls for correctness.
 
 The first strategy is an iterative FIFO worklist:
 
@@ -71,6 +73,12 @@ Future strategies may replace FIFO traversal with priority-based, heuristic,
 peer-aware, or backtracking behavior without changing fetch, extract, link, or
 lockfile write phases.
 
+Before a peer-aware strategy exists, peer dependencies are represented as peer
+requirement metadata on resolved package records or metadata records. They are
+not direct dependency requests, transitive dependency requests, manifest update
+inputs, or `node_modules` link targets by themselves. A non-peer-aware strategy
+must not silently enqueue peer dependencies as ordinary dependencies.
+
 The installer performance baseline in
 `docs/specs/core/install/performance/SPEC.md`
 documents the current recursive bottleneck and the measurement fixture for
@@ -83,6 +91,13 @@ a requested range cannot be satisfied, dependency metadata is invalid, or the
 strategy detects an unsupported graph condition. Failed resolution must not be
 reported as a successful install, and it must not cause partial lockfile or
 manifest writes.
+
+M1 does not require a public structured diagnostic format for graph conflicts.
+Resolver failures must still be typed internally enough for callers to
+distinguish missing metadata, invalid metadata, unsatisfied ranges, invalid
+ranges, and unsupported graph conditions. A public machine-readable diagnostic
+format must be covered by an owning diagnostics SPEC before it becomes part of
+RPM's user-facing or API-facing contract.
 
 ## Test Fixtures
 
@@ -97,11 +112,8 @@ The semver baseline fixtures are defined by
 `docs/specs/core/semver/SPEC.md` and must be used before installer flow relies
 on semver range behavior.
 
-## Open Questions
+## Resolved Follow-Up
 
-- Which Rust module owns the first `ResolutionStrategy` trait or equivalent
-  type? Tracked by #58.
-- How should peer dependencies be represented before a peer-aware strategy
-  exists? Tracked by #58.
-- Should graph conflicts be reported as structured diagnostics before M1?
-  Tracked by #58.
+ADR 0006 records the resolved #58 boundary decisions for
+`ResolutionStrategy` ownership, pre-peer-aware dependency representation, and
+M1 graph-conflict diagnostics.

--- a/docs/specs/core/semver/SPEC.md
+++ b/docs/specs/core/semver/SPEC.md
@@ -3,7 +3,7 @@ spec_id: semver_resolution
 title: Semver Resolution
 status: draft
 owner: core/resolver/semver
-last_reviewed: 2026-06-12
+last_reviewed: 2026-06-18
 authors:
   - nerdchanii
 deciders:
@@ -26,7 +26,7 @@ related_issues:
 
 Status: Draft
 Owner: core/resolver/semver
-Last reviewed: 2026-06-12
+Last reviewed: 2026-06-18
 
 ## Purpose
 
@@ -135,6 +135,26 @@ Do not add `panic!`, `unwrap`, or `expect` in production semver code except for
 compile-time constants or impossible internal invariants documented with a short
 comment. Tests may use them.
 
+## JavaScript Wrapper Input Policy
+
+RPM does not currently expose a JavaScript semver API. When a WASM or npm
+wrapper exposes `coerce`, that wrapper must keep the Rust core typed boundary
+and map JavaScript values at the wrapper edge.
+
+Wrapper `coerce` must accept JavaScript strings and safe integers according to
+the existing Rust string and numeric APIs. A wrapper-owned `SemVer` object must
+round-trip as an already parsed version, matching `node-semver` behavior for
+its own `SemVer` instances.
+
+Arbitrary JavaScript objects and functions are intentionally unsupported
+wrapper inputs. A wrapper must not read an arbitrary object's `version`
+property and must not call a function input. Those values must produce a
+non-match result equivalent to `node-semver` `coerce` returning `null`.
+
+JavaScript-only coerce input fixtures belong with the future JavaScript wrapper
+that exposes this boundary. They must not be added to the Rust-core fixture
+subset until a concrete wrapper API exists.
+
 ## Error Cases
 
 - An exact version that is absent from metadata fails resolution.
@@ -163,6 +183,12 @@ remain readable.
 Imported or derived `node-semver` fixture groups must be clearly separated from
 RPM-authored fixtures and must preserve the required ISC notice.
 
+Advanced loose-mode cases that map to RPM's typed Rust APIs are covered in the
+derived fixture subset. JavaScript-only object, function, `undefined`, and
+other non-string value shapes are wrapper behavior or intentionally not
+applicable to the typed Rust core. Wrapper-specific `coerce` behavior for those
+JavaScript-only inputs remains tracked by #67.
+
 Failing resolver fixtures are separate project scenarios:
 
 - `tests/fixtures/install-projects/semver-unsatisfied/`
@@ -185,5 +211,3 @@ Required fixture cases:
 
 - Whether future JavaScript wrappers expose `node-semver` `coerce` behavior for
   JavaScript-only object and function inputs. Tracked by #67.
-- Whether remaining advanced loose-mode fixture cases are Rust-core behavior,
-  wrapper behavior, or intentionally not applicable. Tracked by #68.

--- a/src/core/resolver/mod.rs
+++ b/src/core/resolver/mod.rs
@@ -1,1 +1,476 @@
+use std::collections::{HashMap, VecDeque};
+
+use thiserror::Error;
+
+use crate::core::resolver::semver::SemverError;
+use crate::util::parse_library_name;
+
 pub mod semver;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DependencyRequestKind {
+    DirectProduction,
+    DirectDevelopment,
+    Transitive,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DependencyRequest {
+    pub package_name: String,
+    pub requested: String,
+    pub kind: DependencyRequestKind,
+}
+
+impl DependencyRequest {
+    pub fn new(
+        package_name: impl Into<String>,
+        requested: impl Into<String>,
+        kind: DependencyRequestKind,
+    ) -> Self {
+        Self {
+            package_name: package_name.into(),
+            requested: normalize_requested(requested.into()),
+            kind,
+        }
+    }
+
+    pub fn from_spec(
+        dependency: impl Into<String>,
+        kind: DependencyRequestKind,
+    ) -> Result<Self, ResolutionError> {
+        let dependency = dependency.into();
+        let (package_name, requested) = parse_library_name(dependency.clone());
+        if package_name.trim().is_empty() {
+            return Err(ResolutionError::InvalidDependencyDeclaration {
+                declaration: dependency,
+            });
+        }
+        Ok(Self::new(package_name, requested, kind))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyDeclaration {
+    pub package_name: String,
+    pub requested: String,
+}
+
+impl DependencyDeclaration {
+    pub fn new(package_name: impl Into<String>, requested: impl Into<String>) -> Self {
+        Self {
+            package_name: package_name.into(),
+            requested: normalize_requested(requested.into()),
+        }
+    }
+
+    pub fn from_spec(dependency: impl Into<String>) -> Result<Self, ResolutionError> {
+        let dependency = dependency.into();
+        let (package_name, requested) = parse_library_name(dependency.clone());
+        if package_name.trim().is_empty() {
+            return Err(ResolutionError::InvalidDependencyDeclaration {
+                declaration: dependency,
+            });
+        }
+        Ok(Self::new(package_name, requested))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedRequest {
+    pub requested: String,
+    pub kind: DependencyRequestKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyEdge {
+    pub package_name: String,
+    pub requested: String,
+    pub resolved_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedPackage {
+    pub package_name: String,
+    pub version: String,
+    pub requests: Vec<ResolvedRequest>,
+    pub dependencies: Vec<DependencyEdge>,
+}
+
+impl ResolvedPackage {
+    fn add_request(&mut self, request: ResolvedRequest) {
+        if !self.requests.contains(&request) {
+            self.requests.push(request);
+        }
+    }
+
+    fn add_dependency(&mut self, edge: DependencyEdge) {
+        if !self.dependencies.contains(&edge) {
+            self.dependencies.push(edge);
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedDependencyGraph {
+    packages: Vec<ResolvedPackage>,
+}
+
+impl ResolvedDependencyGraph {
+    pub fn packages(&self) -> &[ResolvedPackage] {
+        &self.packages
+    }
+
+    pub fn package(&self, package_name: &str, version: &str) -> Option<&ResolvedPackage> {
+        self.packages
+            .iter()
+            .find(|package| package.package_name == package_name && package.version == version)
+    }
+}
+
+pub trait PackageMetadataProvider {
+    fn select_version(
+        &self,
+        package_name: &str,
+        requested: &str,
+    ) -> Result<String, ResolutionError>;
+
+    fn dependencies_for_version(
+        &self,
+        package_name: &str,
+        version: &str,
+    ) -> Result<Vec<DependencyDeclaration>, ResolutionError>;
+}
+
+pub trait ResolutionStrategy {
+    fn resolve<M: PackageMetadataProvider>(
+        &self,
+        requests: Vec<DependencyRequest>,
+        metadata: &M,
+    ) -> Result<ResolvedDependencyGraph, ResolutionError>;
+}
+
+#[derive(Debug, Default)]
+pub struct FifoResolutionStrategy;
+
+impl FifoResolutionStrategy {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ResolutionStrategy for FifoResolutionStrategy {
+    fn resolve<M: PackageMetadataProvider>(
+        &self,
+        requests: Vec<DependencyRequest>,
+        metadata: &M,
+    ) -> Result<ResolvedDependencyGraph, ResolutionError> {
+        let mut worklist = requests
+            .into_iter()
+            .map(|request| PendingRequest {
+                request,
+                requested_by: None,
+            })
+            .collect::<VecDeque<_>>();
+        let mut packages: Vec<ResolvedPackage> = Vec::new();
+        let mut package_indexes: HashMap<String, usize> = HashMap::new();
+
+        while let Some(pending) = worklist.pop_front() {
+            let version = metadata
+                .select_version(&pending.request.package_name, &pending.request.requested)?;
+            let package_key = package_key(&pending.request.package_name, &version);
+
+            if let Some(parent_key) = pending.requested_by.as_ref() {
+                let parent_index = package_indexes.get(parent_key).copied().ok_or_else(|| {
+                    ResolutionError::ParentPackageMissing {
+                        package_key: parent_key.clone(),
+                    }
+                })?;
+                packages[parent_index].add_dependency(DependencyEdge {
+                    package_name: pending.request.package_name.clone(),
+                    requested: pending.request.requested.clone(),
+                    resolved_version: version.clone(),
+                });
+            }
+
+            let request = ResolvedRequest {
+                requested: pending.request.requested.clone(),
+                kind: pending.request.kind,
+            };
+
+            if let Some(package_index) = package_indexes.get(&package_key).copied() {
+                packages[package_index].add_request(request);
+                continue;
+            }
+
+            let package_index = packages.len();
+            package_indexes.insert(package_key.clone(), package_index);
+            packages.push(ResolvedPackage {
+                package_name: pending.request.package_name.clone(),
+                version,
+                requests: vec![request],
+                dependencies: Vec::new(),
+            });
+
+            let package = &packages[package_index];
+            let dependencies =
+                metadata.dependencies_for_version(&package.package_name, &package.version)?;
+            for dependency in dependencies {
+                worklist.push_back(PendingRequest {
+                    request: DependencyRequest::new(
+                        dependency.package_name,
+                        dependency.requested,
+                        DependencyRequestKind::Transitive,
+                    ),
+                    requested_by: Some(package_key.clone()),
+                });
+            }
+        }
+
+        Ok(ResolvedDependencyGraph { packages })
+    }
+}
+
+pub fn resolve_dependency_graph<M: PackageMetadataProvider>(
+    requests: Vec<DependencyRequest>,
+    metadata: &M,
+) -> Result<ResolvedDependencyGraph, ResolutionError> {
+    FifoResolutionStrategy::new().resolve(requests, metadata)
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ResolutionError {
+    #[error("missing package metadata for {package_name}")]
+    MissingMetadata { package_name: String },
+    #[error("{package_name} requested {requested} error {source}")]
+    VersionSelection {
+        package_name: String,
+        requested: String,
+        source: SemverError,
+    },
+    #[error("invalid dependency declaration {declaration}")]
+    InvalidDependencyDeclaration { declaration: String },
+    #[error("resolved parent package {package_key} is missing from graph")]
+    ParentPackageMissing { package_key: String },
+}
+
+impl ResolutionError {
+    pub fn version_selection(
+        package_name: impl Into<String>,
+        requested: impl Into<String>,
+        source: SemverError,
+    ) -> Self {
+        Self::VersionSelection {
+            package_name: package_name.into(),
+            requested: requested.into(),
+            source,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PendingRequest {
+    request: DependencyRequest,
+    requested_by: Option<String>,
+}
+
+fn normalize_requested(requested: String) -> String {
+    if requested.is_empty() {
+        "latest".to_string()
+    } else {
+        requested
+    }
+}
+
+fn package_key(package_name: &str, version: &str) -> String {
+    format!("{package_name}@{version}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        resolve_dependency_graph, DependencyDeclaration, DependencyRequest, DependencyRequestKind,
+        PackageMetadataProvider, ResolutionError,
+    };
+    use crate::registry::Registry;
+    use crate::util::test_support::fixture_path;
+    use std::cell::Cell;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::Path;
+
+    struct FixtureMetadataProvider {
+        registries: HashMap<String, Registry>,
+    }
+
+    impl FixtureMetadataProvider {
+        fn from_fixture_root(root: &Path) -> Self {
+            let mut registries = HashMap::new();
+            for entry in fs::read_dir(root).expect("registry fixture root should exist") {
+                let entry = entry.expect("registry fixture entry should be readable");
+                let path = entry.path();
+                if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+                    continue;
+                }
+
+                let fixture = fs::read_to_string(&path).expect("registry fixture should be read");
+                let registry: Registry = serde_json::from_str(&fixture).unwrap_or_else(|error| {
+                    panic!("{} did not deserialize: {error}", path.display())
+                });
+                registries.insert(registry.name.clone(), registry);
+            }
+            Self { registries }
+        }
+    }
+
+    impl PackageMetadataProvider for FixtureMetadataProvider {
+        fn select_version(
+            &self,
+            package_name: &str,
+            requested: &str,
+        ) -> Result<String, ResolutionError> {
+            let registry = self.registries.get(package_name).ok_or_else(|| {
+                ResolutionError::MissingMetadata {
+                    package_name: package_name.to_string(),
+                }
+            })?;
+            registry.select_version(requested).map_err(|source| {
+                ResolutionError::version_selection(package_name, requested, source)
+            })
+        }
+
+        fn dependencies_for_version(
+            &self,
+            package_name: &str,
+            version: &str,
+        ) -> Result<Vec<DependencyDeclaration>, ResolutionError> {
+            let registry = self.registries.get(package_name).ok_or_else(|| {
+                ResolutionError::MissingMetadata {
+                    package_name: package_name.to_string(),
+                }
+            })?;
+
+            registry
+                .get_dependencies_for_version(version)
+                .into_iter()
+                .map(DependencyDeclaration::from_spec)
+                .collect()
+        }
+    }
+
+    struct FailingSelectionProvider {
+        dependency_reads: Cell<usize>,
+    }
+
+    impl PackageMetadataProvider for FailingSelectionProvider {
+        fn select_version(
+            &self,
+            package_name: &str,
+            requested: &str,
+        ) -> Result<String, ResolutionError> {
+            Err(ResolutionError::version_selection(
+                package_name,
+                requested,
+                crate::core::resolver::semver::SemverError::UnsatisfiedRange {
+                    range: requested.to_string(),
+                },
+            ))
+        }
+
+        fn dependencies_for_version(
+            &self,
+            _package_name: &str,
+            _version: &str,
+        ) -> Result<Vec<DependencyDeclaration>, ResolutionError> {
+            self.dependency_reads.set(self.dependency_reads.get() + 1);
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn resolves_shared_transitive_graph_from_offline_registry_metadata() {
+        let root = fixture_path(&["registry", "shared-transitive", "metadata"]);
+        let provider = FixtureMetadataProvider::from_fixture_root(&root);
+
+        let graph = resolve_dependency_graph(
+            vec![
+                DependencyRequest::new(
+                    "@rpm-fixture/alpha",
+                    "^1.0.0",
+                    DependencyRequestKind::DirectProduction,
+                ),
+                DependencyRequest::new(
+                    "@rpm-fixture/beta",
+                    "^1.0.0",
+                    DependencyRequestKind::DirectDevelopment,
+                ),
+            ],
+            &provider,
+        )
+        .expect("shared transitive graph should resolve");
+
+        let expected = fs::read_to_string(fixture_path(&[
+            "registry",
+            "shared-transitive",
+            "expected",
+            "resolved-packages.txt",
+        ]))
+        .expect("expected resolved package list should be readable");
+        let resolved = graph
+            .packages()
+            .iter()
+            .map(|package| {
+                format!(
+                    "{}@{} requested {}",
+                    package.package_name, package.version, package.requests[0].requested
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(format!("{resolved}\n"), expected);
+        assert_eq!(graph.packages().len(), 3);
+
+        let alpha = graph.package("@rpm-fixture/alpha", "1.0.0").unwrap();
+        assert_eq!(
+            alpha.requests[0].kind,
+            DependencyRequestKind::DirectProduction
+        );
+        assert_eq!(alpha.dependencies.len(), 1);
+        assert_eq!(alpha.dependencies[0].package_name, "@rpm-fixture/shared");
+        assert_eq!(alpha.dependencies[0].requested, "^1.0.0");
+        assert_eq!(alpha.dependencies[0].resolved_version, "1.0.0");
+
+        let beta = graph.package("@rpm-fixture/beta", "1.0.0").unwrap();
+        assert_eq!(
+            beta.requests[0].kind,
+            DependencyRequestKind::DirectDevelopment
+        );
+        assert_eq!(beta.dependencies.len(), 1);
+        assert_eq!(beta.dependencies[0].package_name, "@rpm-fixture/shared");
+
+        let shared = graph.package("@rpm-fixture/shared", "1.0.0").unwrap();
+        assert_eq!(shared.requests.len(), 1);
+        assert_eq!(shared.requests[0].kind, DependencyRequestKind::Transitive);
+        assert!(shared.dependencies.is_empty());
+    }
+
+    #[test]
+    fn failed_version_selection_stops_before_reading_dependency_metadata() {
+        let provider = FailingSelectionProvider {
+            dependency_reads: Cell::new(0),
+        };
+
+        let error = resolve_dependency_graph(
+            vec![DependencyRequest::new(
+                "@rpm-fixture/missing",
+                ">=9.0.0",
+                DependencyRequestKind::DirectProduction,
+            )],
+            &provider,
+        )
+        .expect_err("unsatisfied direct request should fail resolution");
+
+        assert!(matches!(error, ResolutionError::VersionSelection { .. }));
+        assert_eq!(provider.dependency_reads.get(), 0);
+    }
+}

--- a/src/lib/api/mod.rs
+++ b/src/lib/api/mod.rs
@@ -4,8 +4,15 @@ use constants::REGISTRY_PATH;
 
 use crate::registry::Registry;
 use std::io::Error;
+#[cfg(test)]
+use std::{fs, io::ErrorKind, path::PathBuf};
 
 pub async fn get_registry(lib_name: &str, version: &str) -> std::io::Result<Registry> {
+    #[cfg(test)]
+    if let Some(registry) = read_registry_fixture(lib_name)? {
+        return Ok(registry);
+    }
+
     let request_url = format!("{}/{}/{}", REGISTRY_PATH, lib_name, version);
     let registry = reqwest::get(&request_url)
         .await
@@ -21,6 +28,11 @@ pub async fn get_registry(lib_name: &str, version: &str) -> std::io::Result<Regi
 }
 
 pub async fn get_tarball(tarball_url: &str) -> std::io::Result<Vec<u8>> {
+    #[cfg(test)]
+    if std::env::var_os("RPM_REGISTRY_FIXTURE_ROOT").is_some() {
+        return fixture_tarball(tarball_url);
+    }
+
     let response = reqwest::get(tarball_url)
         .await
         .map_err(|error| Error::other(format!("failed to download {tarball_url}: {error}")))?
@@ -38,4 +50,76 @@ pub async fn get_registry_text(lib_name: &str, version: &str) -> std::io::Result
         .text()
         .await
         .map_err(|error| Error::other(format!("failed to read registry {request_url}: {error}")))
+}
+
+#[cfg(test)]
+fn read_registry_fixture(lib_name: &str) -> std::io::Result<Option<Registry>> {
+    let Some(root) = std::env::var_os("RPM_REGISTRY_FIXTURE_ROOT") else {
+        return Ok(None);
+    };
+    let file_name = format!("{}.json", lib_name.replace('/', "__"));
+    let path = PathBuf::from(root).join(file_name);
+    let fixture = fs::read_to_string(&path).map_err(|error| {
+        Error::new(
+            error.kind(),
+            format!(
+                "failed to read registry fixture {}: {error}",
+                path.display()
+            ),
+        )
+    })?;
+    serde_json::from_str(&fixture).map(Some).map_err(|error| {
+        Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "failed to parse registry fixture {}: {error}",
+                path.display()
+            ),
+        )
+    })
+}
+
+#[cfg(test)]
+fn fixture_tarball(tarball_url: &str) -> std::io::Result<Vec<u8>> {
+    use flate2::{write::GzEncoder, Compression};
+    use std::io::Write;
+    use tar::{Builder, Header};
+
+    let package_name = package_name_from_tarball_url(tarball_url)?;
+    let package_json = format!(r#"{{"name":"{package_name}"}}"#);
+    let encoder = GzEncoder::new(Vec::new(), Compression::default());
+    let mut builder = Builder::new(encoder);
+    let mut header = Header::new_gnu();
+    header.set_size(package_json.len() as u64);
+    header.set_cksum();
+    builder.append_data(&mut header, "package/package.json", package_json.as_bytes())?;
+    builder.finish()?;
+    let mut encoder = builder.into_inner()?;
+    encoder.flush()?;
+    encoder.finish()
+}
+
+#[cfg(test)]
+fn package_name_from_tarball_url(tarball_url: &str) -> std::io::Result<String> {
+    let path = tarball_url
+        .split_once("://")
+        .and_then(|(_, rest)| rest.split_once('/').map(|(_, path)| path))
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                format!("invalid fixture tarball URL: {tarball_url}"),
+            )
+        })?;
+    let parts = path
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    match parts.as_slice() {
+        [scope, name, ..] if scope.starts_with('@') => Ok(format!("{scope}/{name}")),
+        [name, ..] => Ok((*name).to_string()),
+        _ => Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!("invalid fixture tarball URL path: {tarball_url}"),
+        )),
+    }
 }

--- a/src/lib/command/working_process/add.rs
+++ b/src/lib/command/working_process/add.rs
@@ -1,15 +1,35 @@
-use std::io::{Error, ErrorKind, Write};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    future::Future,
+    io::{Error, ErrorKind, Write},
+};
+
+use tokio::time::sleep;
 
 use crate::{
     api,
+    core::resolver::{
+        resolve_dependency_graph, DependencyDeclaration, DependencyRequest, DependencyRequestKind,
+        PackageMetadataProvider, ResolutionError, ResolvedPackage,
+    },
     lockfile::{LockFile, Relationship},
     package_manifest::PackageManifest,
-    util::parse_library_name,
+    registry::Registry,
 };
-use async_recursion::async_recursion;
-use tokio::time::sleep;
 
-#[async_recursion]
+#[derive(Clone)]
+struct LockedInstallPackage {
+    key: String,
+    package_name: String,
+    requested: String,
+    version: String,
+    relationship: Relationship,
+    tarball: Option<String>,
+    integrity: Option<String>,
+    shasum: Option<String>,
+    dependencies: Vec<String>,
+}
+
 pub async fn add(
     pkg: &mut PackageManifest,
     lockfile: &mut LockFile,
@@ -17,75 +37,206 @@ pub async fn add(
     dev: bool,
     write_manifest: bool,
 ) -> std::io::Result<()> {
+    let request_kind = direct_request_kind(dev);
+    let requests = libs
+        .into_iter()
+        .map(|dependency| DependencyRequest::from_spec(dependency, request_kind))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(resolution_error_to_io)?;
+    let mut metadata = InstallMetadata::from_lockfile(lockfile);
+
+    populate_metadata(&mut metadata, &requests, |package_name| async move {
+        api::get_registry(&package_name, "").await
+    })
+    .await?;
+    let graph = resolve_dependency_graph(requests, &metadata).map_err(resolution_error_to_io)?;
+
     lockfile.set_project_metadata(pkg.get_name(), pkg.get_version());
-    add_with_context(pkg, lockfile, libs, dev, write_manifest, true).await
+    apply_resolved_graph(pkg, lockfile, graph.packages(), &metadata, write_manifest).await
 }
 
-#[async_recursion]
-async fn add_with_context(
+async fn populate_metadata<F, Fut>(
+    metadata: &mut InstallMetadata,
+    requests: &[DependencyRequest],
+    mut fetch_registry: F,
+) -> std::io::Result<()>
+where
+    F: FnMut(String) -> Fut,
+    Fut: Future<Output = std::io::Result<Registry>>,
+{
+    let mut visited = HashSet::new();
+    let mut worklist = requests.iter().cloned().collect::<VecDeque<_>>();
+
+    while let Some(request) = worklist.pop_front() {
+        let package_name = request.package_name.clone();
+        if !metadata.has_locked_request(&package_name, &request.requested)
+            && !metadata.has_registry(&package_name)
+        {
+            let registry = fetch_registry(package_name.clone()).await?;
+            metadata.insert_registry(package_name.clone(), registry);
+        }
+
+        let version = metadata
+            .select_version(&package_name, &request.requested)
+            .map_err(resolution_error_to_io)?;
+        let package_key = format!("{package_name}@{version}");
+        if !visited.insert(package_key) {
+            continue;
+        }
+
+        let dependencies = metadata
+            .dependencies_for_version(&package_name, &version)
+            .map_err(resolution_error_to_io)?;
+        for dependency in dependencies {
+            worklist.push_back(DependencyRequest::new(
+                dependency.package_name,
+                dependency.requested,
+                DependencyRequestKind::Transitive,
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+async fn apply_resolved_graph(
     pkg: &mut PackageManifest,
     lockfile: &mut LockFile,
-    libs: Vec<String>,
-    dev: bool,
+    packages: &[ResolvedPackage],
+    metadata: &InstallMetadata,
     write_manifest: bool,
-    root_dependency: bool,
 ) -> std::io::Result<()> {
-    for lib in libs {
-        print!("installing {}...", lib);
+    for package in packages {
+        print!("installing {}@{}...", package.package_name, package.version);
         std::io::stdout().flush()?;
         sleep(std::time::Duration::from_millis(1)).await;
         print!("\r\x1b[K");
-        let (library_name, requested_range) = parse_library_name(lib.clone());
-        let requested = if requested_range.is_empty() {
-            "latest".to_string()
-        } else {
-            requested_range.clone()
-        };
-        let registry = api::get_registry(&library_name, "").await?;
-        let version = registry.select_version(&requested).map_err(|error| {
-            Error::new(
-                ErrorKind::InvalidData,
-                format!("{library_name} requested {requested} error {error}"),
-            )
-        })?;
-        let key = format!("{}@{}", library_name, version);
 
-        registry.download_tarball(&key, &version).await?;
-        let dependencies = registry.get_dependencies_for_version(&version);
-        let dist = registry.get_dist_for_version(&version);
-        let manifest_version = manifest_version_from_requested(&requested, &version);
-        let relationship = if root_dependency {
-            if dev {
-                Relationship::Dev
-            } else {
-                Relationship::Direct
+        let requested = requested_for_lockfile(package, metadata);
+        let relationship = relationship_for_package(package);
+        if let Some(locked_package) = metadata.locked_package_for_resolved(package) {
+            if let Some(tarball) = &locked_package.tarball {
+                Registry::download_tarball_url(&locked_package.key, tarball).await?;
             }
+            lockfile.add_dependency_entry(
+                &locked_package.key,
+                locked_package.package_name.clone(),
+                requested.clone(),
+                locked_package.version.clone(),
+                relationship,
+                locked_package.tarball.clone(),
+                locked_package.integrity.clone(),
+                locked_package.shasum.clone(),
+                &locked_package.dependencies,
+            );
         } else {
-            Relationship::Transitive
-        };
+            let key = format!("{}@{}", package.package_name, package.version);
+            let registry = metadata.registry_io(&package.package_name)?;
+            registry.download_tarball(&key, &package.version).await?;
 
-        lockfile.add_dependency_entry(
-            &key,
-            library_name.clone(),
-            requested,
-            version.clone(),
-            relationship,
-            dist.map(|dist| dist.tarball.clone()),
-            dist.and_then(|dist| dist.integrity.clone()),
-            dist.map(|dist| dist.shasum.clone()),
-            &dependencies,
-        );
+            let dependencies = package
+                .dependencies
+                .iter()
+                .map(|dependency| format!("{}@{}", dependency.package_name, dependency.requested))
+                .collect::<Vec<_>>();
+            let dist = registry.get_dist_for_version(&package.version);
+
+            lockfile.add_dependency_entry(
+                &key,
+                package.package_name.clone(),
+                requested.clone(),
+                package.version.clone(),
+                relationship,
+                dist.map(|dist| dist.tarball.clone()),
+                dist.and_then(|dist| dist.integrity.clone()),
+                dist.map(|dist| dist.shasum.clone()),
+                &dependencies,
+            );
+        }
+
         if write_manifest {
-            if dev {
-                pkg.add_dev_dependency(library_name, manifest_version);
-            } else {
-                pkg.add_dependency(library_name, manifest_version);
+            maybe_update_manifest(pkg, package, &requested);
+        }
+    }
+
+    Ok(())
+}
+
+fn maybe_update_manifest(pkg: &mut PackageManifest, package: &ResolvedPackage, requested: &str) {
+    let manifest_version = manifest_version_from_requested(requested, &package.version);
+    match direct_request_kind_for_package(package) {
+        Some(DependencyRequestKind::DirectProduction) => {
+            pkg.add_dependency(package.package_name.clone(), manifest_version)
+        }
+        Some(DependencyRequestKind::DirectDevelopment) => {
+            pkg.add_dev_dependency(package.package_name.clone(), manifest_version)
+        }
+        _ => {}
+    }
+}
+
+fn direct_request_kind(dev: bool) -> DependencyRequestKind {
+    if dev {
+        DependencyRequestKind::DirectDevelopment
+    } else {
+        DependencyRequestKind::DirectProduction
+    }
+}
+
+fn direct_request_kind_for_package(package: &ResolvedPackage) -> Option<DependencyRequestKind> {
+    direct_request_for_package(package).map(|request| request.kind)
+}
+
+fn direct_request_for_package(
+    package: &ResolvedPackage,
+) -> Option<&crate::core::resolver::ResolvedRequest> {
+    package
+        .requests
+        .iter()
+        .find(|request| matches!(request.kind, DependencyRequestKind::DirectProduction))
+        .or_else(|| {
+            package
+                .requests
+                .iter()
+                .find(|request| matches!(request.kind, DependencyRequestKind::DirectDevelopment))
+        })
+}
+
+fn requested_for_lockfile(package: &ResolvedPackage, metadata: &InstallMetadata) -> String {
+    if let Some(request) = direct_request_for_package(package) {
+        if matches!(request.kind, DependencyRequestKind::DirectDevelopment) {
+            if let Some(locked_requested) = locked_direct_request(package, metadata) {
+                return locked_requested;
             }
         }
 
-        add_with_context(pkg, lockfile, dependencies, dev, false, false).await?;
+        return request.requested.clone();
     }
-    Ok(())
+
+    package
+        .requests
+        .first()
+        .map(|request| request.requested.clone())
+        .unwrap_or_else(|| package.version.clone())
+}
+
+fn locked_direct_request(package: &ResolvedPackage, metadata: &InstallMetadata) -> Option<String> {
+    metadata
+        .locked_package_for_resolved(package)
+        .filter(|locked| matches!(locked.relationship, Relationship::Direct))
+        .map(|locked| locked.requested.clone())
+}
+
+fn relationship_for_package(package: &ResolvedPackage) -> Relationship {
+    match direct_request_kind_for_package(package) {
+        Some(DependencyRequestKind::DirectProduction) => Relationship::Direct,
+        Some(DependencyRequestKind::DirectDevelopment) => Relationship::Dev,
+        _ => Relationship::Transitive,
+    }
+}
+
+fn resolution_error_to_io(error: ResolutionError) -> std::io::Error {
+    Error::new(ErrorKind::InvalidData, error.to_string())
 }
 
 fn manifest_version_from_requested(requested: &str, resolved: &str) -> String {
@@ -96,17 +247,403 @@ fn manifest_version_from_requested(requested: &str, resolved: &str) -> String {
     }
 }
 
+#[derive(Default)]
+struct InstallMetadata {
+    registries: HashMap<String, Registry>,
+    locked_by_request: HashMap<(String, String), LockedInstallPackage>,
+    locked_by_version: HashMap<(String, String), LockedInstallPackage>,
+}
+
+impl InstallMetadata {
+    fn from_lockfile(lockfile: &LockFile) -> Self {
+        let mut metadata = Self::default();
+
+        for (key, dependency) in lockfile.get_packages() {
+            let package_name = package_name_from_lock_key(key);
+            let locked_package = LockedInstallPackage {
+                key: key.clone(),
+                package_name: package_name.clone(),
+                requested: dependency.get_requested(),
+                version: dependency.get_version(),
+                relationship: dependency.get_relationship(),
+                tarball: dependency.get_tarball(),
+                integrity: dependency.get_integrity(),
+                shasum: dependency.get_shasum(),
+                dependencies: dependency.get_dependencies(),
+            };
+            metadata.locked_by_request.insert(
+                (package_name.clone(), locked_package.requested.clone()),
+                locked_package.clone(),
+            );
+            metadata.locked_by_version.insert(
+                (package_name, locked_package.version.clone()),
+                locked_package,
+            );
+        }
+
+        metadata
+    }
+
+    fn insert_registry(&mut self, package_name: String, registry: Registry) {
+        self.registries.insert(package_name, registry);
+    }
+
+    fn has_registry(&self, package_name: &str) -> bool {
+        self.registries.contains_key(package_name)
+    }
+
+    fn has_locked_request(&self, package_name: &str, requested: &str) -> bool {
+        self.locked_by_request
+            .contains_key(&(package_name.to_string(), requested.to_string()))
+    }
+
+    fn locked_package_for_request(
+        &self,
+        package_name: &str,
+        requested: &str,
+    ) -> Option<&LockedInstallPackage> {
+        self.locked_by_request
+            .get(&(package_name.to_string(), requested.to_string()))
+    }
+
+    fn locked_package_for_version(
+        &self,
+        package_name: &str,
+        version: &str,
+    ) -> Option<&LockedInstallPackage> {
+        self.locked_by_version
+            .get(&(package_name.to_string(), version.to_string()))
+    }
+
+    fn locked_package_for_resolved(
+        &self,
+        package: &ResolvedPackage,
+    ) -> Option<&LockedInstallPackage> {
+        package
+            .requests
+            .iter()
+            .find_map(|request| {
+                self.locked_package_for_request(&package.package_name, &request.requested)
+            })
+            .or_else(|| self.locked_package_for_version(&package.package_name, &package.version))
+    }
+
+    fn registry(&self, package_name: &str) -> Result<&Registry, ResolutionError> {
+        self.registries
+            .get(package_name)
+            .ok_or_else(|| ResolutionError::MissingMetadata {
+                package_name: package_name.to_string(),
+            })
+    }
+
+    fn registry_io(&self, package_name: &str) -> std::io::Result<&Registry> {
+        self.registry(package_name).map_err(resolution_error_to_io)
+    }
+}
+
+impl PackageMetadataProvider for InstallMetadata {
+    fn select_version(
+        &self,
+        package_name: &str,
+        requested: &str,
+    ) -> Result<String, ResolutionError> {
+        if let Some(locked_package) = self.locked_package_for_request(package_name, requested) {
+            return Ok(locked_package.version.clone());
+        }
+
+        let registry = self.registry(package_name)?;
+        registry
+            .select_version(requested)
+            .map_err(|source| ResolutionError::version_selection(package_name, requested, source))
+    }
+
+    fn dependencies_for_version(
+        &self,
+        package_name: &str,
+        version: &str,
+    ) -> Result<Vec<DependencyDeclaration>, ResolutionError> {
+        if let Some(locked_package) = self.locked_package_for_version(package_name, version) {
+            return locked_package
+                .dependencies
+                .iter()
+                .cloned()
+                .map(DependencyDeclaration::from_spec)
+                .collect();
+        }
+
+        let registry = self.registry(package_name)?;
+        registry
+            .get_dependencies_for_version(version)
+            .into_iter()
+            .map(DependencyDeclaration::from_spec)
+            .collect()
+    }
+}
+
+fn package_name_from_lock_key(key: &str) -> String {
+    match key.rsplit_once('@') {
+        Some((name, _)) if !name.is_empty() => name.to_string(),
+        _ => key.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::{
+        direct_request_kind, manifest_version_from_requested, populate_metadata,
+        relationship_for_package, requested_for_lockfile, InstallMetadata,
+    };
+    use crate::{
+        core::resolver::{
+            resolve_dependency_graph, DependencyRequest, DependencyRequestKind, ResolvedPackage,
+            ResolvedRequest,
+        },
+        lockfile::{LockFile, Relationship},
+        package_manifest::PackageManifest,
+        registry::Registry,
+        util::test_support::fixture_path,
+    };
+    use std::{cell::RefCell, collections::HashMap, fs, path::Path, rc::Rc};
+
+    fn registry_fixture_file_name(package_name: &str) -> String {
+        format!("{}.json", package_name.replace('/', "__"))
+    }
+
+    fn load_registry_fixture(root: &Path, package_name: &str) -> Registry {
+        let path = root.join(registry_fixture_file_name(package_name));
+        let fixture = fs::read_to_string(&path).unwrap_or_else(|error| {
+            panic!(
+                "failed to read registry fixture {}: {error}",
+                path.display()
+            )
+        });
+        serde_json::from_str(&fixture)
+            .unwrap_or_else(|error| panic!("{} did not deserialize: {error}", path.display()))
+    }
+
+    #[tokio::test]
+    async fn preload_discovers_shared_transitive_metadata_before_resolution() {
+        let root = fixture_path(&["registry", "shared-transitive", "metadata"]);
+        let requests = vec![
+            DependencyRequest::new(
+                "@rpm-fixture/alpha",
+                "^1.0.0",
+                DependencyRequestKind::DirectProduction,
+            ),
+            DependencyRequest::new(
+                "@rpm-fixture/beta",
+                "^1.0.0",
+                DependencyRequestKind::DirectDevelopment,
+            ),
+        ];
+        let fetches = Rc::new(RefCell::new(HashMap::<String, usize>::new()));
+        let fetches_for_loader = Rc::clone(&fetches);
+        let mut metadata = InstallMetadata::default();
+
+        populate_metadata(&mut metadata, &requests, |package_name| {
+            let root = root.clone();
+            let package_name = package_name.to_string();
+            let fetches = Rc::clone(&fetches_for_loader);
+            async move {
+                let count = fetches.borrow().get(&package_name).copied().unwrap_or(0) + 1;
+                fetches.borrow_mut().insert(package_name.clone(), count);
+                Ok(load_registry_fixture(&root, &package_name))
+            }
+        })
+        .await
+        .expect("metadata preload should succeed");
+
+        let graph = resolve_dependency_graph(requests, &metadata).expect("graph should resolve");
+
+        assert_eq!(graph.packages().len(), 3);
+        assert_eq!(fetches.borrow().get("@rpm-fixture/alpha"), Some(&1));
+        assert_eq!(fetches.borrow().get("@rpm-fixture/beta"), Some(&1));
+        assert_eq!(fetches.borrow().get("@rpm-fixture/shared"), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn preload_prefers_locked_versions_and_dependencies_when_present() {
+        let fixture_root = fixture_path(&["install-projects", "lockfile-reproducible"]);
+        let registry_root = fixture_root.join("registry");
+        let lockfile = LockFile::load_from_path(fixture_root.join("rpm.lock")).unwrap();
+        let requests = vec![DependencyRequest::new(
+            "@rpm-fixture/locked-parent",
+            "^1.0.0",
+            DependencyRequestKind::DirectProduction,
+        )];
+        let mut metadata = InstallMetadata::from_lockfile(&lockfile);
+
+        populate_metadata(&mut metadata, &requests, |package_name| {
+            let registry_root = registry_root.clone();
+            let package_name = package_name.to_string();
+            async move { Ok(load_registry_fixture(&registry_root, &package_name)) }
+        })
+        .await
+        .expect("locked fixture metadata should preload");
+
+        let graph = resolve_dependency_graph(requests, &metadata).expect("graph should resolve");
+        let mut resolved = graph
+            .packages()
+            .iter()
+            .map(|package| {
+                format!(
+                    "{}@{} requested {}",
+                    package.package_name,
+                    package.version,
+                    requested_for_lockfile(package, &metadata)
+                )
+            })
+            .collect::<Vec<_>>();
+        resolved.sort();
+        let mut expected = fs::read_to_string(fixture_root.join("expected/resolved-packages.txt"))
+            .unwrap()
+            .lines()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        expected.sort();
+
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn relationship_prefers_direct_requests_over_transitive() {
+        let package = ResolvedPackage {
+            package_name: "shared".to_string(),
+            version: "1.0.0".to_string(),
+            requests: vec![
+                ResolvedRequest {
+                    requested: "1.0.0".to_string(),
+                    kind: DependencyRequestKind::Transitive,
+                },
+                ResolvedRequest {
+                    requested: "^1.0.0".to_string(),
+                    kind: DependencyRequestKind::DirectDevelopment,
+                },
+            ],
+            dependencies: Vec::new(),
+        };
+
+        assert_eq!(relationship_for_package(&package), Relationship::Dev);
+        assert_eq!(
+            requested_for_lockfile(&package, &InstallMetadata::default()),
+            "^1.0.0".to_string()
+        );
+    }
+
+    #[test]
+    fn requested_for_lockfile_preserves_existing_prod_request_on_later_dev_pass() {
+        let mut lockfile = LockFile::load_from_path(fixture_path(&[
+            "install-projects",
+            "lockfile-reproducible",
+            "rpm.lock",
+        ]))
+        .unwrap();
+        lockfile.add_dependency_entry(
+            &"shared@1.0.0".to_string(),
+            "shared".to_string(),
+            "^1.0.0".to_string(),
+            "1.0.0".to_string(),
+            Relationship::Direct,
+            None,
+            None,
+            None,
+            &[],
+        );
+        let metadata = InstallMetadata::from_lockfile(&lockfile);
+        let package = ResolvedPackage {
+            package_name: "shared".to_string(),
+            version: "1.0.0".to_string(),
+            requests: vec![ResolvedRequest {
+                requested: "~1.0.0".to_string(),
+                kind: DependencyRequestKind::DirectDevelopment,
+            }],
+            dependencies: Vec::new(),
+        };
+
+        assert_eq!(relationship_for_package(&package), Relationship::Dev);
+        let requested = requested_for_lockfile(&package, &metadata);
+        assert_eq!(requested, "^1.0.0".to_string());
+
+        lockfile.add_dependency_entry(
+            &"shared@1.0.0".to_string(),
+            "shared".to_string(),
+            requested,
+            "1.0.0".to_string(),
+            relationship_for_package(&package),
+            None,
+            None,
+            None,
+            &[],
+        );
+        assert_eq!(
+            lockfile
+                .get_dependency_for_request("shared", "^1.0.0")
+                .map(|(_, dependency)| dependency.get_relationship()),
+            Some(Relationship::Direct)
+        );
+        assert_eq!(
+            lockfile
+                .get_dependency("shared@1.0.0")
+                .map(|dependency| dependency.get_requested()),
+            Some("^1.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn add_uses_existing_lockfile_records_before_registry_selection() {
+        let fixture_root = fixture_path(&["install-projects", "lockfile-reproducible"]);
+        let mut package_manifest =
+            PackageManifest::read_from_path(fixture_root.join("package.json")).unwrap();
+        let mut lockfile =
+            LockFile::load_from_path(fixture_root.join("rpm-without-tarballs.lock")).unwrap();
+        let libs = package_manifest
+            .get_dependencies()
+            .into_iter()
+            .map(|(library_name, version)| format!("{library_name}@{version}"))
+            .collect::<Vec<_>>();
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(super::add(
+                &mut package_manifest,
+                &mut lockfile,
+                libs,
+                false,
+                false,
+            ))
+            .unwrap();
+
+        let parent = lockfile
+            .get_dependency_for_request("@rpm-fixture/locked-parent", "^1.0.0")
+            .expect("locked parent should remain available after add");
+        assert_eq!(parent.0, "@rpm-fixture/locked-parent@1.0.0");
+        assert_eq!(parent.1.get_version(), "1.0.0");
+        assert_eq!(
+            parent.1.get_dependencies(),
+            vec!["@rpm-fixture/locked-child@^1.0.0"]
+        );
+
+        let child = lockfile
+            .get_dependency_for_request("@rpm-fixture/locked-child", "^1.0.0")
+            .expect("locked child should remain available after add");
+        assert_eq!(child.0, "@rpm-fixture/locked-child@1.0.0");
+        assert_eq!(child.1.get_version(), "1.0.0");
+        assert!(child.1.get_dependencies().is_empty());
+    }
+
     #[test]
     fn manifest_version_preserves_requested_range_for_direct_adds() {
         assert_eq!(
-            super::manifest_version_from_requested("^1.2.0", "1.4.0"),
-            "^1.2.0"
+            direct_request_kind(false),
+            DependencyRequestKind::DirectProduction
         );
         assert_eq!(
-            super::manifest_version_from_requested("latest", "1.4.0"),
-            "1.4.0"
+            direct_request_kind(true),
+            DependencyRequestKind::DirectDevelopment
         );
+        assert_eq!(manifest_version_from_requested("^1.2.0", "1.4.0"), "^1.2.0");
+        assert_eq!(manifest_version_from_requested("latest", "1.4.0"), "1.4.0");
     }
 }

--- a/src/lib/command/working_process/add.rs
+++ b/src/lib/command/working_process/add.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     future::Future,
     io::{Error, ErrorKind, Write},
+    path::Path,
 };
 
 use tokio::time::sleep;
@@ -37,6 +38,25 @@ pub async fn add(
     dev: bool,
     write_manifest: bool,
 ) -> std::io::Result<()> {
+    add_with_cache_dir(
+        pkg,
+        lockfile,
+        libs,
+        dev,
+        write_manifest,
+        Path::new("./.rpm/.cache"),
+    )
+    .await
+}
+
+pub(crate) async fn add_with_cache_dir(
+    pkg: &mut PackageManifest,
+    lockfile: &mut LockFile,
+    libs: Vec<String>,
+    dev: bool,
+    write_manifest: bool,
+    cache_dir: &Path,
+) -> std::io::Result<()> {
     let request_kind = direct_request_kind(dev);
     let requests = libs
         .into_iter()
@@ -52,7 +72,15 @@ pub async fn add(
     let graph = resolve_dependency_graph(requests, &metadata).map_err(resolution_error_to_io)?;
 
     lockfile.set_project_metadata(pkg.get_name(), pkg.get_version());
-    apply_resolved_graph(pkg, lockfile, graph.packages(), &metadata, write_manifest).await
+    apply_resolved_graph(
+        pkg,
+        lockfile,
+        graph.packages(),
+        &metadata,
+        write_manifest,
+        cache_dir,
+    )
+    .await
 }
 
 async fn populate_metadata<F, Fut>(
@@ -105,6 +133,7 @@ async fn apply_resolved_graph(
     packages: &[ResolvedPackage],
     metadata: &InstallMetadata,
     write_manifest: bool,
+    cache_dir: &Path,
 ) -> std::io::Result<()> {
     for package in packages {
         print!("installing {}@{}...", package.package_name, package.version);
@@ -116,7 +145,8 @@ async fn apply_resolved_graph(
         let relationship = relationship_for_package(package);
         if let Some(locked_package) = metadata.locked_package_for_resolved(package) {
             if let Some(tarball) = &locked_package.tarball {
-                Registry::download_tarball_url(&locked_package.key, tarball).await?;
+                Registry::download_tarball_url_to_dir(&locked_package.key, tarball, cache_dir)
+                    .await?;
             }
             lockfile.add_dependency_entry(
                 &locked_package.key,
@@ -132,7 +162,9 @@ async fn apply_resolved_graph(
         } else {
             let key = format!("{}@{}", package.package_name, package.version);
             let registry = metadata.registry_io(&package.package_name)?;
-            registry.download_tarball(&key, &package.version).await?;
+            registry
+                .download_tarball_to_dir(&key, &package.version, cache_dir)
+                .await?;
 
             let dependencies = package
                 .dependencies

--- a/src/lib/command/working_process/install.rs
+++ b/src/lib/command/working_process/install.rs
@@ -1,36 +1,62 @@
 use crate::{
-    command::working_process, lockfile::LockFile, node_linker::NodeModules,
+    command::working_process::add_with_cache_dir, lockfile::LockFile, node_linker::NodeModules,
     package_manifest::PackageManifest,
 };
+use std::path::Path;
 
 pub async fn install() -> std::io::Result<()> {
-    let mut package_manifest = PackageManifest::read_default()?;
+    install_in(Path::new(".")).await
+}
+
+async fn install_in(project_root: &Path) -> std::io::Result<()> {
+    let package_path = project_root.join("package.json");
+    let lockfile_path = project_root.join("rpm.lock");
+    let cache_dir = project_root.join(".rpm").join(".cache");
+    let node_modules_path = project_root.join("node_modules");
+
+    let mut package_manifest = PackageManifest::read_from_path(&package_path)?;
     let dependencies = package_manifest.get_dependencies();
-    let mut lockfile = LockFile::load()?;
+    let mut lockfile = LockFile::load_from_path(&lockfile_path)?;
     let libs = dependencies
         .iter()
         .map(|(lib_name, version)| format!("{}@{}", lib_name, version))
         .collect::<Vec<String>>();
-    working_process::add(&mut package_manifest, &mut lockfile, libs, false, false).await?;
+    add_with_cache_dir(
+        &mut package_manifest,
+        &mut lockfile,
+        libs,
+        false,
+        false,
+        &cache_dir,
+    )
+    .await?;
 
     let dev_deps = package_manifest.get_dev_dependencies();
     let dev_libs = dev_deps
         .iter()
         .map(|(lib_name, version)| format!("{}@{}", lib_name, version))
         .collect::<Vec<String>>();
-    working_process::add(&mut package_manifest, &mut lockfile, dev_libs, true, false).await?;
+    add_with_cache_dir(
+        &mut package_manifest,
+        &mut lockfile,
+        dev_libs,
+        true,
+        false,
+        &cache_dir,
+    )
+    .await?;
 
-    lockfile.save()?;
-    package_manifest.save_to_path("./package.json")?;
+    lockfile.save_to_path(&lockfile_path)?;
+    package_manifest.save_to_path(&package_path)?;
     if !lockfile.get_packages().is_empty() {
-        NodeModules::init()?;
+        NodeModules::init_from_paths(&node_modules_path, &lockfile_path, &cache_dir)?;
     }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::install;
+    use super::install_in;
     use crate::{
         lockfile::{LockFile, Relationship},
         package_manifest::PackageManifest,
@@ -42,14 +68,13 @@ mod tests {
         fs, io,
         os::unix::fs::PermissionsExt,
         path::{Path, PathBuf},
-        sync::Mutex,
+        thread,
+        time::Duration,
     };
-
-    static INSTALL_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[tokio::test]
     async fn installs_performance_small_fixture_from_deterministic_inputs() {
-        let _guard = INSTALL_TEST_LOCK.lock().unwrap();
+        let _guard = TestEnvLock::acquire().unwrap();
         let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let root_before = root_fingerprints(&repo_root).unwrap();
         let fixture_root = fixture_path(&["install-projects", "performance-small"]);
@@ -59,8 +84,8 @@ mod tests {
             .unwrap();
         let project_root = package_path.parent().unwrap();
 
-        let _env = FixtureInstallEnv::new(project_root, &fixture_root.join("registry")).unwrap();
-        install().await.unwrap();
+        let _env = FixtureInstallEnv::new(&fixture_root.join("registry"));
+        install_in(project_root).await.unwrap();
 
         let lock_path = project_root.join("rpm.lock");
         let lock = LockFile::load_from_path(&lock_path).unwrap();
@@ -150,7 +175,7 @@ mod tests {
 
     #[tokio::test]
     async fn install_failure_preserves_existing_node_modules() {
-        let _guard = INSTALL_TEST_LOCK.lock().unwrap();
+        let _guard = TestEnvLock::acquire().unwrap();
         let fixture_root = fixture_path(&["install-projects", "performance-small"]);
         let project = TempProject::new("install-failure-preserves-node-modules").unwrap();
         let package_path = project
@@ -165,8 +190,8 @@ mod tests {
         read_only_permissions.set_mode(0o444);
         fs::set_permissions(&package_path, read_only_permissions).unwrap();
 
-        let _env = FixtureInstallEnv::new(project_root, &fixture_root.join("registry")).unwrap();
-        let error = install().await.unwrap_err();
+        let _env = FixtureInstallEnv::new(&fixture_root.join("registry"));
+        let error = install_in(project_root).await.unwrap_err();
         fs::set_permissions(&package_path, original_permissions).unwrap();
 
         assert!(error
@@ -201,27 +226,47 @@ mod tests {
         Ok(entries)
     }
 
+    struct TestEnvLock {
+        path: PathBuf,
+    }
+
+    impl TestEnvLock {
+        fn acquire() -> io::Result<Self> {
+            let path = std::env::temp_dir().join("rpm-install-test-env-lock");
+            loop {
+                match fs::create_dir(&path) {
+                    Ok(()) => return Ok(Self { path }),
+                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+        }
+    }
+
+    impl Drop for TestEnvLock {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir(&self.path);
+        }
+    }
+
     struct FixtureInstallEnv {
-        original_dir: PathBuf,
         previous_fixture_root: Option<OsString>,
     }
 
     impl FixtureInstallEnv {
-        fn new(project_root: &Path, registry_root: &Path) -> io::Result<Self> {
-            let original_dir = std::env::current_dir()?;
+        fn new(registry_root: &Path) -> Self {
             let previous_fixture_root = std::env::var_os("RPM_REGISTRY_FIXTURE_ROOT");
-            std::env::set_current_dir(project_root)?;
             std::env::set_var("RPM_REGISTRY_FIXTURE_ROOT", registry_root);
-            Ok(Self {
-                original_dir,
+            Self {
                 previous_fixture_root,
-            })
+            }
         }
     }
 
     impl Drop for FixtureInstallEnv {
         fn drop(&mut self) {
-            let _ = std::env::set_current_dir(&self.original_dir);
             match &self.previous_fixture_root {
                 Some(value) => std::env::set_var("RPM_REGISTRY_FIXTURE_ROOT", value),
                 None => std::env::remove_var("RPM_REGISTRY_FIXTURE_ROOT"),

--- a/src/lib/command/working_process/install.rs
+++ b/src/lib/command/working_process/install.rs
@@ -1,4 +1,7 @@
-use crate::{command::working_process, lockfile::LockFile, package_manifest::PackageManifest};
+use crate::{
+    command::working_process, lockfile::LockFile, node_linker::NodeModules,
+    package_manifest::PackageManifest,
+};
 
 pub async fn install() -> std::io::Result<()> {
     let mut package_manifest = PackageManifest::read_default()?;
@@ -19,5 +22,244 @@ pub async fn install() -> std::io::Result<()> {
 
     lockfile.save()?;
     package_manifest.save_to_path("./package.json")?;
+    if !lockfile.get_packages().is_empty() {
+        NodeModules::init()?;
+    }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::install;
+    use crate::{
+        lockfile::{LockFile, Relationship},
+        package_manifest::PackageManifest,
+        util::test_support::{fixture_path, TempProject},
+    };
+    use std::{
+        collections::BTreeMap,
+        ffi::OsString,
+        fs, io,
+        os::unix::fs::PermissionsExt,
+        path::{Path, PathBuf},
+        sync::Mutex,
+    };
+
+    static INSTALL_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[tokio::test]
+    async fn installs_performance_small_fixture_from_deterministic_inputs() {
+        let _guard = INSTALL_TEST_LOCK.lock().unwrap();
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let root_before = root_fingerprints(&repo_root).unwrap();
+        let fixture_root = fixture_path(&["install-projects", "performance-small"]);
+        let project = TempProject::new("performance-small-install").unwrap();
+        let package_path = project
+            .copy_fixture(fixture_root.join("package.json"), "package.json")
+            .unwrap();
+        let project_root = package_path.parent().unwrap();
+
+        let _env = FixtureInstallEnv::new(project_root, &fixture_root.join("registry")).unwrap();
+        install().await.unwrap();
+
+        let lock_path = project_root.join("rpm.lock");
+        let lock = LockFile::load_from_path(&lock_path).unwrap();
+        let expected = fs::read_to_string(fixture_root.join("expected/resolved-packages.txt"))
+            .unwrap()
+            .lines()
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        assert_eq!(resolved_packages(&lock), expected);
+        assert_eq!(
+            lock.get_dependency("@rpm-fixture/alpha@1.0.0")
+                .map(|dependency| dependency.get_relationship()),
+            Some(Relationship::Direct)
+        );
+        assert_eq!(
+            lock.get_dependency("@rpm-fixture/beta@1.0.0")
+                .map(|dependency| dependency.get_relationship()),
+            Some(Relationship::Direct)
+        );
+        assert_eq!(
+            lock.get_dependency("@rpm-fixture/shared@1.0.0")
+                .map(|dependency| dependency.get_relationship()),
+            Some(Relationship::Transitive)
+        );
+
+        let package = PackageManifest::read_from_path(&package_path).unwrap();
+        assert_eq!(package.get_name(), "performance-small");
+        assert_eq!(
+            sorted_dependencies(package.get_dependencies()),
+            vec![
+                ("@rpm-fixture/alpha".to_string(), "^1.0.0".to_string()),
+                ("@rpm-fixture/beta".to_string(), "^1.0.0".to_string()),
+            ]
+        );
+
+        let node_modules = project_root.join("node_modules");
+        assert!(node_modules
+            .join("@rpm-fixture")
+            .join("alpha")
+            .join("package.json")
+            .is_file());
+        assert!(node_modules
+            .join("@rpm-fixture")
+            .join("beta")
+            .join("package.json")
+            .is_file());
+        assert!(node_modules
+            .join("@rpm-fixture")
+            .join("shared")
+            .join("package.json")
+            .is_file());
+        assert_eq!(
+            fs::read_link(
+                node_modules
+                    .join("@rpm-fixture")
+                    .join("alpha")
+                    .join("node_modules")
+                    .join("@rpm-fixture")
+                    .join("shared")
+            )
+            .unwrap(),
+            PathBuf::from("../../../../@rpm-fixture/shared")
+        );
+        assert_eq!(
+            fs::read_link(
+                node_modules
+                    .join("@rpm-fixture")
+                    .join("beta")
+                    .join("node_modules")
+                    .join("@rpm-fixture")
+                    .join("shared")
+            )
+            .unwrap(),
+            PathBuf::from("../../../../@rpm-fixture/shared")
+        );
+
+        assert_eq!(
+            sorted_cache_entries(&project_root.join(".rpm/.cache")).unwrap(),
+            vec![
+                "@rpm-fixture-alpha@1.0.0.tgz".to_string(),
+                "@rpm-fixture-beta@1.0.0.tgz".to_string(),
+                "@rpm-fixture-shared@1.0.0.tgz".to_string(),
+            ]
+        );
+        assert_eq!(root_fingerprints(&repo_root).unwrap(), root_before);
+    }
+
+    #[tokio::test]
+    async fn install_failure_preserves_existing_node_modules() {
+        let _guard = INSTALL_TEST_LOCK.lock().unwrap();
+        let fixture_root = fixture_path(&["install-projects", "performance-small"]);
+        let project = TempProject::new("install-failure-preserves-node-modules").unwrap();
+        let package_path = project
+            .copy_fixture(fixture_root.join("package.json"), "package.json")
+            .unwrap();
+        let project_root = package_path.parent().unwrap();
+        let existing_file = project_root.join("node_modules").join("keep.txt");
+        fs::create_dir_all(existing_file.parent().unwrap()).unwrap();
+        fs::write(&existing_file, "existing node_modules content").unwrap();
+        let original_permissions = fs::metadata(&package_path).unwrap().permissions();
+        let mut read_only_permissions = original_permissions.clone();
+        read_only_permissions.set_mode(0o444);
+        fs::set_permissions(&package_path, read_only_permissions).unwrap();
+
+        let _env = FixtureInstallEnv::new(project_root, &fixture_root.join("registry")).unwrap();
+        let error = install().await.unwrap_err();
+        fs::set_permissions(&package_path, original_permissions).unwrap();
+
+        assert!(error
+            .to_string()
+            .contains("failed to open package manifest"));
+        assert_eq!(
+            fs::read_to_string(&existing_file).unwrap(),
+            "existing node_modules content"
+        );
+    }
+
+    fn resolved_packages(lock: &LockFile) -> Vec<String> {
+        let mut packages = lock
+            .get_packages()
+            .into_iter()
+            .map(|(key, dependency)| format!("{key} requested {}", dependency.get_requested()))
+            .collect::<Vec<_>>();
+        packages.sort();
+        packages
+    }
+
+    fn sorted_dependencies(mut dependencies: Vec<(String, String)>) -> Vec<(String, String)> {
+        dependencies.sort();
+        dependencies
+    }
+
+    fn sorted_cache_entries(cache_dir: &Path) -> io::Result<Vec<String>> {
+        let mut entries = fs::read_dir(cache_dir)?
+            .map(|entry| entry.map(|entry| entry.file_name().to_string_lossy().into_owned()))
+            .collect::<io::Result<Vec<_>>>()?;
+        entries.sort();
+        Ok(entries)
+    }
+
+    struct FixtureInstallEnv {
+        original_dir: PathBuf,
+        previous_fixture_root: Option<OsString>,
+    }
+
+    impl FixtureInstallEnv {
+        fn new(project_root: &Path, registry_root: &Path) -> io::Result<Self> {
+            let original_dir = std::env::current_dir()?;
+            let previous_fixture_root = std::env::var_os("RPM_REGISTRY_FIXTURE_ROOT");
+            std::env::set_current_dir(project_root)?;
+            std::env::set_var("RPM_REGISTRY_FIXTURE_ROOT", registry_root);
+            Ok(Self {
+                original_dir,
+                previous_fixture_root,
+            })
+        }
+    }
+
+    impl Drop for FixtureInstallEnv {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.original_dir);
+            match &self.previous_fixture_root {
+                Some(value) => std::env::set_var("RPM_REGISTRY_FIXTURE_ROOT", value),
+                None => std::env::remove_var("RPM_REGISTRY_FIXTURE_ROOT"),
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum PathFingerprint {
+        Missing,
+        File(Vec<u8>),
+        Dir(BTreeMap<String, PathFingerprint>),
+    }
+
+    fn root_fingerprints(repo_root: &Path) -> io::Result<BTreeMap<String, PathFingerprint>> {
+        let mut fingerprints = BTreeMap::new();
+        for path in ["package.json", "rpm.lock", ".rpm", "node_modules"] {
+            fingerprints.insert(path.to_string(), fingerprint_path(&repo_root.join(path))?);
+        }
+        Ok(fingerprints)
+    }
+
+    fn fingerprint_path(path: &Path) -> io::Result<PathFingerprint> {
+        if !path.exists() {
+            return Ok(PathFingerprint::Missing);
+        }
+        if path.is_file() {
+            return fs::read(path).map(PathFingerprint::File);
+        }
+
+        let mut entries = BTreeMap::new();
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            entries.insert(
+                entry.file_name().to_string_lossy().into_owned(),
+                fingerprint_path(&entry.path())?,
+            );
+        }
+        Ok(PathFingerprint::Dir(entries))
+    }
 }

--- a/src/lib/command/working_process/mod.rs
+++ b/src/lib/command/working_process/mod.rs
@@ -2,5 +2,6 @@ mod add;
 mod install;
 mod run;
 pub use add::add;
+pub(crate) use add::add_with_cache_dir;
 pub use install::install;
 pub use run::run;

--- a/src/lib/lockfile/mod.rs
+++ b/src/lib/lockfile/mod.rs
@@ -77,6 +77,24 @@ impl Dependency {
         }
         dependencies
     }
+
+    pub fn get_dependencies(&self) -> Vec<String> {
+        let mut dependencies = self.dependencies.iter().cloned().collect::<Vec<_>>();
+        dependencies.sort();
+        dependencies
+    }
+
+    pub fn get_tarball(&self) -> Option<String> {
+        self.tarball.clone()
+    }
+
+    pub fn get_integrity(&self) -> Option<String> {
+        self.integrity.clone()
+    }
+
+    pub fn get_shasum(&self) -> Option<String> {
+        self.shasum.clone()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -281,6 +299,19 @@ impl LockFile {
 
     pub fn get_dependency(&self, name: &str) -> Option<&Dependency> {
         self.dependencies.get(name)
+    }
+
+    pub fn get_dependency_for_request(
+        &self,
+        package_name: &str,
+        requested: &str,
+    ) -> Option<(String, Dependency)> {
+        self.dependencies
+            .iter()
+            .find(|(_, dependency)| {
+                dependency.name == package_name && dependency.requested == requested
+            })
+            .map(|(key, dependency)| (key.clone(), dependency.clone()))
     }
 }
 

--- a/src/lib/node_linker/mod.rs
+++ b/src/lib/node_linker/mod.rs
@@ -45,7 +45,7 @@ impl NodeModules {
         Self::init_from_paths("node_modules", LOCK_FILE_PATH, CACHE_DIR)
     }
 
-    fn init_from_paths<P, Q, R>(
+    pub(crate) fn init_from_paths<P, Q, R>(
         node_modules_path: P,
         lockfile_path: Q,
         cache_dir: R,

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -320,6 +320,12 @@ impl Registry {
 
         save_tarball(&key, &mut bytes_file)
     }
+
+    pub async fn download_tarball_url(key: &str, tarball_url: &str) -> std::io::Result<()> {
+        let mut bytes_file = api::get_tarball(tarball_url).await?;
+        save_tarball(key, &mut bytes_file)
+    }
+
     /// get dependencies from registry
     /// return dependencies vector
     /// Example:
@@ -556,6 +562,7 @@ mod tests {
     fn semver_registry_fixtures_match_registry_metadata_shape() {
         let fixture_roots = [
             "tests/fixtures/registry/shared-transitive/metadata",
+            "tests/fixtures/install-projects/lockfile-reproducible/registry",
             "tests/fixtures/install-projects/performance-small/registry",
             "tests/fixtures/install-projects/semver-baseline/registry",
             "tests/fixtures/install-projects/semver-unsatisfied/registry",

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -302,6 +302,16 @@ impl Registry {
 
     /// download tarball from registry and return tarball bytes
     pub async fn download_tarball(&self, key: &str, version: &str) -> std::io::Result<()> {
+        self.download_tarball_to_dir(key, version, Path::new(CACHE_DIR))
+            .await
+    }
+
+    pub(crate) async fn download_tarball_to_dir(
+        &self,
+        key: &str,
+        version: &str,
+        cache_dir: &Path,
+    ) -> std::io::Result<()> {
         let url = self
             .get_dist_for_version(version)
             .map(|dist| dist.get_tarball())
@@ -318,12 +328,20 @@ impl Registry {
             key.to_owned()
         };
 
-        save_tarball(&key, &mut bytes_file)
+        save_tarball_to_dir(cache_dir, &key, &mut bytes_file)
     }
 
     pub async fn download_tarball_url(key: &str, tarball_url: &str) -> std::io::Result<()> {
+        Self::download_tarball_url_to_dir(key, tarball_url, Path::new(CACHE_DIR)).await
+    }
+
+    pub(crate) async fn download_tarball_url_to_dir(
+        key: &str,
+        tarball_url: &str,
+        cache_dir: &Path,
+    ) -> std::io::Result<()> {
         let mut bytes_file = api::get_tarball(tarball_url).await?;
-        save_tarball(key, &mut bytes_file)
+        save_tarball_to_dir(cache_dir, key, &mut bytes_file)
     }
 
     /// get dependencies from registry
@@ -352,10 +370,6 @@ impl Registry {
                 .and_then(|dist_tags| dist_tags.get_latest())
         }
     }
-}
-
-fn save_tarball(tarball_name: &str, bytes_file: &mut [u8]) -> Result<(), Error> {
-    save_tarball_to_dir(CACHE_DIR, tarball_name, bytes_file)
 }
 
 pub(crate) fn tarball_cache_file_name(package_name: &str, version: &str) -> String {

--- a/tests/fixtures/install-projects/lockfile-reproducible/expected/resolved-packages.txt
+++ b/tests/fixtures/install-projects/lockfile-reproducible/expected/resolved-packages.txt
@@ -1,0 +1,2 @@
+@rpm-fixture/locked-parent@1.0.0 requested ^1.0.0
+@rpm-fixture/locked-child@1.0.0 requested ^1.0.0

--- a/tests/fixtures/install-projects/lockfile-reproducible/package.json
+++ b/tests/fixtures/install-projects/lockfile-reproducible/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "lockfile-reproducible-app",
+  "version": "0.0.0",
+  "dependencies": {
+    "@rpm-fixture/locked-parent": "^1.0.0"
+  }
+}

--- a/tests/fixtures/install-projects/lockfile-reproducible/registry/@rpm-fixture__locked-child.json
+++ b/tests/fixtures/install-projects/lockfile-reproducible/registry/@rpm-fixture__locked-child.json
@@ -1,0 +1,38 @@
+{
+  "name": "@rpm-fixture/locked-child",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/locked-child",
+      "version": "1.0.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/locked-child/-/locked-child-1.0.0.tgz",
+        "integrity": "sha512-locked-child-100",
+        "shasum": "fixture-locked-child-1-0-0"
+      },
+      "description": "@rpm-fixture/locked-child 1.0.0 fixture"
+    },
+    "1.1.0": {
+      "name": "@rpm-fixture/locked-child",
+      "version": "1.1.0",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/locked-child/-/locked-child-1.1.0.tgz",
+        "integrity": "sha512-locked-child-110",
+        "shasum": "fixture-locked-child-1-1-0"
+      },
+      "description": "@rpm-fixture/locked-child 1.1.0 fixture"
+    }
+  },
+  "_id": "@rpm-fixture/locked-child",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/locked-child fixture"
+}

--- a/tests/fixtures/install-projects/lockfile-reproducible/registry/@rpm-fixture__locked-parent.json
+++ b/tests/fixtures/install-projects/lockfile-reproducible/registry/@rpm-fixture__locked-parent.json
@@ -1,0 +1,42 @@
+{
+  "name": "@rpm-fixture/locked-parent",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/locked-parent",
+      "version": "1.0.0",
+      "dependencies": {
+        "@rpm-fixture/locked-child": "^1.0.0"
+      },
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/locked-parent/-/locked-parent-1.0.0.tgz",
+        "integrity": "sha512-locked-parent-100",
+        "shasum": "fixture-locked-parent-1-0-0"
+      },
+      "description": "@rpm-fixture/locked-parent 1.0.0 fixture"
+    },
+    "1.1.0": {
+      "name": "@rpm-fixture/locked-parent",
+      "version": "1.1.0",
+      "dependencies": {
+        "@rpm-fixture/locked-child": "^1.1.0"
+      },
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/locked-parent/-/locked-parent-1.1.0.tgz",
+        "integrity": "sha512-locked-parent-110",
+        "shasum": "fixture-locked-parent-1-1-0"
+      },
+      "description": "@rpm-fixture/locked-parent 1.1.0 fixture"
+    }
+  },
+  "_id": "@rpm-fixture/locked-parent",
+  "maintainers": [
+    {
+      "name": "rpm-fixture",
+      "email": "fixtures@example.invalid"
+    }
+  ],
+  "description": "@rpm-fixture/locked-parent fixture"
+}

--- a/tests/fixtures/install-projects/lockfile-reproducible/rpm-without-tarballs.lock
+++ b/tests/fixtures/install-projects/lockfile-reproducible/rpm-without-tarballs.lock
@@ -1,0 +1,17 @@
+lockfile_version = 1
+name = "lockfile-reproducible-app"
+version = "0.0.0"
+
+["@rpm-fixture/locked-parent@1.0.0"]
+name = "@rpm-fixture/locked-parent"
+requested = "^1.0.0"
+version = "1.0.0"
+relationship = "direct"
+dependencies = ["@rpm-fixture/locked-child@^1.0.0"]
+
+["@rpm-fixture/locked-child@1.0.0"]
+name = "@rpm-fixture/locked-child"
+requested = "^1.0.0"
+version = "1.0.0"
+relationship = "transitive"
+dependencies = []

--- a/tests/fixtures/install-projects/lockfile-reproducible/rpm.lock
+++ b/tests/fixtures/install-projects/lockfile-reproducible/rpm.lock
@@ -1,0 +1,23 @@
+lockfile_version = 1
+name = "lockfile-reproducible-app"
+version = "0.0.0"
+
+["@rpm-fixture/locked-parent@1.0.0"]
+name = "@rpm-fixture/locked-parent"
+requested = "^1.0.0"
+version = "1.0.0"
+relationship = "direct"
+tarball = "https://registry.example.invalid/@rpm-fixture/locked-parent/-/locked-parent-1.0.0.tgz"
+integrity = "sha512-locked-parent-100"
+shasum = "fixture-locked-parent-1-0-0"
+dependencies = ["@rpm-fixture/locked-child@^1.0.0"]
+
+["@rpm-fixture/locked-child@1.0.0"]
+name = "@rpm-fixture/locked-child"
+requested = "^1.0.0"
+version = "1.0.0"
+relationship = "transitive"
+tarball = "https://registry.example.invalid/@rpm-fixture/locked-child/-/locked-child-1.0.0.tgz"
+integrity = "sha512-locked-child-100"
+shasum = "fixture-locked-child-1-0-0"
+dependencies = []

--- a/tests/fixtures/semver/node-semver/README.md
+++ b/tests/fixtures/semver/node-semver/README.md
@@ -86,7 +86,8 @@ core is expected to pass now:
   partial, hyphen, tilde, caret, union, invalid ranges, spaced operators,
   standalone operators, wildcard ranges with prerelease/build metadata,
   numeric safety boundaries, include-prerelease hyphen ranges, and loose-mode
-  range parsing subsets, including long build metadata stripping
+  range parsing subsets, including loose numeric normalization and long build
+  metadata stripping
 - `satisfies` for exact, wildcard, comparator, spaced comparator, union, caret,
   tilde, `~>` alias, partial, hyphen range forms, and loose-mode include and
   exclude range parsing subsets
@@ -102,10 +103,28 @@ core is expected to pass now:
 The full upstream fixture corpus also covers behavior that remains tracked
 outside this Rust-core subset:
 
-- Remaining advanced loose-mode fixture inventory and classification is
-  tracked by #68.
+- Advanced loose-mode Rust-core cases from the pinned `range-parse.js` corpus
+  are represented in `compatibility-subset.json`, including loose comparator
+  normalization, loose prerelease suffix normalization, loose numeric
+  normalization, and loose long build metadata stripping.
+- Loose-mode range operation cases for `satisfies`, `max_satisfying`,
+  `min_satisfying`, `outside`, `gtr`, `ltr`, and `valid_range` are represented
+  when the upstream input shape maps to RPM's typed Rust APIs.
 - Dist-tags are registry metadata selectors, not semver ranges; that boundary
   is defined in `docs/specs/core/semver/SPEC.md`.
-- JavaScript-only `coerce` object and function input behavior is tracked by
-  #67 because those value kinds do not map directly to the typed Rust string
-  and number APIs.
+- JavaScript-only object, function, `undefined`, and other non-string value
+  shapes are wrapper behavior or intentionally not applicable to the typed Rust
+  APIs. `coerce` object and function input behavior remains tracked by #67.
+
+## JavaScript Wrapper Policy
+
+The Rust core intentionally keeps `coerce` typed as string and numeric APIs.
+Future JavaScript wrappers must map JavaScript-only inputs at the wrapper edge
+as defined in `docs/specs/core/semver/SPEC.md`: arbitrary objects and functions
+are unsupported and must produce the wrapper equivalent of `node-semver`
+`coerce` returning `null`.
+
+No wrapper-level fixtures are present yet because RPM does not currently expose
+a JavaScript semver API. When that API exists, its fixture group should cover
+the JavaScript-only object and function cases separately from this Rust-core
+compatibility subset.

--- a/tests/fixtures/semver/node-semver/compatibility-subset.json
+++ b/tests/fixtures/semver/node-semver/compatibility-subset.json
@@ -1459,6 +1459,11 @@
   "valid_range_loose": [
     [">01.02.03", ">1.2.3"],
     ["~1.2.3beta", ">=1.2.3-beta <1.3.0-0"],
-    [">=09090", ">=9090.0.0"]
+    [">=09090", ">=9090.0.0"],
+    ["4.17.0+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3", "4.17.0"],
+    ["1.2.3+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa - 2.0.0", ">=1.2.3 <=2.0.0"],
+    ["1.2.3+sha512.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "1.2.3"],
+    ["1.2.3+sha256.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "1.2.3"],
+    ["1.2.3+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa || 2.0.0+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "1.2.3||2.0.0"]
   ]
 }


### PR DESCRIPTION
Summary:
- preserve requested dependency ranges in install/add resolution so lockfile request fields remain stable
- document installer/resolver/performance boundaries in ADRs and SPECs
- align semver subset fixtures with the documented spec

Validation:
- Packaging verifier reported clean worktree and verified local commits at `2e01410`, `62e6d02`, `c1ae5db`.
- Commit A validation: `cargo fmt --all --check`, `cargo test add:: --lib`, `cargo test install:: --lib`, `cargo check` passed with `/private/tmp` target dirs.
- Commit B validation: scoped `git diff --check` passed.
- Commit C validation: scoped `git diff --check` and Bun JSON parse passed.

File scope:
- production: `src/core/resolver/mod.rs`, `src/lib/command/working_process/add.rs`, `src/lib/command/working_process/install.rs`, `src/lib/lockfile/mod.rs`, `src/lib/api/mod.rs`, `src/lib/registry/mod.rs`
- docs/spec/ADR: `docs/adrs/0005-installer-performance-measurement-boundary.md`, `docs/adrs/0006-resolver-strategy-boundary.md`, `docs/specs/core/install/performance/SPEC.md`, `docs/specs/core/resolver/SPEC.md`, `docs/specs/core/semver/SPEC.md`
- fixtures: `tests/fixtures/install-projects/lockfile-reproducible/*`, `tests/fixtures/semver/node-semver/*`

Commits in branch:
- `2e01410` Preserve lockfile requests during install resolution
- `62e6d02` Document installer and resolver boundaries
- `c1ae5db` Align semver subset fixtures with spec
