### PR TITLE
docs(spec): audit installer side effects

### DIFF
--- a/docs/specs/core/install/recovery/SPEC.md
+++ b/docs/specs/core/install/recovery/SPEC.md
@@ -3,7 +3,7 @@ spec_id: install_recovery
 title: Install Recovery
 status: draft
 owner: core/install/recovery
-last_reviewed: 2026-05-29
+last_reviewed: 2026-06-22
 authors:
   - nerdchanii
 deciders:
@@ -14,13 +14,14 @@ related_adrs:
   - 0002-single-crate-cli-core-boundary
 related_issues:
   - 50
+  - 79
 ---
 
 # Spec: Install Recovery
 
 Status: Draft
 Owner: core/install/recovery
-Last reviewed: 2026-05-29
+Last reviewed: 2026-06-22
 
 ## Purpose
 
@@ -49,6 +50,24 @@ reported as successful downloads.
 A failed resolve, fetch, extract, or link phase must leave the previous
 `node_modules` directory untouched. A failed write phase must not be reported as
 a successful install.
+
+## M3 Side-Effect Audit
+
+The 2026-06-22 M3 audit classifies current installer side effects against this
+recovery contract and the related cache, lockfile, manifest, linker, resolver,
+and performance SPECs.
+
+| Phase | Code path | State touched | Current tests | SPEC status | Follow-up |
+| --- | --- | --- | --- | --- | --- |
+| read manifest | `install_in` calls `PackageManifest::read_from_path` before later phases | `package.json` read only | manifest parser tests and install fixture copy tests | conforms | none |
+| resolve graph | `add_with_cache_dir` populates metadata and calls `resolve_dependency_graph` before output writes | in-memory graph, lockfile, and manifest state | resolver and install fixture tests | conforms | none |
+| fetch/cache | `Registry::download_tarball*_to_dir` writes tarballs through staged cache publication | `.rpm/.cache` | registry cache write tests and install cache fixture assertions | conforms | none after #82 |
+| extract | `NodeModules::init_from_lockfile` builds a staged `node_modules` tree with `NodeResolver::resolve_deps` | temporary sibling staging directory | linker extract-failure recovery tests | conforms | #81 may add broader phase-boundary fixtures |
+| link | `NodeModules::linking` creates package-local dependency links inside staging | temporary sibling staging directory | linker missing-target recovery tests | conforms | #81 may add broader phase-boundary fixtures |
+| write lockfile | `install_in` backs up install state, writes `rpm.lock`, and restores on later failure | `rpm.lock` and sibling backup | lockfile save tests and output-failure install fixture | conforms | none after #80 |
+| write manifest | `install_in` backs up install state, writes `package.json`, and restores on later failure | `package.json` and sibling backup | manifest save tests, read-only manifest test, and output-failure install fixture | conforms | none after #80 |
+| replace output | `replace_node_modules` renames staged output into place and restores a backup on write failure | `node_modules` and sibling backup | staged replacement success plus extract/link failure recovery tests | conforms | #81 may add a direct replacement-failure fixture |
+| integrity gate | installer records `dist.integrity` or `dist.shasum`; it does not verify tarballs before extraction | lockfile metadata only | lockfile and registry metadata fixture tests | conforms | #83 owns the verification gate |
 
 ## Test Fixtures
 


### PR DESCRIPTION
## Contract

SPEC status: conforms
SPEC path: docs/specs/core/install/recovery/SPEC.md

## Plan

- [x] Intake passed
- [x] SPEC impact classified
- [x] Implementation complete
- [x] Validation run
- [x] Review requested

## Summary

- Add the M3 side-effect audit matrix to the install recovery SPEC.
- Classify read, resolve, fetch/cache, extract, link, write, replace, and integrity-gate phases.
- Confirm #80 and #82 are sufficient after their merged fixes, while #81 and #83 remain focused follow-ups.

## Validation

- [x] `cargo check`
- [x] GitHub Rust `verify` check passed

## Review

- Codex review was requested with `scripts/watch-codex-review.sh 87 --request-review --format jsonl`.
- The Codex connector reported code-review usage limits, so no review feedback was available to resolve in this run.

Closes #79
