### PR TITLE
chore(repo): enforce PR metadata policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -24,5 +24,4 @@ assignees: ""
 
 ## Related work
 
-<!-- Linked issues, PRs, specs, or notes. -->
-
+<!-- Linked issues, PRs, specs, or notes. Implementation PRs should close this issue with `Closes #<number>` when applicable. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,8 @@
 - [ ] Scope is focused on one behavior, bug, or mechanical change.
 - [ ] Behavior changes include relevant tests or fixtures.
 - [ ] SPEC impact is classified when contract-affecting.
+- [ ] PR has at least one approved label: `bug`, `documentation`, `enhancement`, `refactor`, `planning`, `milestone-contract`, or `process:metadata-cleanup`.
+- [ ] `Closes #` below is replaced with a real issue number so GitHub recognizes the connected issue.
 - [ ] PR is ready for review when implementation is complete.
 
 Closes #
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,8 @@
 - [ ] Behavior changes include relevant tests or fixtures.
 - [ ] SPEC impact is classified when contract-affecting.
 - [ ] PR has at least one approved label: `bug`, `documentation`, `enhancement`, `refactor`, `planning`, `milestone-contract`, or `process:metadata-cleanup`.
-- [ ] `Closes #` below is replaced with a real issue number so GitHub recognizes the connected issue.
+- [ ] `Closes #` below is replaced with a real issue number, or this PR uses the documented `No closing issue: <reason>` exemption.
 - [ ] PR is ready for review when implementation is complete.
 
 Closes #
+<!-- If this PR qualifies for an exemption, replace the closing reference with: No closing issue: <reason> -->

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,31 @@
+name: PR Policy
+
+on:
+  pull_request:
+    branches: ["main"]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  metadata:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check PR metadata policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/check-pr-policy.sh "${{ github.event.pull_request.number }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,8 @@ verify:
   `refactor`, `planning`, `milestone-contract`, or
   `process:metadata-cleanup`
 - at least one GitHub-recognized closing issue reference, for example
-  `Closes #123`
+  `Closes #123`, or an explicit exemption in the PR body using
+  `No closing issue: <reason>`
 
 The PR policy workflow skips draft PRs and enforces this metadata when a PR is
 ready for review. The workflow depends on the approved labels already existing
@@ -59,7 +60,8 @@ Before marking a PR ready:
 
 - run the narrowest relevant validation
 - apply at least one approved label
-- replace the `Closes #` placeholder with a real closing issue reference
+- replace the `Closes #` placeholder with a real closing issue reference or a
+  documented `No closing issue: <reason>` exemption
 - update the PR checklist
 - push the branch
 - list follow-up work instead of expanding scope

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,24 @@ contract issue body. Do not rely on comments alone as the current summary.
 
 Open PRs with a clear summary, validation notes, and a focused checklist. Keep implementation and cleanup separate.
 
+Before a PR is ready for review, it must have repository metadata that CI can
+verify:
+
+- at least one approved label: `bug`, `documentation`, `enhancement`,
+  `refactor`, `planning`, `milestone-contract`, or
+  `process:metadata-cleanup`
+- at least one GitHub-recognized closing issue reference, for example
+  `Closes #123`
+
+The PR policy workflow skips draft PRs and enforces this metadata when a PR is
+ready for review. The workflow depends on the approved labels already existing
+in the repository.
+
 Before marking a PR ready:
 
 - run the narrowest relevant validation
+- apply at least one approved label
+- replace the `Closes #` placeholder with a real closing issue reference
 - update the PR checklist
 - push the branch
 - list follow-up work instead of expanding scope

--- a/scripts/check-pr-policy.sh
+++ b/scripts/check-pr-policy.sh
@@ -54,11 +54,6 @@ fi
 
 pr_ref="${1:-${PR_POLICY_PR_REF:-}}"
 
-if [ -z "${pr_ref}" ] && [ -z "${PR_POLICY_LABELS:-}" ]; then
-  printf 'pr_policy.usage=check-pr-policy.sh [pr-number-or-url]\n'
-  exit 2
-fi
-
 status="ok"
 
 printf 'pr_policy.allowed_labels=%s\n' "$(print_allowed_labels)"
@@ -74,6 +69,11 @@ printf 'pr_policy.draft=%s\n' "${pr_draft}"
 if [ "${pr_draft}" = "true" ]; then
   printf 'pr_policy.status=skipped\n'
   exit 0
+fi
+
+if [ -z "${pr_ref}" ] && [ -z "${PR_POLICY_LABELS:-}" ]; then
+  printf 'pr_policy.usage=check-pr-policy.sh [pr-number-or-url]\n'
+  exit 2
 fi
 
 if [ -n "${PR_POLICY_LABELS:-}" ]; then

