### PR TITLE
docs: define integrity verification gate

### DIFF
--- a/docs/specs/core/install/performance/SPEC.md
+++ b/docs/specs/core/install/performance/SPEC.md
@@ -3,7 +3,7 @@ spec_id: installer_performance
 title: Installer Performance Baseline
 status: draft
 owner: core/install/performance
-last_reviewed: 2026-06-18
+last_reviewed: 2026-06-22
 authors:
   - nerdchanii
 deciders:
@@ -16,13 +16,14 @@ related_adrs:
 related_issues:
   - 50
   - 60
+  - 83
 ---
 
 # Spec: Installer Performance Baseline
 
 Status: Draft
 Owner: core/install/performance
-Last reviewed: 2026-06-18
+Last reviewed: 2026-06-22
 
 ## Purpose
 
@@ -122,10 +123,23 @@ package name and selected version. Resolver event logs may be added later for
 diagnostics, but they are not required for the first installer measurement
 harness.
 
-Before tarball verification is implemented, registry `dist.integrity` is the
-authoritative integrity field when present. Registry `dist.shasum` is the
-legacy fallback when `dist.integrity` is absent. Recording either value before
-verification does not mean RPM has cryptographically verified the tarball.
+## Integrity Gate
+
+M3 defers cryptographic tarball verification. Until a later focused issue
+implements verification, RPM may record registry integrity metadata but must
+not claim that cached tarballs are verified.
+
+When metadata is recorded before verification exists, registry `dist.integrity`
+is the authoritative field when present. Registry `dist.shasum` is the legacy
+fallback when `dist.integrity` is absent. Recording either value in `rpm.lock`
+does not mean RPM has cryptographically verified the downloaded bytes.
+
+A future verification implementation must run after tarball bytes are
+downloaded and before extraction begins. It must define the supported
+Subresource Integrity algorithms, the legacy `shasum` fallback behavior, and
+the error reported when bytes do not match the selected metadata. A verification
+failure must be returned as a failed integrity phase and must not publish
+extracted package contents or report the install as successful.
 
 ## Error Cases
 


### PR DESCRIPTION
## Contract

SPEC status: stale/incomplete gate clarified
SPEC path: `docs/specs/core/install/performance/SPEC.md`

This PR resolves the M3 integrity decision by explicitly deferring cryptographic tarball verification while preserving the current metadata-recording contract for `dist.integrity` and legacy `dist.shasum`. It also defines the timing and failure behavior a future verifier must satisfy before RPM can claim verified tarballs.

## Plan

- [x] Intake passed
- [x] SPEC impact classified
- [x] Implementation complete
- [x] Validation run
- [x] Review resolution complete

## Validation

- `git diff --check`
- Codex review requested twice; accepted date-sync feedback applied, second review found no major issues on `fc210a1e24`.
- Cargo validation not run; this is a docs-only SPEC clarification with no Rust behavior change.

Closes #83