--- a/scripts/check-pr-policy.sh
+++ b/scripts/check-pr-policy.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+allowed_labels=(
+  "bug"
+  "documentation"
+  "enhancement"
+  "refactor"
+  "planning"
+  "milestone-contract"
+  "process:metadata-cleanup"
+)
+
+print_allowed_labels() {
+  local separator=""
+  local label
+
+  for label in "${allowed_labels[@]}"; do
+    printf '%s%s' "${separator}" "${label}"
+    separator=","
+  done
+}
+
+label_is_allowed() {
+  local candidate="$1"
+  local label
+
+  for label in "${allowed_labels[@]}"; do
+    if [ "${candidate}" = "${label}" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+has_allowed_label() {
+  local labels="$1"
+  local label
+
+  while IFS= read -r label; do
+    if label_is_allowed "${label}"; then
+      return 0
+    fi
+  done <<< "${labels}"
+
+  return 1
+}
+
+if [ "$#" -gt 1 ]; then
+  printf 'pr_policy.usage=check-pr-policy.sh [pr-number-or-url]\n'
+  exit 2
+fi
+
+pr_ref="${1:-${PR_POLICY_PR_REF:-}}"
+
+if [ -z "${pr_ref}" ] && [ -z "${PR_POLICY_LABELS:-}" ]; then
+  printf 'pr_policy.usage=check-pr-policy.sh [pr-number-or-url]\n'
+  exit 2
+fi
+
+status="ok"
+
+printf 'pr_policy.allowed_labels=%s\n' "$(print_allowed_labels)"
+
+if [ -n "${PR_POLICY_DRAFT:-}" ]; then
+  pr_draft="${PR_POLICY_DRAFT}"
+else
+  pr_draft="$(gh pr view "${pr_ref}" --json isDraft --jq '.isDraft')"
+fi
+
+printf 'pr_policy.draft=%s\n' "${pr_draft}"
+
+if [ "${pr_draft}" = "true" ]; then
+  printf 'pr_policy.status=skipped\n'
+  exit 0
+fi
+
+if [ -n "${PR_POLICY_LABELS:-}" ]; then
+  pr_labels="${PR_POLICY_LABELS}"
+else
+  pr_labels="$(gh pr view "${pr_ref}" --json labels --jq '.labels[].name')"
+fi
+
+if has_allowed_label "${pr_labels}"; then
+  printf 'pr_policy.required_label=ok\n'
+else
+  status="fail"
+  printf 'pr_policy.required_label=missing\n'
+fi
+
+if [ -n "${PR_POLICY_CLOSING_ISSUES_COUNT:-}" ]; then
+  closing_issues_count="${PR_POLICY_CLOSING_ISSUES_COUNT}"
+else
+  closing_issues_count="$(gh pr view "${pr_ref}" --json closingIssuesReferences --jq '.closingIssuesReferences | length')"
+fi
+
+printf 'pr_policy.closing_issues=%s\n' "${closing_issues_count}"
+
+if [ "${closing_issues_count}" -gt 0 ]; then
+  printf 'pr_policy.connected_issue=ok\n'
+else
+  status="fail"
+  printf 'pr_policy.connected_issue=missing\n'
+fi
+
+printf 'pr_policy.status=%s\n' "${status}"
+
+if [ "${status}" != "ok" ]; then
+  exit 1
+fi

--- a/scripts/check-pr-policy.sh
+++ b/scripts/check-pr-policy.sh
@@ -47,6 +47,12 @@ has_allowed_label() {
   return 1
 }
 
+has_closing_issue_exemption() {
+  local body="$1"
+
+  grep -Eq '^No closing issue: .+' <<< "${body}"
+}
+
 if [ "$#" -gt 1 ]; then
   printf 'pr_policy.usage=check-pr-policy.sh [pr-number-or-url]\n'
   exit 2
@@ -100,8 +106,20 @@ printf 'pr_policy.closing_issues=%s\n' "${closing_issues_count}"
 if [ "${closing_issues_count}" -gt 0 ]; then
   printf 'pr_policy.connected_issue=ok\n'
 else
-  status="fail"
   printf 'pr_policy.connected_issue=missing\n'
+
+  if [ -n "${PR_POLICY_BODY:-}" ]; then
+    pr_body="${PR_POLICY_BODY}"
+  else
+    pr_body="$(gh pr view "${pr_ref}" --json body --jq '.body')"
+  fi
+
+  if has_closing_issue_exemption "${pr_body}"; then
+    printf 'pr_policy.closing_issue_exemption=ok\n'
+  else
+    status="fail"
+    printf 'pr_policy.closing_issue_exemption=missing\n'
+  fi
 fi
 
 printf 'pr_policy.status=%s\n' "${status}"


### PR DESCRIPTION
## Summary
- Add a PR Policy workflow and `scripts/check-pr-policy.sh` gate for required PR metadata.
- Document required labels and closing issue references in CONTRIBUTING.md.
- Update the pull request template so authors provide the policy metadata up front.

## Validation
- Policy verification passed for script syntax, policy diff, and draft policy fixture checks.

## Rollout note
- Branch protection and required status checks must be configured separately if this policy should block merges.

Closes #75
