### PR TITLE
install: verify tarball integrity before extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -944,6 +944,7 @@ name = "rpm"
 version = "0.1.0"
 dependencies = [
  "async-recursion",
+ "base64",
  "chrono",
  "flate2",
  "memmap",
@@ -951,6 +952,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "structopt",
  "tar",
@@ -1074,6 +1076,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ harness = false
 
 [dependencies]
 async-recursion = "1.0.2"
+base64 = "0.21.0"
 chrono = "0.4.24"
 flate2 = "1.0.25"
 memmap = "0.7.0"
@@ -27,6 +28,7 @@ regex = "1.7.0"
 reqwest = { version = "0.11.14", features = ["json"] }
 serde = { version = "1.0.155", features = ["derive"] }
 serde_json = "1.0.94"
+sha1 = "0.10.6"
 sha2 = "0.10.6"
 structopt = "0.3.26"
 tar = "0.4.38"

--- a/benches/BENCHMARKS.md
+++ b/benches/BENCHMARKS.md
@@ -1,8 +1,8 @@
 ---
-benchmark_data: benches/histories/2026-06-22-001/benchmarks.json
-benchmark_chart: benches/histories/2026-06-22-001/benchmark.svg
-history_directory: benches/histories/2026-06-22-001
-generated_at: 2026-06-22T08:20:24.975Z
+benchmark_data: benches/histories/2026-06-22-002/benchmarks.json
+benchmark_chart: benches/histories/2026-06-22-002/benchmark.svg
+history_directory: benches/histories/2026-06-22-002
+generated_at: 2026-06-22T10:03:30.871Z
 status: "Representative suite"
 ---
 
@@ -10,7 +10,7 @@ status: "Representative suite"
 
 Status: Representative suite
 Date: 2026-06-22
-History directory: `benches/histories/2026-06-22-001`
+History directory: `benches/histories/2026-06-22-002`
 
 ## Command
 
@@ -38,14 +38,14 @@ node scripts/benchmark-semver.mjs
 
 | Operation | RPM Rust mean ns/iter | node-semver mean ns/iter | Rust speedup |
 | --- | ---: | ---: | ---: |
-| version_parse | 1,975.2 | 5,060 | 2.56x |
-| valid_canonical | 3,961.4 | 4,960.2 | 1.25x |
-| invalid_version | 505.2 | 22,101.2 | 43.75x |
-| range_parse | 4,648 | 3,930.6 | 0.85x |
-| invalid_range | 1,400.6 | 48,214.2 | 34.42x |
-| satisfies | 4,075.6 | 5,169.2 | 1.27x |
-| max_satisfying | 5,280.8 | 26,006.4 | 4.92x |
-| min_satisfying | 5,265 | 21,893.4 | 4.16x |
+| version_parse | 2,148 | 4,776.6 | 2.22x |
+| valid_canonical | 3,964.2 | 4,903 | 1.24x |
+| invalid_version | 469.6 | 22,571.8 | 48.07x |
+| range_parse | 4,473.2 | 4,021.2 | 0.90x |
+| invalid_range | 1,429.8 | 47,552.8 | 33.26x |
+| satisfies | 4,197.4 | 5,192 | 1.24x |
+| max_satisfying | 5,230 | 26,371.8 | 5.04x |
+| min_satisfying | 5,197 | 20,631.2 | 3.97x |
 
 ## Notes
 

--- a/benches/BENCHMARKS.md
+++ b/benches/BENCHMARKS.md
@@ -1,16 +1,16 @@
 ---
-benchmark_data: benches/histories/2026-06-16-002/benchmarks.json
-benchmark_chart: benches/histories/2026-06-16-002/benchmark.svg
-history_directory: benches/histories/2026-06-16-002
-generated_at: 2026-06-16T04:25:01.398Z
+benchmark_data: benches/histories/2026-06-22-000/benchmarks.json
+benchmark_chart: benches/histories/2026-06-22-000/benchmark.svg
+history_directory: benches/histories/2026-06-22-000
+generated_at: 2026-06-22T06:20:11.055Z
 status: "Representative suite"
 ---
 
 # Semver Benchmark Checkpoint
 
 Status: Representative suite
-Date: 2026-06-16
-History directory: `benches/histories/2026-06-16-002`
+Date: 2026-06-22
+History directory: `benches/histories/2026-06-22-000`
 
 ## Command
 
@@ -38,14 +38,14 @@ node scripts/benchmark-semver.mjs
 
 | Operation | RPM Rust mean ns/iter | node-semver mean ns/iter | Rust speedup |
 | --- | ---: | ---: | ---: |
-| version_parse | 1,941.2 | 5,635.4 | 2.90x |
-| valid_canonical | 3,911.6 | 4,988.6 | 1.28x |
-| invalid_version | 503 | 24,519 | 48.75x |
-| range_parse | 4,816.2 | 4,998.6 | 1.04x |
-| invalid_range | 1,394.8 | 64,006.2 | 45.89x |
-| satisfies | 4,246.2 | 6,380.4 | 1.50x |
-| max_satisfying | 5,763 | 31,960.8 | 5.55x |
-| min_satisfying | 5,373.4 | 24,837.4 | 4.62x |
+| version_parse | 2,414 | 5,498.8 | 2.28x |
+| valid_canonical | 4,791.2 | 6,257.6 | 1.31x |
+| invalid_version | 598.2 | 28,989.6 | 48.46x |
+| range_parse | 5,933.6 | 5,067.6 | 0.85x |
+| invalid_range | 1,926.2 | 63,877 | 33.16x |
+| satisfies | 5,410 | 6,041 | 1.12x |
+| max_satisfying | 7,306.6 | 34,251.8 | 4.69x |
+| min_satisfying | 7,030.2 | 25,525.8 | 3.63x |
 
 ## Notes
 

--- a/benches/BENCHMARKS.md
+++ b/benches/BENCHMARKS.md
@@ -1,8 +1,8 @@
 ---
-benchmark_data: benches/histories/2026-06-22-002/benchmarks.json
-benchmark_chart: benches/histories/2026-06-22-002/benchmark.svg
-history_directory: benches/histories/2026-06-22-002
-generated_at: 2026-06-22T10:03:30.871Z
+benchmark_data: benches/histories/2026-06-22-003/benchmarks.json
+benchmark_chart: benches/histories/2026-06-22-003/benchmark.svg
+history_directory: benches/histories/2026-06-22-003
+generated_at: 2026-06-22T10:07:58.941Z
 status: "Representative suite"
 ---
 
@@ -10,7 +10,7 @@ status: "Representative suite"
 
 Status: Representative suite
 Date: 2026-06-22
-History directory: `benches/histories/2026-06-22-002`
+History directory: `benches/histories/2026-06-22-003`
 
 ## Command
 
@@ -38,14 +38,14 @@ node scripts/benchmark-semver.mjs
 
 | Operation | RPM Rust mean ns/iter | node-semver mean ns/iter | Rust speedup |
 | --- | ---: | ---: | ---: |
-| version_parse | 2,148 | 4,776.6 | 2.22x |
-| valid_canonical | 3,964.2 | 4,903 | 1.24x |
-| invalid_version | 469.6 | 22,571.8 | 48.07x |
-| range_parse | 4,473.2 | 4,021.2 | 0.90x |
-| invalid_range | 1,429.8 | 47,552.8 | 33.26x |
-| satisfies | 4,197.4 | 5,192 | 1.24x |
-| max_satisfying | 5,230 | 26,371.8 | 5.04x |
-| min_satisfying | 5,197 | 20,631.2 | 3.97x |
+| version_parse | 2,167.8 | 5,589.4 | 2.58x |
+| valid_canonical | 4,077.6 | 5,805.4 | 1.42x |
+| invalid_version | 532.4 | 28,893.2 | 54.27x |
+| range_parse | 5,640.4 | 5,077.2 | 0.90x |
+| invalid_range | 1,738 | 59,550.8 | 34.26x |
+| satisfies | 4,947 | 6,512.4 | 1.32x |
+| max_satisfying | 6,777 | 33,920.8 | 5.01x |
+| min_satisfying | 6,307.8 | 25,238.8 | 4.00x |
 
 ## Notes
 

--- a/benches/BENCHMARKS.md
+++ b/benches/BENCHMARKS.md
@@ -1,8 +1,8 @@
 ---
-benchmark_data: benches/histories/2026-06-22-000/benchmarks.json
-benchmark_chart: benches/histories/2026-06-22-000/benchmark.svg
-history_directory: benches/histories/2026-06-22-000
-generated_at: 2026-06-22T06:20:11.055Z
+benchmark_data: benches/histories/2026-06-22-001/benchmarks.json
+benchmark_chart: benches/histories/2026-06-22-001/benchmark.svg
+history_directory: benches/histories/2026-06-22-001
+generated_at: 2026-06-22T08:20:24.975Z
 status: "Representative suite"
 ---
 
@@ -10,7 +10,7 @@ status: "Representative suite"
 
 Status: Representative suite
 Date: 2026-06-22
-History directory: `benches/histories/2026-06-22-000`
+History directory: `benches/histories/2026-06-22-001`
 
 ## Command
 
@@ -38,14 +38,14 @@ node scripts/benchmark-semver.mjs
 
 | Operation | RPM Rust mean ns/iter | node-semver mean ns/iter | Rust speedup |
 | --- | ---: | ---: | ---: |
-| version_parse | 2,414 | 5,498.8 | 2.28x |
-| valid_canonical | 4,791.2 | 6,257.6 | 1.31x |
-| invalid_version | 598.2 | 28,989.6 | 48.46x |
-| range_parse | 5,933.6 | 5,067.6 | 0.85x |
-| invalid_range | 1,926.2 | 63,877 | 33.16x |
-| satisfies | 5,410 | 6,041 | 1.12x |
-| max_satisfying | 7,306.6 | 34,251.8 | 4.69x |
-| min_satisfying | 7,030.2 | 25,525.8 | 3.63x |
+| version_parse | 1,975.2 | 5,060 | 2.56x |
+| valid_canonical | 3,961.4 | 4,960.2 | 1.25x |
+| invalid_version | 505.2 | 22,101.2 | 43.75x |
+| range_parse | 4,648 | 3,930.6 | 0.85x |
+| invalid_range | 1,400.6 | 48,214.2 | 34.42x |
+| satisfies | 4,075.6 | 5,169.2 | 1.27x |
+| max_satisfying | 5,280.8 | 26,006.4 | 4.92x |
+| min_satisfying | 5,265 | 21,893.4 | 4.16x |
 
 ## Notes
 

--- a/benches/histories/2026-06-22-000/benchmark.svg
+++ b/benches/histories/2026-06-22-000/benchmark.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="438" viewBox="0 0 980 438" role="img" aria-labelledby="title desc">
+  <title id="title">Semver benchmark comparison</title>
+  <desc id="desc">Mean nanoseconds per iteration for RPM Rust and node-semver benchmark operations.</desc>
+  <style>
+    text { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .title { font-size: 22px; font-weight: 700; fill: #111827; }
+    .meta { font-size: 12px; fill: #4b5563; }
+    .legend { font-size: 12px; fill: #374151; }
+    .label { font-size: 12px; fill: #111827; }
+    .value { font-size: 11px; fill: #374151; }
+    .speed { font-size: 12px; font-weight: 700; fill: #111827; text-anchor: end; }
+  </style>
+  <rect width="980" height="438" fill="#ffffff"/>
+  <text x="24" y="34" class="title">Semver benchmark comparison</text>
+  <text x="24" y="56" class="meta">2026-06-22T06:20:11.055Z · 50000 iterations · 5 samples</text>
+  <rect x="24" y="72" width="12" height="12" fill="#2563eb"/>
+  <text x="42" y="82" class="legend">RPM Rust</text>
+  <rect x="126" y="72" width="12" height="12" fill="#f97316"/>
+  <text x="144" y="82" class="legend">node-semver</text>
+  <text x="956" y="82" class="legend" text-anchor="end">Rust speedup</text>
+
+  <text x="24" y="117" class="label">version_parse</text>
+  <rect x="190" y="100" width="21" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="116" width="48" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="111" class="value">2414 ns</text>
+  <text x="768" y="127" class="value">5498.8 ns</text>
+  <text x="868" y="119" class="speed">2.28x</text>
+
+  <text x="24" y="153" class="label">valid_canonical</text>
+  <rect x="190" y="136" width="42" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="152" width="55" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="147" class="value">4791.2 ns</text>
+  <text x="768" y="163" class="value">6257.6 ns</text>
+  <text x="868" y="155" class="speed">1.31x</text>
+
+  <text x="24" y="189" class="label">invalid_version</text>
+  <rect x="190" y="172" width="5" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="188" width="254" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="183" class="value">598.2 ns</text>
+  <text x="768" y="199" class="value">28989.6 ns</text>
+  <text x="868" y="191" class="speed">48.46x</text>
+
+  <text x="24" y="225" class="label">range_parse</text>
+  <rect x="190" y="208" width="52" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="224" width="44" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="219" class="value">5933.6 ns</text>
+  <text x="768" y="235" class="value">5067.6 ns</text>
+  <text x="868" y="227" class="speed">0.85x</text>
+
+  <text x="24" y="261" class="label">invalid_range</text>
+  <rect x="190" y="244" width="17" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="260" width="560" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="255" class="value">1926.2 ns</text>
+  <text x="768" y="271" class="value">63877 ns</text>
+  <text x="868" y="263" class="speed">33.16x</text>
+
+  <text x="24" y="297" class="label">satisfies</text>
+  <rect x="190" y="280" width="47" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="296" width="53" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="291" class="value">5410 ns</text>
+  <text x="768" y="307" class="value">6041 ns</text>
+  <text x="868" y="299" class="speed">1.12x</text>
+
+  <text x="24" y="333" class="label">max_satisfying</text>
+  <rect x="190" y="316" width="64" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="332" width="300" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="327" class="value">7306.6 ns</text>
+  <text x="768" y="343" class="value">34251.8 ns</text>
+  <text x="868" y="335" class="speed">4.69x</text>
+
+  <text x="24" y="369" class="label">min_satisfying</text>
+  <rect x="190" y="352" width="62" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="368" width="224" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="363" class="value">7030.2 ns</text>
+  <text x="768" y="379" class="value">25525.8 ns</text>
+  <text x="868" y="371" class="speed">3.63x</text>
+</svg>

--- a/benches/histories/2026-06-22-000/benchmarks.json
+++ b/benches/histories/2026-06-22-000/benchmarks.json
@@ -1,0 +1,728 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-06-22T06:20:11.055Z",
+  "startedAt": "2026-06-22T06:17:42.458Z",
+  "outputDir": "benches/histories/2026-06-22-000",
+  "history": {
+    "root": "benches/histories",
+    "directory": "2026-06-22-000"
+  },
+  "settings": {
+    "iterations": 50000,
+    "samples": 5,
+    "warmupSamples": 1
+  },
+  "commands": [
+    {
+      "implementation": "rpm-rust",
+      "command": "cargo bench --bench semver --quiet"
+    },
+    {
+      "implementation": "node-semver",
+      "command": "node scripts/benchmark-node-semver.mjs"
+    }
+  ],
+  "runs": [
+    {
+      "implementation": "rpm-rust",
+      "command": "cargo bench --bench semver --quiet",
+      "metadata": {
+        "implementation": "rpm-rust",
+        "crate_version": "0.1.0",
+        "rustc_version": "rustc 1.96.0 (ac68faa20 2026-05-25)",
+        "target_os": "macos",
+        "target_arch": "aarch64",
+        "iterations": "50000",
+        "samples": "5",
+        "warmup_samples": "1",
+        "outlier_policy": "record_all_samples"
+      },
+      "samples": [
+        {
+          "operation": "version_parse",
+          "sample": 1,
+          "totalMs": 113.461,
+          "nsPerIter": 2269
+        },
+        {
+          "operation": "version_parse",
+          "sample": 2,
+          "totalMs": 124.411,
+          "nsPerIter": 2488
+        },
+        {
+          "operation": "version_parse",
+          "sample": 3,
+          "totalMs": 121.09,
+          "nsPerIter": 2421
+        },
+        {
+          "operation": "version_parse",
+          "sample": 4,
+          "totalMs": 128.82,
+          "nsPerIter": 2576
+        },
+        {
+          "operation": "version_parse",
+          "sample": 5,
+          "totalMs": 115.821,
+          "nsPerIter": 2316
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 1,
+          "totalMs": 245.919,
+          "nsPerIter": 4918
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 2,
+          "totalMs": 238.841,
+          "nsPerIter": 4776
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 3,
+          "totalMs": 232.854,
+          "nsPerIter": 4657
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 4,
+          "totalMs": 238.909,
+          "nsPerIter": 4778
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 5,
+          "totalMs": 241.4,
+          "nsPerIter": 4827
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 1,
+          "totalMs": 31.967,
+          "nsPerIter": 639
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 2,
+          "totalMs": 26.113,
+          "nsPerIter": 522
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 3,
+          "totalMs": 32.485,
+          "nsPerIter": 649
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 4,
+          "totalMs": 28.187,
+          "nsPerIter": 563
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 5,
+          "totalMs": 30.922,
+          "nsPerIter": 618
+        },
+        {
+          "operation": "range_parse",
+          "sample": 1,
+          "totalMs": 330.65,
+          "nsPerIter": 6612
+        },
+        {
+          "operation": "range_parse",
+          "sample": 2,
+          "totalMs": 265.971,
+          "nsPerIter": 5319
+        },
+        {
+          "operation": "range_parse",
+          "sample": 3,
+          "totalMs": 302.72,
+          "nsPerIter": 6054
+        },
+        {
+          "operation": "range_parse",
+          "sample": 4,
+          "totalMs": 289.19,
+          "nsPerIter": 5783
+        },
+        {
+          "operation": "range_parse",
+          "sample": 5,
+          "totalMs": 295.004,
+          "nsPerIter": 5900
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 1,
+          "totalMs": 91.142,
+          "nsPerIter": 1822
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 2,
+          "totalMs": 80.722,
+          "nsPerIter": 1614
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 3,
+          "totalMs": 117.126,
+          "nsPerIter": 2342
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 4,
+          "totalMs": 103.61,
+          "nsPerIter": 2072
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 5,
+          "totalMs": 89.091,
+          "nsPerIter": 1781
+        },
+        {
+          "operation": "satisfies",
+          "sample": 1,
+          "totalMs": 243.803,
+          "nsPerIter": 4876
+        },
+        {
+          "operation": "satisfies",
+          "sample": 2,
+          "totalMs": 269.142,
+          "nsPerIter": 5382
+        },
+        {
+          "operation": "satisfies",
+          "sample": 3,
+          "totalMs": 259.283,
+          "nsPerIter": 5185
+        },
+        {
+          "operation": "satisfies",
+          "sample": 4,
+          "totalMs": 286.532,
+          "nsPerIter": 5730
+        },
+        {
+          "operation": "satisfies",
+          "sample": 5,
+          "totalMs": 293.861,
+          "nsPerIter": 5877
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 1,
+          "totalMs": 458.888,
+          "nsPerIter": 9177
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 2,
+          "totalMs": 344.953,
+          "nsPerIter": 6899
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 3,
+          "totalMs": 299.594,
+          "nsPerIter": 5991
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 4,
+          "totalMs": 360.28,
+          "nsPerIter": 7205
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 5,
+          "totalMs": 363.063,
+          "nsPerIter": 7261
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 1,
+          "totalMs": 374.171,
+          "nsPerIter": 7483
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 2,
+          "totalMs": 349.3,
+          "nsPerIter": 6985
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 3,
+          "totalMs": 348.298,
+          "nsPerIter": 6965
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 4,
+          "totalMs": 339.089,
+          "nsPerIter": 6781
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 5,
+          "totalMs": 346.86,
+          "nsPerIter": 6937
+        }
+      ],
+      "rawOutput": "semver benchmark suite=representative\nmetadata,key,value\nmetadata,implementation,rpm-rust\nmetadata,crate_version,0.1.0\nmetadata,rustc_version,rustc 1.96.0 (ac68faa20 2026-05-25)\nmetadata,target_os,macos\nmetadata,target_arch,aarch64\nmetadata,iterations,50000\nmetadata,samples,5\nmetadata,warmup_samples,1\nmetadata,outlier_policy,record_all_samples\nname,sample,total_ms,ns_per_iter\nversion_parse,1,113.461,2269\nversion_parse,2,124.411,2488\nversion_parse,3,121.090,2421\nversion_parse,4,128.820,2576\nversion_parse,5,115.821,2316\nvalid_canonical,1,245.919,4918\nvalid_canonical,2,238.841,4776\nvalid_canonical,3,232.854,4657\nvalid_canonical,4,238.909,4778\nvalid_canonical,5,241.400,4827\ninvalid_version,1,31.967,639\ninvalid_version,2,26.113,522\ninvalid_version,3,32.485,649\ninvalid_version,4,28.187,563\ninvalid_version,5,30.922,618\nrange_parse,1,330.650,6612\nrange_parse,2,265.971,5319\nrange_parse,3,302.720,6054\nrange_parse,4,289.190,5783\nrange_parse,5,295.004,5900\ninvalid_range,1,91.142,1822\ninvalid_range,2,80.722,1614\ninvalid_range,3,117.126,2342\ninvalid_range,4,103.610,2072\ninvalid_range,5,89.091,1781\nsatisfies,1,243.803,4876\nsatisfies,2,269.142,5382\nsatisfies,3,259.283,5185\nsatisfies,4,286.532,5730\nsatisfies,5,293.861,5877\nmax_satisfying,1,458.888,9177\nmax_satisfying,2,344.953,6899\nmax_satisfying,3,299.594,5991\nmax_satisfying,4,360.280,7205\nmax_satisfying,5,363.063,7261\nmin_satisfying,1,374.171,7483\nmin_satisfying,2,349.300,6985\nmin_satisfying,3,348.298,6965\nmin_satisfying,4,339.089,6781\nmin_satisfying,5,346.860,6937"
+    },
+    {
+      "implementation": "node-semver",
+      "command": "node scripts/benchmark-node-semver.mjs",
+      "metadata": {
+        "implementation": "node-semver",
+        "node_version": "v22.22.3",
+        "npm_version": "10.9.8",
+        "node_semver_version": "7.8.2",
+        "platform": "darwin",
+        "arch": "arm64",
+        "iterations": "50000",
+        "samples": "5",
+        "warmup_samples": "1",
+        "outlier_policy": "record_all_samples"
+      },
+      "samples": [
+        {
+          "operation": "version_parse",
+          "sample": 1,
+          "totalMs": 262.317,
+          "nsPerIter": 5246
+        },
+        {
+          "operation": "version_parse",
+          "sample": 2,
+          "totalMs": 276.881,
+          "nsPerIter": 5537
+        },
+        {
+          "operation": "version_parse",
+          "sample": 3,
+          "totalMs": 278.908,
+          "nsPerIter": 5578
+        },
+        {
+          "operation": "version_parse",
+          "sample": 4,
+          "totalMs": 265.376,
+          "nsPerIter": 5307
+        },
+        {
+          "operation": "version_parse",
+          "sample": 5,
+          "totalMs": 291.347,
+          "nsPerIter": 5826
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 1,
+          "totalMs": 334.074,
+          "nsPerIter": 6681
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 2,
+          "totalMs": 336.723,
+          "nsPerIter": 6734
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 3,
+          "totalMs": 297.315,
+          "nsPerIter": 5946
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 4,
+          "totalMs": 298.255,
+          "nsPerIter": 5965
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 5,
+          "totalMs": 298.146,
+          "nsPerIter": 5962
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 1,
+          "totalMs": 1367.242,
+          "nsPerIter": 27344
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 2,
+          "totalMs": 1358.591,
+          "nsPerIter": 27171
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 3,
+          "totalMs": 1517.354,
+          "nsPerIter": 30347
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 4,
+          "totalMs": 1583.317,
+          "nsPerIter": 31666
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 5,
+          "totalMs": 1421.007,
+          "nsPerIter": 28420
+        },
+        {
+          "operation": "range_parse",
+          "sample": 1,
+          "totalMs": 309.535,
+          "nsPerIter": 6190
+        },
+        {
+          "operation": "range_parse",
+          "sample": 2,
+          "totalMs": 253.686,
+          "nsPerIter": 5073
+        },
+        {
+          "operation": "range_parse",
+          "sample": 3,
+          "totalMs": 235.378,
+          "nsPerIter": 4707
+        },
+        {
+          "operation": "range_parse",
+          "sample": 4,
+          "totalMs": 235.645,
+          "nsPerIter": 4712
+        },
+        {
+          "operation": "range_parse",
+          "sample": 5,
+          "totalMs": 232.804,
+          "nsPerIter": 4656
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 1,
+          "totalMs": 3206.884,
+          "nsPerIter": 64137
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 2,
+          "totalMs": 3608.837,
+          "nsPerIter": 72176
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 3,
+          "totalMs": 3125.733,
+          "nsPerIter": 62514
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 4,
+          "totalMs": 2928.517,
+          "nsPerIter": 58570
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 5,
+          "totalMs": 3099.405,
+          "nsPerIter": 61988
+        },
+        {
+          "operation": "satisfies",
+          "sample": 1,
+          "totalMs": 352.256,
+          "nsPerIter": 7045
+        },
+        {
+          "operation": "satisfies",
+          "sample": 2,
+          "totalMs": 267.901,
+          "nsPerIter": 5358
+        },
+        {
+          "operation": "satisfies",
+          "sample": 3,
+          "totalMs": 289.992,
+          "nsPerIter": 5799
+        },
+        {
+          "operation": "satisfies",
+          "sample": 4,
+          "totalMs": 273.339,
+          "nsPerIter": 5466
+        },
+        {
+          "operation": "satisfies",
+          "sample": 5,
+          "totalMs": 326.888,
+          "nsPerIter": 6537
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 1,
+          "totalMs": 1926.612,
+          "nsPerIter": 38532
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 2,
+          "totalMs": 1949.28,
+          "nsPerIter": 38985
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 3,
+          "totalMs": 1502.127,
+          "nsPerIter": 30042
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 4,
+          "totalMs": 1507.303,
+          "nsPerIter": 30146
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 5,
+          "totalMs": 1677.727,
+          "nsPerIter": 33554
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 1,
+          "totalMs": 1180.805,
+          "nsPerIter": 23616
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 2,
+          "totalMs": 1262.32,
+          "nsPerIter": 25246
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 3,
+          "totalMs": 1328.907,
+          "nsPerIter": 26578
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 4,
+          "totalMs": 1266.854,
+          "nsPerIter": 25337
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 5,
+          "totalMs": 1342.614,
+          "nsPerIter": 26852
+        }
+      ],
+      "rawOutput": "semver benchmark suite=representative\nmetadata,key,value\nmetadata,implementation,node-semver\nmetadata,node_version,v22.22.3\nmetadata,npm_version,10.9.8\nmetadata,node_semver_version,7.8.2\nmetadata,platform,darwin\nmetadata,arch,arm64\nmetadata,iterations,50000\nmetadata,samples,5\nmetadata,warmup_samples,1\nmetadata,outlier_policy,record_all_samples\nname,sample,total_ms,ns_per_iter\nversion_parse,1,262.317,5246\nversion_parse,2,276.881,5537\nversion_parse,3,278.908,5578\nversion_parse,4,265.376,5307\nversion_parse,5,291.347,5826\nvalid_canonical,1,334.074,6681\nvalid_canonical,2,336.723,6734\nvalid_canonical,3,297.315,5946\nvalid_canonical,4,298.255,5965\nvalid_canonical,5,298.146,5962\ninvalid_version,1,1367.242,27344\ninvalid_version,2,1358.591,27171\ninvalid_version,3,1517.354,30347\ninvalid_version,4,1583.317,31666\ninvalid_version,5,1421.007,28420\nrange_parse,1,309.535,6190\nrange_parse,2,253.686,5073\nrange_parse,3,235.378,4707\nrange_parse,4,235.645,4712\nrange_parse,5,232.804,4656\ninvalid_range,1,3206.884,64137\ninvalid_range,2,3608.837,72176\ninvalid_range,3,3125.733,62514\ninvalid_range,4,2928.517,58570\ninvalid_range,5,3099.405,61988\nsatisfies,1,352.256,7045\nsatisfies,2,267.901,5358\nsatisfies,3,289.992,5799\nsatisfies,4,273.339,5466\nsatisfies,5,326.888,6537\nmax_satisfying,1,1926.612,38532\nmax_satisfying,2,1949.280,38985\nmax_satisfying,3,1502.127,30042\nmax_satisfying,4,1507.303,30146\nmax_satisfying,5,1677.727,33554\nmin_satisfying,1,1180.805,23616\nmin_satisfying,2,1262.320,25246\nmin_satisfying,3,1328.907,26578\nmin_satisfying,4,1266.854,25337\nmin_satisfying,5,1342.614,26852"
+    }
+  ],
+  "summaries": {
+    "rpm-rust": {
+      "version_parse": {
+        "meanNsPerIter": 2414,
+        "medianNsPerIter": 2421,
+        "minNsPerIter": 2269,
+        "maxNsPerIter": 2576,
+        "stddevNsPerIter": 111.71,
+        "samples": 5
+      },
+      "valid_canonical": {
+        "meanNsPerIter": 4791.2,
+        "medianNsPerIter": 4778,
+        "minNsPerIter": 4657,
+        "maxNsPerIter": 4918,
+        "stddevNsPerIter": 84.59,
+        "samples": 5
+      },
+      "invalid_version": {
+        "meanNsPerIter": 598.2,
+        "medianNsPerIter": 618,
+        "minNsPerIter": 522,
+        "maxNsPerIter": 649,
+        "stddevNsPerIter": 48.34,
+        "samples": 5
+      },
+      "range_parse": {
+        "meanNsPerIter": 5933.6,
+        "medianNsPerIter": 5900,
+        "minNsPerIter": 5319,
+        "maxNsPerIter": 6612,
+        "stddevNsPerIter": 418.63,
+        "samples": 5
+      },
+      "invalid_range": {
+        "meanNsPerIter": 1926.2,
+        "medianNsPerIter": 1822,
+        "minNsPerIter": 1614,
+        "maxNsPerIter": 2342,
+        "stddevNsPerIter": 254.38,
+        "samples": 5
+      },
+      "satisfies": {
+        "meanNsPerIter": 5410,
+        "medianNsPerIter": 5382,
+        "minNsPerIter": 4876,
+        "maxNsPerIter": 5877,
+        "stddevNsPerIter": 362.51,
+        "samples": 5
+      },
+      "max_satisfying": {
+        "meanNsPerIter": 7306.6,
+        "medianNsPerIter": 7205,
+        "minNsPerIter": 5991,
+        "maxNsPerIter": 9177,
+        "stddevNsPerIter": 1039.97,
+        "samples": 5
+      },
+      "min_satisfying": {
+        "meanNsPerIter": 7030.2,
+        "medianNsPerIter": 6965,
+        "minNsPerIter": 6781,
+        "maxNsPerIter": 7483,
+        "stddevNsPerIter": 237.53,
+        "samples": 5
+      }
+    },
+    "node-semver": {
+      "version_parse": {
+        "meanNsPerIter": 5498.8,
+        "medianNsPerIter": 5537,
+        "minNsPerIter": 5246,
+        "maxNsPerIter": 5826,
+        "stddevNsPerIter": 207.6,
+        "samples": 5
+      },
+      "valid_canonical": {
+        "meanNsPerIter": 6257.6,
+        "medianNsPerIter": 5965,
+        "minNsPerIter": 5946,
+        "maxNsPerIter": 6734,
+        "stddevNsPerIter": 367.78,
+        "samples": 5
+      },
+      "invalid_version": {
+        "meanNsPerIter": 28989.6,
+        "medianNsPerIter": 28420,
+        "minNsPerIter": 27171,
+        "maxNsPerIter": 31666,
+        "stddevNsPerIter": 1751.88,
+        "samples": 5
+      },
+      "range_parse": {
+        "meanNsPerIter": 5067.6,
+        "medianNsPerIter": 4712,
+        "minNsPerIter": 4656,
+        "maxNsPerIter": 6190,
+        "stddevNsPerIter": 580.64,
+        "samples": 5
+      },
+      "invalid_range": {
+        "meanNsPerIter": 63877,
+        "medianNsPerIter": 62514,
+        "minNsPerIter": 58570,
+        "maxNsPerIter": 72176,
+        "stddevNsPerIter": 4528.38,
+        "samples": 5
+      },
+      "satisfies": {
+        "meanNsPerIter": 6041,
+        "medianNsPerIter": 5799,
+        "minNsPerIter": 5358,
+        "maxNsPerIter": 7045,
+        "stddevNsPerIter": 649.57,
+        "samples": 5
+      },
+      "max_satisfying": {
+        "meanNsPerIter": 34251.8,
+        "medianNsPerIter": 33554,
+        "minNsPerIter": 30042,
+        "maxNsPerIter": 38985,
+        "stddevNsPerIter": 3893.33,
+        "samples": 5
+      },
+      "min_satisfying": {
+        "meanNsPerIter": 25525.8,
+        "medianNsPerIter": 25337,
+        "minNsPerIter": 23616,
+        "maxNsPerIter": 26852,
+        "stddevNsPerIter": 1151.28,
+        "samples": 5
+      }
+    }
+  },
+  "comparisons": [
+    {
+      "operation": "version_parse",
+      "rpmRustMeanNsPerIter": 2414,
+      "nodeSemverMeanNsPerIter": 5498.8,
+      "rustSpeedupVsNode": 2.28
+    },
+    {
+      "operation": "valid_canonical",
+      "rpmRustMeanNsPerIter": 4791.2,
+      "nodeSemverMeanNsPerIter": 6257.6,
+      "rustSpeedupVsNode": 1.31
+    },
+    {
+      "operation": "invalid_version",
+      "rpmRustMeanNsPerIter": 598.2,
+      "nodeSemverMeanNsPerIter": 28989.6,
+      "rustSpeedupVsNode": 48.46
+    },
+    {
+      "operation": "range_parse",
+      "rpmRustMeanNsPerIter": 5933.6,
+      "nodeSemverMeanNsPerIter": 5067.6,
+      "rustSpeedupVsNode": 0.85
+    },
+    {
+      "operation": "invalid_range",
+      "rpmRustMeanNsPerIter": 1926.2,
+      "nodeSemverMeanNsPerIter": 63877,
+      "rustSpeedupVsNode": 33.16
+    },
+    {
+      "operation": "satisfies",
+      "rpmRustMeanNsPerIter": 5410,
+      "nodeSemverMeanNsPerIter": 6041,
+      "rustSpeedupVsNode": 1.12
+    },
+    {
+      "operation": "max_satisfying",
+      "rpmRustMeanNsPerIter": 7306.6,
+      "nodeSemverMeanNsPerIter": 34251.8,
+      "rustSpeedupVsNode": 4.69
+    },
+    {
+      "operation": "min_satisfying",
+      "rpmRustMeanNsPerIter": 7030.2,
+      "nodeSemverMeanNsPerIter": 25525.8,
+      "rustSpeedupVsNode": 3.63
+    }
+  ]
+}

--- a/benches/histories/2026-06-22-001/benchmark.svg
+++ b/benches/histories/2026-06-22-001/benchmark.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="438" viewBox="0 0 980 438" role="img" aria-labelledby="title desc">
+  <title id="title">Semver benchmark comparison</title>
+  <desc id="desc">Mean nanoseconds per iteration for RPM Rust and node-semver benchmark operations.</desc>
+  <style>
+    text { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .title { font-size: 22px; font-weight: 700; fill: #111827; }
+    .meta { font-size: 12px; fill: #4b5563; }
+    .legend { font-size: 12px; fill: #374151; }
+    .label { font-size: 12px; fill: #111827; }
+    .value { font-size: 11px; fill: #374151; }
+    .speed { font-size: 12px; font-weight: 700; fill: #111827; text-anchor: end; }
+  </style>
+  <rect width="980" height="438" fill="#ffffff"/>
+  <text x="24" y="34" class="title">Semver benchmark comparison</text>
+  <text x="24" y="56" class="meta">2026-06-22T08:20:24.975Z · 50000 iterations · 5 samples</text>
+  <rect x="24" y="72" width="12" height="12" fill="#2563eb"/>
+  <text x="42" y="82" class="legend">RPM Rust</text>
+  <rect x="126" y="72" width="12" height="12" fill="#f97316"/>
+  <text x="144" y="82" class="legend">node-semver</text>
+  <text x="956" y="82" class="legend" text-anchor="end">Rust speedup</text>
+
+  <text x="24" y="117" class="label">version_parse</text>
+  <rect x="190" y="100" width="23" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="116" width="59" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="111" class="value">1975.2 ns</text>
+  <text x="768" y="127" class="value">5060 ns</text>
+  <text x="868" y="119" class="speed">2.56x</text>
+
+  <text x="24" y="153" class="label">valid_canonical</text>
+  <rect x="190" y="136" width="46" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="152" width="58" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="147" class="value">3961.4 ns</text>
+  <text x="768" y="163" class="value">4960.2 ns</text>
+  <text x="868" y="155" class="speed">1.25x</text>
+
+  <text x="24" y="189" class="label">invalid_version</text>
+  <rect x="190" y="172" width="6" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="188" width="257" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="183" class="value">505.2 ns</text>
+  <text x="768" y="199" class="value">22101.2 ns</text>
+  <text x="868" y="191" class="speed">43.75x</text>
+
+  <text x="24" y="225" class="label">range_parse</text>
+  <rect x="190" y="208" width="54" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="224" width="46" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="219" class="value">4648 ns</text>
+  <text x="768" y="235" class="value">3930.6 ns</text>
+  <text x="868" y="227" class="speed">0.85x</text>
+
+  <text x="24" y="261" class="label">invalid_range</text>
+  <rect x="190" y="244" width="16" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="260" width="560" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="255" class="value">1400.6 ns</text>
+  <text x="768" y="271" class="value">48214.2 ns</text>
+  <text x="868" y="263" class="speed">34.42x</text>
+
+  <text x="24" y="297" class="label">satisfies</text>
+  <rect x="190" y="280" width="47" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="296" width="60" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="291" class="value">4075.6 ns</text>
+  <text x="768" y="307" class="value">5169.2 ns</text>
+  <text x="868" y="299" class="speed">1.27x</text>
+
+  <text x="24" y="333" class="label">max_satisfying</text>
+  <rect x="190" y="316" width="61" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="332" width="302" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="327" class="value">5280.8 ns</text>
+  <text x="768" y="343" class="value">26006.4 ns</text>
+  <text x="868" y="335" class="speed">4.92x</text>
+
+  <text x="24" y="369" class="label">min_satisfying</text>
+  <rect x="190" y="352" width="61" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="368" width="254" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="363" class="value">5265 ns</text>
+  <text x="768" y="379" class="value">21893.4 ns</text>
+  <text x="868" y="371" class="speed">4.16x</text>
+</svg>

--- a/benches/histories/2026-06-22-001/benchmarks.json
+++ b/benches/histories/2026-06-22-001/benchmarks.json
@@ -1,0 +1,728 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-06-22T08:20:24.975Z",
+  "startedAt": "2026-06-22T08:18:39.304Z",
+  "outputDir": "benches/histories/2026-06-22-001",
+  "history": {
+    "root": "benches/histories",
+    "directory": "2026-06-22-001"
+  },
+  "settings": {
+    "iterations": 50000,
+    "samples": 5,
+    "warmupSamples": 1
+  },
+  "commands": [
+    {
+      "implementation": "rpm-rust",
+      "command": "cargo bench --bench semver --quiet"
+    },
+    {
+      "implementation": "node-semver",
+      "command": "node scripts/benchmark-node-semver.mjs"
+    }
+  ],
+  "runs": [
+    {
+      "implementation": "rpm-rust",
+      "command": "cargo bench --bench semver --quiet",
+      "metadata": {
+        "implementation": "rpm-rust",
+        "crate_version": "0.1.0",
+        "rustc_version": "rustc 1.96.0 (ac68faa20 2026-05-25)",
+        "target_os": "macos",
+        "target_arch": "aarch64",
+        "iterations": "50000",
+        "samples": "5",
+        "warmup_samples": "1",
+        "outlier_policy": "record_all_samples"
+      },
+      "samples": [
+        {
+          "operation": "version_parse",
+          "sample": 1,
+          "totalMs": 96.931,
+          "nsPerIter": 1938
+        },
+        {
+          "operation": "version_parse",
+          "sample": 2,
+          "totalMs": 101.113,
+          "nsPerIter": 2022
+        },
+        {
+          "operation": "version_parse",
+          "sample": 3,
+          "totalMs": 99.088,
+          "nsPerIter": 1981
+        },
+        {
+          "operation": "version_parse",
+          "sample": 4,
+          "totalMs": 99.434,
+          "nsPerIter": 1988
+        },
+        {
+          "operation": "version_parse",
+          "sample": 5,
+          "totalMs": 97.383,
+          "nsPerIter": 1947
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 1,
+          "totalMs": 190.962,
+          "nsPerIter": 3819
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 2,
+          "totalMs": 193.407,
+          "nsPerIter": 3868
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 3,
+          "totalMs": 215.884,
+          "nsPerIter": 4317
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 4,
+          "totalMs": 195.405,
+          "nsPerIter": 3908
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 5,
+          "totalMs": 194.791,
+          "nsPerIter": 3895
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 1,
+          "totalMs": 25.722,
+          "nsPerIter": 514
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 2,
+          "totalMs": 25.154,
+          "nsPerIter": 503
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 3,
+          "totalMs": 25.037,
+          "nsPerIter": 500
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 4,
+          "totalMs": 24.942,
+          "nsPerIter": 498
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 5,
+          "totalMs": 25.573,
+          "nsPerIter": 511
+        },
+        {
+          "operation": "range_parse",
+          "sample": 1,
+          "totalMs": 233.513,
+          "nsPerIter": 4670
+        },
+        {
+          "operation": "range_parse",
+          "sample": 2,
+          "totalMs": 236.13,
+          "nsPerIter": 4722
+        },
+        {
+          "operation": "range_parse",
+          "sample": 3,
+          "totalMs": 230.578,
+          "nsPerIter": 4611
+        },
+        {
+          "operation": "range_parse",
+          "sample": 4,
+          "totalMs": 230.85,
+          "nsPerIter": 4617
+        },
+        {
+          "operation": "range_parse",
+          "sample": 5,
+          "totalMs": 231.006,
+          "nsPerIter": 4620
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 1,
+          "totalMs": 69.387,
+          "nsPerIter": 1387
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 2,
+          "totalMs": 70.481,
+          "nsPerIter": 1409
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 3,
+          "totalMs": 70.57,
+          "nsPerIter": 1411
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 4,
+          "totalMs": 70.07,
+          "nsPerIter": 1401
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 5,
+          "totalMs": 69.767,
+          "nsPerIter": 1395
+        },
+        {
+          "operation": "satisfies",
+          "sample": 1,
+          "totalMs": 202.991,
+          "nsPerIter": 4059
+        },
+        {
+          "operation": "satisfies",
+          "sample": 2,
+          "totalMs": 206.207,
+          "nsPerIter": 4124
+        },
+        {
+          "operation": "satisfies",
+          "sample": 3,
+          "totalMs": 203.265,
+          "nsPerIter": 4065
+        },
+        {
+          "operation": "satisfies",
+          "sample": 4,
+          "totalMs": 203.226,
+          "nsPerIter": 4064
+        },
+        {
+          "operation": "satisfies",
+          "sample": 5,
+          "totalMs": 203.344,
+          "nsPerIter": 4066
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 1,
+          "totalMs": 264.015,
+          "nsPerIter": 5280
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 2,
+          "totalMs": 264.363,
+          "nsPerIter": 5287
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 3,
+          "totalMs": 263.312,
+          "nsPerIter": 5266
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 4,
+          "totalMs": 265.012,
+          "nsPerIter": 5300
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 5,
+          "totalMs": 263.55,
+          "nsPerIter": 5271
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 1,
+          "totalMs": 263.953,
+          "nsPerIter": 5279
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 2,
+          "totalMs": 262.626,
+          "nsPerIter": 5252
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 3,
+          "totalMs": 263.322,
+          "nsPerIter": 5266
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 4,
+          "totalMs": 262.777,
+          "nsPerIter": 5255
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 5,
+          "totalMs": 263.653,
+          "nsPerIter": 5273
+        }
+      ],
+      "rawOutput": "semver benchmark suite=representative\nmetadata,key,value\nmetadata,implementation,rpm-rust\nmetadata,crate_version,0.1.0\nmetadata,rustc_version,rustc 1.96.0 (ac68faa20 2026-05-25)\nmetadata,target_os,macos\nmetadata,target_arch,aarch64\nmetadata,iterations,50000\nmetadata,samples,5\nmetadata,warmup_samples,1\nmetadata,outlier_policy,record_all_samples\nname,sample,total_ms,ns_per_iter\nversion_parse,1,96.931,1938\nversion_parse,2,101.113,2022\nversion_parse,3,99.088,1981\nversion_parse,4,99.434,1988\nversion_parse,5,97.383,1947\nvalid_canonical,1,190.962,3819\nvalid_canonical,2,193.407,3868\nvalid_canonical,3,215.884,4317\nvalid_canonical,4,195.405,3908\nvalid_canonical,5,194.791,3895\ninvalid_version,1,25.722,514\ninvalid_version,2,25.154,503\ninvalid_version,3,25.037,500\ninvalid_version,4,24.942,498\ninvalid_version,5,25.573,511\nrange_parse,1,233.513,4670\nrange_parse,2,236.130,4722\nrange_parse,3,230.578,4611\nrange_parse,4,230.850,4617\nrange_parse,5,231.006,4620\ninvalid_range,1,69.387,1387\ninvalid_range,2,70.481,1409\ninvalid_range,3,70.570,1411\ninvalid_range,4,70.070,1401\ninvalid_range,5,69.767,1395\nsatisfies,1,202.991,4059\nsatisfies,2,206.207,4124\nsatisfies,3,203.265,4065\nsatisfies,4,203.226,4064\nsatisfies,5,203.344,4066\nmax_satisfying,1,264.015,5280\nmax_satisfying,2,264.363,5287\nmax_satisfying,3,263.312,5266\nmax_satisfying,4,265.012,5300\nmax_satisfying,5,263.550,5271\nmin_satisfying,1,263.953,5279\nmin_satisfying,2,262.626,5252\nmin_satisfying,3,263.322,5266\nmin_satisfying,4,262.777,5255\nmin_satisfying,5,263.653,5273"
+    },
+    {
+      "implementation": "node-semver",
+      "command": "node scripts/benchmark-node-semver.mjs",
+      "metadata": {
+        "implementation": "node-semver",
+        "node_version": "v22.22.3",
+        "npm_version": "10.9.8",
+        "node_semver_version": "7.8.2",
+        "platform": "darwin",
+        "arch": "arm64",
+        "iterations": "50000",
+        "samples": "5",
+        "warmup_samples": "1",
+        "outlier_policy": "record_all_samples"
+      },
+      "samples": [
+        {
+          "operation": "version_parse",
+          "sample": 1,
+          "totalMs": 251.75,
+          "nsPerIter": 5035
+        },
+        {
+          "operation": "version_parse",
+          "sample": 2,
+          "totalMs": 260.129,
+          "nsPerIter": 5202
+        },
+        {
+          "operation": "version_parse",
+          "sample": 3,
+          "totalMs": 250.903,
+          "nsPerIter": 5018
+        },
+        {
+          "operation": "version_parse",
+          "sample": 4,
+          "totalMs": 248.893,
+          "nsPerIter": 4977
+        },
+        {
+          "operation": "version_parse",
+          "sample": 5,
+          "totalMs": 253.438,
+          "nsPerIter": 5068
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 1,
+          "totalMs": 248.634,
+          "nsPerIter": 4972
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 2,
+          "totalMs": 247.851,
+          "nsPerIter": 4957
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 3,
+          "totalMs": 248.319,
+          "nsPerIter": 4966
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 4,
+          "totalMs": 247.984,
+          "nsPerIter": 4959
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 5,
+          "totalMs": 247.367,
+          "nsPerIter": 4947
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 1,
+          "totalMs": 1120.283,
+          "nsPerIter": 22405
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 2,
+          "totalMs": 1119.475,
+          "nsPerIter": 22389
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 3,
+          "totalMs": 1128.927,
+          "nsPerIter": 22578
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 4,
+          "totalMs": 1080.459,
+          "nsPerIter": 21609
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 5,
+          "totalMs": 1076.278,
+          "nsPerIter": 21525
+        },
+        {
+          "operation": "range_parse",
+          "sample": 1,
+          "totalMs": 197.054,
+          "nsPerIter": 3941
+        },
+        {
+          "operation": "range_parse",
+          "sample": 2,
+          "totalMs": 195.16,
+          "nsPerIter": 3903
+        },
+        {
+          "operation": "range_parse",
+          "sample": 3,
+          "totalMs": 194.863,
+          "nsPerIter": 3897
+        },
+        {
+          "operation": "range_parse",
+          "sample": 4,
+          "totalMs": 197.657,
+          "nsPerIter": 3953
+        },
+        {
+          "operation": "range_parse",
+          "sample": 5,
+          "totalMs": 197.964,
+          "nsPerIter": 3959
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 1,
+          "totalMs": 2425.399,
+          "nsPerIter": 48507
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 2,
+          "totalMs": 2462.439,
+          "nsPerIter": 49248
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 3,
+          "totalMs": 2477.822,
+          "nsPerIter": 49556
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 4,
+          "totalMs": 2340.443,
+          "nsPerIter": 46808
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 5,
+          "totalMs": 2347.649,
+          "nsPerIter": 46952
+        },
+        {
+          "operation": "satisfies",
+          "sample": 1,
+          "totalMs": 264.733,
+          "nsPerIter": 5294
+        },
+        {
+          "operation": "satisfies",
+          "sample": 2,
+          "totalMs": 256.302,
+          "nsPerIter": 5126
+        },
+        {
+          "operation": "satisfies",
+          "sample": 3,
+          "totalMs": 257.76,
+          "nsPerIter": 5155
+        },
+        {
+          "operation": "satisfies",
+          "sample": 4,
+          "totalMs": 258.144,
+          "nsPerIter": 5162
+        },
+        {
+          "operation": "satisfies",
+          "sample": 5,
+          "totalMs": 255.479,
+          "nsPerIter": 5109
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 1,
+          "totalMs": 1295.705,
+          "nsPerIter": 25914
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 2,
+          "totalMs": 1285.994,
+          "nsPerIter": 25719
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 3,
+          "totalMs": 1283.906,
+          "nsPerIter": 25678
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 4,
+          "totalMs": 1347.664,
+          "nsPerIter": 26953
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 5,
+          "totalMs": 1288.41,
+          "nsPerIter": 25768
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 1,
+          "totalMs": 1061.777,
+          "nsPerIter": 21235
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 2,
+          "totalMs": 1064.341,
+          "nsPerIter": 21286
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 3,
+          "totalMs": 1063.614,
+          "nsPerIter": 21272
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 4,
+          "totalMs": 1183.164,
+          "nsPerIter": 23663
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 5,
+          "totalMs": 1100.553,
+          "nsPerIter": 22011
+        }
+      ],
+      "rawOutput": "semver benchmark suite=representative\nmetadata,key,value\nmetadata,implementation,node-semver\nmetadata,node_version,v22.22.3\nmetadata,npm_version,10.9.8\nmetadata,node_semver_version,7.8.2\nmetadata,platform,darwin\nmetadata,arch,arm64\nmetadata,iterations,50000\nmetadata,samples,5\nmetadata,warmup_samples,1\nmetadata,outlier_policy,record_all_samples\nname,sample,total_ms,ns_per_iter\nversion_parse,1,251.750,5035\nversion_parse,2,260.129,5202\nversion_parse,3,250.903,5018\nversion_parse,4,248.893,4977\nversion_parse,5,253.438,5068\nvalid_canonical,1,248.634,4972\nvalid_canonical,2,247.851,4957\nvalid_canonical,3,248.319,4966\nvalid_canonical,4,247.984,4959\nvalid_canonical,5,247.367,4947\ninvalid_version,1,1120.283,22405\ninvalid_version,2,1119.475,22389\ninvalid_version,3,1128.927,22578\ninvalid_version,4,1080.459,21609\ninvalid_version,5,1076.278,21525\nrange_parse,1,197.054,3941\nrange_parse,2,195.160,3903\nrange_parse,3,194.863,3897\nrange_parse,4,197.657,3953\nrange_parse,5,197.964,3959\ninvalid_range,1,2425.399,48507\ninvalid_range,2,2462.439,49248\ninvalid_range,3,2477.822,49556\ninvalid_range,4,2340.443,46808\ninvalid_range,5,2347.649,46952\nsatisfies,1,264.733,5294\nsatisfies,2,256.302,5126\nsatisfies,3,257.760,5155\nsatisfies,4,258.144,5162\nsatisfies,5,255.479,5109\nmax_satisfying,1,1295.705,25914\nmax_satisfying,2,1285.994,25719\nmax_satisfying,3,1283.906,25678\nmax_satisfying,4,1347.664,26953\nmax_satisfying,5,1288.410,25768\nmin_satisfying,1,1061.777,21235\nmin_satisfying,2,1064.341,21286\nmin_satisfying,3,1063.614,21272\nmin_satisfying,4,1183.164,23663\nmin_satisfying,5,1100.553,22011"
+    }
+  ],
+  "summaries": {
+    "rpm-rust": {
+      "version_parse": {
+        "meanNsPerIter": 1975.2,
+        "medianNsPerIter": 1981,
+        "minNsPerIter": 1938,
+        "maxNsPerIter": 2022,
+        "stddevNsPerIter": 30.22,
+        "samples": 5
+      },
+      "valid_canonical": {
+        "meanNsPerIter": 3961.4,
+        "medianNsPerIter": 3895,
+        "minNsPerIter": 3819,
+        "maxNsPerIter": 4317,
+        "stddevNsPerIter": 180.4,
+        "samples": 5
+      },
+      "invalid_version": {
+        "meanNsPerIter": 505.2,
+        "medianNsPerIter": 503,
+        "minNsPerIter": 498,
+        "maxNsPerIter": 514,
+        "stddevNsPerIter": 6.24,
+        "samples": 5
+      },
+      "range_parse": {
+        "meanNsPerIter": 4648,
+        "medianNsPerIter": 4620,
+        "minNsPerIter": 4611,
+        "maxNsPerIter": 4722,
+        "stddevNsPerIter": 42.6,
+        "samples": 5
+      },
+      "invalid_range": {
+        "meanNsPerIter": 1400.6,
+        "medianNsPerIter": 1401,
+        "minNsPerIter": 1387,
+        "maxNsPerIter": 1411,
+        "stddevNsPerIter": 8.89,
+        "samples": 5
+      },
+      "satisfies": {
+        "meanNsPerIter": 4075.6,
+        "medianNsPerIter": 4065,
+        "minNsPerIter": 4059,
+        "maxNsPerIter": 4124,
+        "stddevNsPerIter": 24.32,
+        "samples": 5
+      },
+      "max_satisfying": {
+        "meanNsPerIter": 5280.8,
+        "medianNsPerIter": 5280,
+        "minNsPerIter": 5266,
+        "maxNsPerIter": 5300,
+        "stddevNsPerIter": 12.02,
+        "samples": 5
+      },
+      "min_satisfying": {
+        "meanNsPerIter": 5265,
+        "medianNsPerIter": 5266,
+        "minNsPerIter": 5252,
+        "maxNsPerIter": 5279,
+        "stddevNsPerIter": 10.3,
+        "samples": 5
+      }
+    },
+    "node-semver": {
+      "version_parse": {
+        "meanNsPerIter": 5060,
+        "medianNsPerIter": 5035,
+        "minNsPerIter": 4977,
+        "maxNsPerIter": 5202,
+        "stddevNsPerIter": 76.82,
+        "samples": 5
+      },
+      "valid_canonical": {
+        "meanNsPerIter": 4960.2,
+        "medianNsPerIter": 4959,
+        "minNsPerIter": 4947,
+        "maxNsPerIter": 4972,
+        "stddevNsPerIter": 8.47,
+        "samples": 5
+      },
+      "invalid_version": {
+        "meanNsPerIter": 22101.2,
+        "medianNsPerIter": 22389,
+        "minNsPerIter": 21525,
+        "maxNsPerIter": 22578,
+        "stddevNsPerIter": 441.98,
+        "samples": 5
+      },
+      "range_parse": {
+        "meanNsPerIter": 3930.6,
+        "medianNsPerIter": 3941,
+        "minNsPerIter": 3897,
+        "maxNsPerIter": 3959,
+        "stddevNsPerIter": 25.72,
+        "samples": 5
+      },
+      "invalid_range": {
+        "meanNsPerIter": 48214.2,
+        "medianNsPerIter": 48507,
+        "minNsPerIter": 46808,
+        "maxNsPerIter": 49556,
+        "stddevNsPerIter": 1142.41,
+        "samples": 5
+      },
+      "satisfies": {
+        "meanNsPerIter": 5169.2,
+        "medianNsPerIter": 5155,
+        "minNsPerIter": 5109,
+        "maxNsPerIter": 5294,
+        "stddevNsPerIter": 65.3,
+        "samples": 5
+      },
+      "max_satisfying": {
+        "meanNsPerIter": 26006.4,
+        "medianNsPerIter": 25768,
+        "minNsPerIter": 25678,
+        "maxNsPerIter": 26953,
+        "stddevNsPerIter": 479.97,
+        "samples": 5
+      },
+      "min_satisfying": {
+        "meanNsPerIter": 21893.4,
+        "medianNsPerIter": 21286,
+        "minNsPerIter": 21235,
+        "maxNsPerIter": 23663,
+        "stddevNsPerIter": 931.01,
+        "samples": 5
+      }
+    }
+  },
+  "comparisons": [
+    {
+      "operation": "version_parse",
+      "rpmRustMeanNsPerIter": 1975.2,
+      "nodeSemverMeanNsPerIter": 5060,
+      "rustSpeedupVsNode": 2.56
+    },
+    {
+      "operation": "valid_canonical",
+      "rpmRustMeanNsPerIter": 3961.4,
+      "nodeSemverMeanNsPerIter": 4960.2,
+      "rustSpeedupVsNode": 1.25
+    },
+    {
+      "operation": "invalid_version",
+      "rpmRustMeanNsPerIter": 505.2,
+      "nodeSemverMeanNsPerIter": 22101.2,
+      "rustSpeedupVsNode": 43.75
+    },
+    {
+      "operation": "range_parse",
+      "rpmRustMeanNsPerIter": 4648,
+      "nodeSemverMeanNsPerIter": 3930.6,
+      "rustSpeedupVsNode": 0.85
+    },
+    {
+      "operation": "invalid_range",
+      "rpmRustMeanNsPerIter": 1400.6,
+      "nodeSemverMeanNsPerIter": 48214.2,
+      "rustSpeedupVsNode": 34.42
+    },
+    {
+      "operation": "satisfies",
+      "rpmRustMeanNsPerIter": 4075.6,
+      "nodeSemverMeanNsPerIter": 5169.2,
+      "rustSpeedupVsNode": 1.27
+    },
+    {
+      "operation": "max_satisfying",
+      "rpmRustMeanNsPerIter": 5280.8,
+      "nodeSemverMeanNsPerIter": 26006.4,
+      "rustSpeedupVsNode": 4.92
+    },
+    {
+      "operation": "min_satisfying",
+      "rpmRustMeanNsPerIter": 5265,
+      "nodeSemverMeanNsPerIter": 21893.4,
+      "rustSpeedupVsNode": 4.16
+    }
+  ]
+}

--- a/benches/histories/2026-06-22-002/benchmark.svg
+++ b/benches/histories/2026-06-22-002/benchmark.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="438" viewBox="0 0 980 438" role="img" aria-labelledby="title desc">
+  <title id="title">Semver benchmark comparison</title>
+  <desc id="desc">Mean nanoseconds per iteration for RPM Rust and node-semver benchmark operations.</desc>
+  <style>
+    text { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .title { font-size: 22px; font-weight: 700; fill: #111827; }
+    .meta { font-size: 12px; fill: #4b5563; }
+    .legend { font-size: 12px; fill: #374151; }
+    .label { font-size: 12px; fill: #111827; }
+    .value { font-size: 11px; fill: #374151; }
+    .speed { font-size: 12px; font-weight: 700; fill: #111827; text-anchor: end; }
+  </style>
+  <rect width="980" height="438" fill="#ffffff"/>
+  <text x="24" y="34" class="title">Semver benchmark comparison</text>
+  <text x="24" y="56" class="meta">2026-06-22T10:03:30.871Z · 50000 iterations · 5 samples</text>
+  <rect x="24" y="72" width="12" height="12" fill="#2563eb"/>
+  <text x="42" y="82" class="legend">RPM Rust</text>
+  <rect x="126" y="72" width="12" height="12" fill="#f97316"/>
+  <text x="144" y="82" class="legend">node-semver</text>
+  <text x="956" y="82" class="legend" text-anchor="end">Rust speedup</text>
+
+  <text x="24" y="117" class="label">version_parse</text>
+  <rect x="190" y="100" width="25" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="116" width="56" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="111" class="value">2148 ns</text>
+  <text x="768" y="127" class="value">4776.6 ns</text>
+  <text x="868" y="119" class="speed">2.22x</text>
+
+  <text x="24" y="153" class="label">valid_canonical</text>
+  <rect x="190" y="136" width="47" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="152" width="58" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="147" class="value">3964.2 ns</text>
+  <text x="768" y="163" class="value">4903 ns</text>
+  <text x="868" y="155" class="speed">1.24x</text>
+
+  <text x="24" y="189" class="label">invalid_version</text>
+  <rect x="190" y="172" width="6" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="188" width="266" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="183" class="value">469.6 ns</text>
+  <text x="768" y="199" class="value">22571.8 ns</text>
+  <text x="868" y="191" class="speed">48.07x</text>
+
+  <text x="24" y="225" class="label">range_parse</text>
+  <rect x="190" y="208" width="53" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="224" width="47" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="219" class="value">4473.2 ns</text>
+  <text x="768" y="235" class="value">4021.2 ns</text>
+  <text x="868" y="227" class="speed">0.9x</text>
+
+  <text x="24" y="261" class="label">invalid_range</text>
+  <rect x="190" y="244" width="17" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="260" width="560" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="255" class="value">1429.8 ns</text>
+  <text x="768" y="271" class="value">47552.8 ns</text>
+  <text x="868" y="263" class="speed">33.26x</text>
+
+  <text x="24" y="297" class="label">satisfies</text>
+  <rect x="190" y="280" width="49" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="296" width="61" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="291" class="value">4197.4 ns</text>
+  <text x="768" y="307" class="value">5192 ns</text>
+  <text x="868" y="299" class="speed">1.24x</text>
+
+  <text x="24" y="333" class="label">max_satisfying</text>
+  <rect x="190" y="316" width="62" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="332" width="311" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="327" class="value">5230 ns</text>
+  <text x="768" y="343" class="value">26371.8 ns</text>
+  <text x="868" y="335" class="speed">5.04x</text>
+
+  <text x="24" y="369" class="label">min_satisfying</text>
+  <rect x="190" y="352" width="61" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="368" width="243" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="363" class="value">5197 ns</text>
+  <text x="768" y="379" class="value">20631.2 ns</text>
+  <text x="868" y="371" class="speed">3.97x</text>
+</svg>

--- a/benches/histories/2026-06-22-002/benchmarks.json
+++ b/benches/histories/2026-06-22-002/benchmarks.json
@@ -1,0 +1,728 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-06-22T10:03:30.871Z",
+  "startedAt": "2026-06-22T10:01:49.021Z",
+  "outputDir": "benches/histories/2026-06-22-002",
+  "history": {
+    "root": "benches/histories",
+    "directory": "2026-06-22-002"
+  },
+  "settings": {
+    "iterations": 50000,
+    "samples": 5,
+    "warmupSamples": 1
+  },
+  "commands": [
+    {
+      "implementation": "rpm-rust",
+      "command": "cargo bench --bench semver --quiet"
+    },
+    {
+      "implementation": "node-semver",
+      "command": "node scripts/benchmark-node-semver.mjs"
+    }
+  ],
+  "runs": [
+    {
+      "implementation": "rpm-rust",
+      "command": "cargo bench --bench semver --quiet",
+      "metadata": {
+        "implementation": "rpm-rust",
+        "crate_version": "0.1.0",
+        "rustc_version": "rustc 1.96.0 (ac68faa20 2026-05-25)",
+        "target_os": "macos",
+        "target_arch": "aarch64",
+        "iterations": "50000",
+        "samples": "5",
+        "warmup_samples": "1",
+        "outlier_policy": "record_all_samples"
+      },
+      "samples": [
+        {
+          "operation": "version_parse",
+          "sample": 1,
+          "totalMs": 130.589,
+          "nsPerIter": 2611
+        },
+        {
+          "operation": "version_parse",
+          "sample": 2,
+          "totalMs": 109.494,
+          "nsPerIter": 2189
+        },
+        {
+          "operation": "version_parse",
+          "sample": 3,
+          "totalMs": 98.958,
+          "nsPerIter": 1979
+        },
+        {
+          "operation": "version_parse",
+          "sample": 4,
+          "totalMs": 98.882,
+          "nsPerIter": 1977
+        },
+        {
+          "operation": "version_parse",
+          "sample": 5,
+          "totalMs": 99.202,
+          "nsPerIter": 1984
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 1,
+          "totalMs": 224.04,
+          "nsPerIter": 4480
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 2,
+          "totalMs": 211.971,
+          "nsPerIter": 4239
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 3,
+          "totalMs": 192.681,
+          "nsPerIter": 3853
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 4,
+          "totalMs": 184.44,
+          "nsPerIter": 3688
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 5,
+          "totalMs": 178.067,
+          "nsPerIter": 3561
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 1,
+          "totalMs": 23.36,
+          "nsPerIter": 467
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 2,
+          "totalMs": 23.339,
+          "nsPerIter": 466
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 3,
+          "totalMs": 23.332,
+          "nsPerIter": 466
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 4,
+          "totalMs": 23.638,
+          "nsPerIter": 472
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 5,
+          "totalMs": 23.856,
+          "nsPerIter": 477
+        },
+        {
+          "operation": "range_parse",
+          "sample": 1,
+          "totalMs": 219.156,
+          "nsPerIter": 4383
+        },
+        {
+          "operation": "range_parse",
+          "sample": 2,
+          "totalMs": 219.613,
+          "nsPerIter": 4392
+        },
+        {
+          "operation": "range_parse",
+          "sample": 3,
+          "totalMs": 222.435,
+          "nsPerIter": 4448
+        },
+        {
+          "operation": "range_parse",
+          "sample": 4,
+          "totalMs": 224.859,
+          "nsPerIter": 4497
+        },
+        {
+          "operation": "range_parse",
+          "sample": 5,
+          "totalMs": 232.31,
+          "nsPerIter": 4646
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 1,
+          "totalMs": 70.905,
+          "nsPerIter": 1418
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 2,
+          "totalMs": 70.963,
+          "nsPerIter": 1419
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 3,
+          "totalMs": 71.349,
+          "nsPerIter": 1426
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 4,
+          "totalMs": 71.292,
+          "nsPerIter": 1425
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 5,
+          "totalMs": 73.058,
+          "nsPerIter": 1461
+        },
+        {
+          "operation": "satisfies",
+          "sample": 1,
+          "totalMs": 210.067,
+          "nsPerIter": 4201
+        },
+        {
+          "operation": "satisfies",
+          "sample": 2,
+          "totalMs": 210.213,
+          "nsPerIter": 4204
+        },
+        {
+          "operation": "satisfies",
+          "sample": 3,
+          "totalMs": 210.346,
+          "nsPerIter": 4206
+        },
+        {
+          "operation": "satisfies",
+          "sample": 4,
+          "totalMs": 209.789,
+          "nsPerIter": 4195
+        },
+        {
+          "operation": "satisfies",
+          "sample": 5,
+          "totalMs": 209.078,
+          "nsPerIter": 4181
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 1,
+          "totalMs": 268.158,
+          "nsPerIter": 5363
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 2,
+          "totalMs": 267.033,
+          "nsPerIter": 5340
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 3,
+          "totalMs": 253.251,
+          "nsPerIter": 5065
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 4,
+          "totalMs": 252.587,
+          "nsPerIter": 5051
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 5,
+          "totalMs": 266.561,
+          "nsPerIter": 5331
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 1,
+          "totalMs": 266.593,
+          "nsPerIter": 5331
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 2,
+          "totalMs": 253.873,
+          "nsPerIter": 5077
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 3,
+          "totalMs": 250.011,
+          "nsPerIter": 5000
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 4,
+          "totalMs": 256.048,
+          "nsPerIter": 5120
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 5,
+          "totalMs": 272.869,
+          "nsPerIter": 5457
+        }
+      ],
+      "rawOutput": "semver benchmark suite=representative\nmetadata,key,value\nmetadata,implementation,rpm-rust\nmetadata,crate_version,0.1.0\nmetadata,rustc_version,rustc 1.96.0 (ac68faa20 2026-05-25)\nmetadata,target_os,macos\nmetadata,target_arch,aarch64\nmetadata,iterations,50000\nmetadata,samples,5\nmetadata,warmup_samples,1\nmetadata,outlier_policy,record_all_samples\nname,sample,total_ms,ns_per_iter\nversion_parse,1,130.589,2611\nversion_parse,2,109.494,2189\nversion_parse,3,98.958,1979\nversion_parse,4,98.882,1977\nversion_parse,5,99.202,1984\nvalid_canonical,1,224.040,4480\nvalid_canonical,2,211.971,4239\nvalid_canonical,3,192.681,3853\nvalid_canonical,4,184.440,3688\nvalid_canonical,5,178.067,3561\ninvalid_version,1,23.360,467\ninvalid_version,2,23.339,466\ninvalid_version,3,23.332,466\ninvalid_version,4,23.638,472\ninvalid_version,5,23.856,477\nrange_parse,1,219.156,4383\nrange_parse,2,219.613,4392\nrange_parse,3,222.435,4448\nrange_parse,4,224.859,4497\nrange_parse,5,232.310,4646\ninvalid_range,1,70.905,1418\ninvalid_range,2,70.963,1419\ninvalid_range,3,71.349,1426\ninvalid_range,4,71.292,1425\ninvalid_range,5,73.058,1461\nsatisfies,1,210.067,4201\nsatisfies,2,210.213,4204\nsatisfies,3,210.346,4206\nsatisfies,4,209.789,4195\nsatisfies,5,209.078,4181\nmax_satisfying,1,268.158,5363\nmax_satisfying,2,267.033,5340\nmax_satisfying,3,253.251,5065\nmax_satisfying,4,252.587,5051\nmax_satisfying,5,266.561,5331\nmin_satisfying,1,266.593,5331\nmin_satisfying,2,253.873,5077\nmin_satisfying,3,250.011,5000\nmin_satisfying,4,256.048,5120\nmin_satisfying,5,272.869,5457"
+    },
+    {
+      "implementation": "node-semver",
+      "command": "node scripts/benchmark-node-semver.mjs",
+      "metadata": {
+        "implementation": "node-semver",
+        "node_version": "v22.22.3",
+        "npm_version": "10.9.8",
+        "node_semver_version": "7.8.2",
+        "platform": "darwin",
+        "arch": "arm64",
+        "iterations": "50000",
+        "samples": "5",
+        "warmup_samples": "1",
+        "outlier_policy": "record_all_samples"
+      },
+      "samples": [
+        {
+          "operation": "version_parse",
+          "sample": 1,
+          "totalMs": 239.194,
+          "nsPerIter": 4783
+        },
+        {
+          "operation": "version_parse",
+          "sample": 2,
+          "totalMs": 235.848,
+          "nsPerIter": 4716
+        },
+        {
+          "operation": "version_parse",
+          "sample": 3,
+          "totalMs": 237.814,
+          "nsPerIter": 4756
+        },
+        {
+          "operation": "version_parse",
+          "sample": 4,
+          "totalMs": 233.949,
+          "nsPerIter": 4678
+        },
+        {
+          "operation": "version_parse",
+          "sample": 5,
+          "totalMs": 247.511,
+          "nsPerIter": 4950
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 1,
+          "totalMs": 251.546,
+          "nsPerIter": 5030
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 2,
+          "totalMs": 253.025,
+          "nsPerIter": 5060
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 3,
+          "totalMs": 242.702,
+          "nsPerIter": 4854
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 4,
+          "totalMs": 235.838,
+          "nsPerIter": 4716
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 5,
+          "totalMs": 242.757,
+          "nsPerIter": 4855
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 1,
+          "totalMs": 1161.873,
+          "nsPerIter": 23237
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 2,
+          "totalMs": 1133.252,
+          "nsPerIter": 22665
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 3,
+          "totalMs": 1078.542,
+          "nsPerIter": 21570
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 4,
+          "totalMs": 1119.12,
+          "nsPerIter": 22382
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 5,
+          "totalMs": 1150.251,
+          "nsPerIter": 23005
+        },
+        {
+          "operation": "range_parse",
+          "sample": 1,
+          "totalMs": 213.185,
+          "nsPerIter": 4263
+        },
+        {
+          "operation": "range_parse",
+          "sample": 2,
+          "totalMs": 202.449,
+          "nsPerIter": 4048
+        },
+        {
+          "operation": "range_parse",
+          "sample": 3,
+          "totalMs": 201.139,
+          "nsPerIter": 4022
+        },
+        {
+          "operation": "range_parse",
+          "sample": 4,
+          "totalMs": 197.087,
+          "nsPerIter": 3941
+        },
+        {
+          "operation": "range_parse",
+          "sample": 5,
+          "totalMs": 191.647,
+          "nsPerIter": 3832
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 1,
+          "totalMs": 2373.015,
+          "nsPerIter": 47460
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 2,
+          "totalMs": 2454.416,
+          "nsPerIter": 49088
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 3,
+          "totalMs": 2297.763,
+          "nsPerIter": 45955
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 4,
+          "totalMs": 2425.521,
+          "nsPerIter": 48510
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 5,
+          "totalMs": 2337.574,
+          "nsPerIter": 46751
+        },
+        {
+          "operation": "satisfies",
+          "sample": 1,
+          "totalMs": 259.264,
+          "nsPerIter": 5185
+        },
+        {
+          "operation": "satisfies",
+          "sample": 2,
+          "totalMs": 260.228,
+          "nsPerIter": 5204
+        },
+        {
+          "operation": "satisfies",
+          "sample": 3,
+          "totalMs": 254.802,
+          "nsPerIter": 5096
+        },
+        {
+          "operation": "satisfies",
+          "sample": 4,
+          "totalMs": 253.69,
+          "nsPerIter": 5073
+        },
+        {
+          "operation": "satisfies",
+          "sample": 5,
+          "totalMs": 270.149,
+          "nsPerIter": 5402
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 1,
+          "totalMs": 1364.587,
+          "nsPerIter": 27291
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 2,
+          "totalMs": 1340.66,
+          "nsPerIter": 26813
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 3,
+          "totalMs": 1319.436,
+          "nsPerIter": 26388
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 4,
+          "totalMs": 1339.028,
+          "nsPerIter": 26780
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 5,
+          "totalMs": 1229.381,
+          "nsPerIter": 24587
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 1,
+          "totalMs": 1005.483,
+          "nsPerIter": 20109
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 2,
+          "totalMs": 1001.422,
+          "nsPerIter": 20028
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 3,
+          "totalMs": 1001.502,
+          "nsPerIter": 20030
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 4,
+          "totalMs": 1033.507,
+          "nsPerIter": 20670
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 5,
+          "totalMs": 1115.974,
+          "nsPerIter": 22319
+        }
+      ],
+      "rawOutput": "semver benchmark suite=representative\nmetadata,key,value\nmetadata,implementation,node-semver\nmetadata,node_version,v22.22.3\nmetadata,npm_version,10.9.8\nmetadata,node_semver_version,7.8.2\nmetadata,platform,darwin\nmetadata,arch,arm64\nmetadata,iterations,50000\nmetadata,samples,5\nmetadata,warmup_samples,1\nmetadata,outlier_policy,record_all_samples\nname,sample,total_ms,ns_per_iter\nversion_parse,1,239.194,4783\nversion_parse,2,235.848,4716\nversion_parse,3,237.814,4756\nversion_parse,4,233.949,4678\nversion_parse,5,247.511,4950\nvalid_canonical,1,251.546,5030\nvalid_canonical,2,253.025,5060\nvalid_canonical,3,242.702,4854\nvalid_canonical,4,235.838,4716\nvalid_canonical,5,242.757,4855\ninvalid_version,1,1161.873,23237\ninvalid_version,2,1133.252,22665\ninvalid_version,3,1078.542,21570\ninvalid_version,4,1119.120,22382\ninvalid_version,5,1150.251,23005\nrange_parse,1,213.185,4263\nrange_parse,2,202.449,4048\nrange_parse,3,201.139,4022\nrange_parse,4,197.087,3941\nrange_parse,5,191.647,3832\ninvalid_range,1,2373.015,47460\ninvalid_range,2,2454.416,49088\ninvalid_range,3,2297.763,45955\ninvalid_range,4,2425.521,48510\ninvalid_range,5,2337.574,46751\nsatisfies,1,259.264,5185\nsatisfies,2,260.228,5204\nsatisfies,3,254.802,5096\nsatisfies,4,253.690,5073\nsatisfies,5,270.149,5402\nmax_satisfying,1,1364.587,27291\nmax_satisfying,2,1340.660,26813\nmax_satisfying,3,1319.436,26388\nmax_satisfying,4,1339.028,26780\nmax_satisfying,5,1229.381,24587\nmin_satisfying,1,1005.483,20109\nmin_satisfying,2,1001.422,20028\nmin_satisfying,3,1001.502,20030\nmin_satisfying,4,1033.507,20670\nmin_satisfying,5,1115.974,22319"
+    }
+  ],
+  "summaries": {
+    "rpm-rust": {
+      "version_parse": {
+        "meanNsPerIter": 2148,
+        "medianNsPerIter": 1984,
+        "minNsPerIter": 1977,
+        "maxNsPerIter": 2611,
+        "stddevNsPerIter": 245.25,
+        "samples": 5
+      },
+      "valid_canonical": {
+        "meanNsPerIter": 3964.2,
+        "medianNsPerIter": 3853,
+        "minNsPerIter": 3561,
+        "maxNsPerIter": 4480,
+        "stddevNsPerIter": 344.32,
+        "samples": 5
+      },
+      "invalid_version": {
+        "meanNsPerIter": 469.6,
+        "medianNsPerIter": 467,
+        "minNsPerIter": 466,
+        "maxNsPerIter": 477,
+        "stddevNsPerIter": 4.32,
+        "samples": 5
+      },
+      "range_parse": {
+        "meanNsPerIter": 4473.2,
+        "medianNsPerIter": 4448,
+        "minNsPerIter": 4383,
+        "maxNsPerIter": 4646,
+        "stddevNsPerIter": 95.7,
+        "samples": 5
+      },
+      "invalid_range": {
+        "meanNsPerIter": 1429.8,
+        "medianNsPerIter": 1425,
+        "minNsPerIter": 1418,
+        "maxNsPerIter": 1461,
+        "stddevNsPerIter": 15.92,
+        "samples": 5
+      },
+      "satisfies": {
+        "meanNsPerIter": 4197.4,
+        "medianNsPerIter": 4201,
+        "minNsPerIter": 4181,
+        "maxNsPerIter": 4206,
+        "stddevNsPerIter": 9,
+        "samples": 5
+      },
+      "max_satisfying": {
+        "meanNsPerIter": 5230,
+        "medianNsPerIter": 5331,
+        "minNsPerIter": 5051,
+        "maxNsPerIter": 5363,
+        "stddevNsPerIter": 140.89,
+        "samples": 5
+      },
+      "min_satisfying": {
+        "meanNsPerIter": 5197,
+        "medianNsPerIter": 5120,
+        "minNsPerIter": 5000,
+        "maxNsPerIter": 5457,
+        "stddevNsPerIter": 170.11,
+        "samples": 5
+      }
+    },
+    "node-semver": {
+      "version_parse": {
+        "meanNsPerIter": 4776.6,
+        "medianNsPerIter": 4756,
+        "minNsPerIter": 4678,
+        "maxNsPerIter": 4950,
+        "stddevNsPerIter": 93.73,
+        "samples": 5
+      },
+      "valid_canonical": {
+        "meanNsPerIter": 4903,
+        "medianNsPerIter": 4855,
+        "minNsPerIter": 4716,
+        "maxNsPerIter": 5060,
+        "stddevNsPerIter": 126.85,
+        "samples": 5
+      },
+      "invalid_version": {
+        "meanNsPerIter": 22571.8,
+        "medianNsPerIter": 22665,
+        "minNsPerIter": 21570,
+        "maxNsPerIter": 23237,
+        "stddevNsPerIter": 579.39,
+        "samples": 5
+      },
+      "range_parse": {
+        "meanNsPerIter": 4021.2,
+        "medianNsPerIter": 4022,
+        "minNsPerIter": 3832,
+        "maxNsPerIter": 4263,
+        "stddevNsPerIter": 142.42,
+        "samples": 5
+      },
+      "invalid_range": {
+        "meanNsPerIter": 47552.8,
+        "medianNsPerIter": 47460,
+        "minNsPerIter": 45955,
+        "maxNsPerIter": 49088,
+        "stddevNsPerIter": 1138.2,
+        "samples": 5
+      },
+      "satisfies": {
+        "meanNsPerIter": 5192,
+        "medianNsPerIter": 5185,
+        "minNsPerIter": 5073,
+        "maxNsPerIter": 5402,
+        "stddevNsPerIter": 116.34,
+        "samples": 5
+      },
+      "max_satisfying": {
+        "meanNsPerIter": 26371.8,
+        "medianNsPerIter": 26780,
+        "minNsPerIter": 24587,
+        "maxNsPerIter": 27291,
+        "stddevNsPerIter": 937.23,
+        "samples": 5
+      },
+      "min_satisfying": {
+        "meanNsPerIter": 20631.2,
+        "medianNsPerIter": 20109,
+        "minNsPerIter": 20028,
+        "maxNsPerIter": 22319,
+        "stddevNsPerIter": 877.29,
+        "samples": 5
+      }
+    }
+  },
+  "comparisons": [
+    {
+      "operation": "version_parse",
+      "rpmRustMeanNsPerIter": 2148,
+      "nodeSemverMeanNsPerIter": 4776.6,
+      "rustSpeedupVsNode": 2.22
+    },
+    {
+      "operation": "valid_canonical",
+      "rpmRustMeanNsPerIter": 3964.2,
+      "nodeSemverMeanNsPerIter": 4903,
+      "rustSpeedupVsNode": 1.24
+    },
+    {
+      "operation": "invalid_version",
+      "rpmRustMeanNsPerIter": 469.6,
+      "nodeSemverMeanNsPerIter": 22571.8,
+      "rustSpeedupVsNode": 48.07
+    },
+    {
+      "operation": "range_parse",
+      "rpmRustMeanNsPerIter": 4473.2,
+      "nodeSemverMeanNsPerIter": 4021.2,
+      "rustSpeedupVsNode": 0.9
+    },
+    {
+      "operation": "invalid_range",
+      "rpmRustMeanNsPerIter": 1429.8,
+      "nodeSemverMeanNsPerIter": 47552.8,
+      "rustSpeedupVsNode": 33.26
+    },
+    {
+      "operation": "satisfies",
+      "rpmRustMeanNsPerIter": 4197.4,
+      "nodeSemverMeanNsPerIter": 5192,
+      "rustSpeedupVsNode": 1.24
+    },
+    {
+      "operation": "max_satisfying",
+      "rpmRustMeanNsPerIter": 5230,
+      "nodeSemverMeanNsPerIter": 26371.8,
+      "rustSpeedupVsNode": 5.04
+    },
+    {
+      "operation": "min_satisfying",
+      "rpmRustMeanNsPerIter": 5197,
+      "nodeSemverMeanNsPerIter": 20631.2,
+      "rustSpeedupVsNode": 3.97
+    }
+  ]
+}

--- a/benches/histories/2026-06-22-003/benchmark.svg
+++ b/benches/histories/2026-06-22-003/benchmark.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="438" viewBox="0 0 980 438" role="img" aria-labelledby="title desc">
+  <title id="title">Semver benchmark comparison</title>
+  <desc id="desc">Mean nanoseconds per iteration for RPM Rust and node-semver benchmark operations.</desc>
+  <style>
+    text { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .title { font-size: 22px; font-weight: 700; fill: #111827; }
+    .meta { font-size: 12px; fill: #4b5563; }
+    .legend { font-size: 12px; fill: #374151; }
+    .label { font-size: 12px; fill: #111827; }
+    .value { font-size: 11px; fill: #374151; }
+    .speed { font-size: 12px; font-weight: 700; fill: #111827; text-anchor: end; }
+  </style>
+  <rect width="980" height="438" fill="#ffffff"/>
+  <text x="24" y="34" class="title">Semver benchmark comparison</text>
+  <text x="24" y="56" class="meta">2026-06-22T10:07:58.941Z · 50000 iterations · 5 samples</text>
+  <rect x="24" y="72" width="12" height="12" fill="#2563eb"/>
+  <text x="42" y="82" class="legend">RPM Rust</text>
+  <rect x="126" y="72" width="12" height="12" fill="#f97316"/>
+  <text x="144" y="82" class="legend">node-semver</text>
+  <text x="956" y="82" class="legend" text-anchor="end">Rust speedup</text>
+
+  <text x="24" y="117" class="label">version_parse</text>
+  <rect x="190" y="100" width="20" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="116" width="53" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="111" class="value">2167.8 ns</text>
+  <text x="768" y="127" class="value">5589.4 ns</text>
+  <text x="868" y="119" class="speed">2.58x</text>
+
+  <text x="24" y="153" class="label">valid_canonical</text>
+  <rect x="190" y="136" width="38" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="152" width="55" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="147" class="value">4077.6 ns</text>
+  <text x="768" y="163" class="value">5805.4 ns</text>
+  <text x="868" y="155" class="speed">1.42x</text>
+
+  <text x="24" y="189" class="label">invalid_version</text>
+  <rect x="190" y="172" width="5" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="188" width="272" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="183" class="value">532.4 ns</text>
+  <text x="768" y="199" class="value">28893.2 ns</text>
+  <text x="868" y="191" class="speed">54.27x</text>
+
+  <text x="24" y="225" class="label">range_parse</text>
+  <rect x="190" y="208" width="53" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="224" width="48" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="219" class="value">5640.4 ns</text>
+  <text x="768" y="235" class="value">5077.2 ns</text>
+  <text x="868" y="227" class="speed">0.9x</text>
+
+  <text x="24" y="261" class="label">invalid_range</text>
+  <rect x="190" y="244" width="16" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="260" width="560" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="255" class="value">1738 ns</text>
+  <text x="768" y="271" class="value">59550.8 ns</text>
+  <text x="868" y="263" class="speed">34.26x</text>
+
+  <text x="24" y="297" class="label">satisfies</text>
+  <rect x="190" y="280" width="47" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="296" width="61" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="291" class="value">4947 ns</text>
+  <text x="768" y="307" class="value">6512.4 ns</text>
+  <text x="868" y="299" class="speed">1.32x</text>
+
+  <text x="24" y="333" class="label">max_satisfying</text>
+  <rect x="190" y="316" width="64" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="332" width="319" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="327" class="value">6777 ns</text>
+  <text x="768" y="343" class="value">33920.8 ns</text>
+  <text x="868" y="335" class="speed">5.01x</text>
+
+  <text x="24" y="369" class="label">min_satisfying</text>
+  <rect x="190" y="352" width="59" height="12" rx="2" fill="#2563eb"/>
+  <rect x="190" y="368" width="237" height="12" rx="2" fill="#f97316"/>
+  <text x="768" y="363" class="value">6307.8 ns</text>
+  <text x="768" y="379" class="value">25238.8 ns</text>
+  <text x="868" y="371" class="speed">4x</text>
+</svg>

--- a/benches/histories/2026-06-22-003/benchmarks.json
+++ b/benches/histories/2026-06-22-003/benchmarks.json
@@ -1,0 +1,728 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-06-22T10:07:58.941Z",
+  "startedAt": "2026-06-22T10:05:56.715Z",
+  "outputDir": "benches/histories/2026-06-22-003",
+  "history": {
+    "root": "benches/histories",
+    "directory": "2026-06-22-003"
+  },
+  "settings": {
+    "iterations": 50000,
+    "samples": 5,
+    "warmupSamples": 1
+  },
+  "commands": [
+    {
+      "implementation": "rpm-rust",
+      "command": "cargo bench --bench semver --quiet"
+    },
+    {
+      "implementation": "node-semver",
+      "command": "node scripts/benchmark-node-semver.mjs"
+    }
+  ],
+  "runs": [
+    {
+      "implementation": "rpm-rust",
+      "command": "cargo bench --bench semver --quiet",
+      "metadata": {
+        "implementation": "rpm-rust",
+        "crate_version": "0.1.0",
+        "rustc_version": "rustc 1.96.0 (ac68faa20 2026-05-25)",
+        "target_os": "macos",
+        "target_arch": "aarch64",
+        "iterations": "50000",
+        "samples": "5",
+        "warmup_samples": "1",
+        "outlier_policy": "record_all_samples"
+      },
+      "samples": [
+        {
+          "operation": "version_parse",
+          "sample": 1,
+          "totalMs": 96.527,
+          "nsPerIter": 1930
+        },
+        {
+          "operation": "version_parse",
+          "sample": 2,
+          "totalMs": 111.104,
+          "nsPerIter": 2222
+        },
+        {
+          "operation": "version_parse",
+          "sample": 3,
+          "totalMs": 112.423,
+          "nsPerIter": 2248
+        },
+        {
+          "operation": "version_parse",
+          "sample": 4,
+          "totalMs": 113.939,
+          "nsPerIter": 2278
+        },
+        {
+          "operation": "version_parse",
+          "sample": 5,
+          "totalMs": 108.059,
+          "nsPerIter": 2161
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 1,
+          "totalMs": 199.785,
+          "nsPerIter": 3995
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 2,
+          "totalMs": 200.75,
+          "nsPerIter": 4015
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 3,
+          "totalMs": 202.546,
+          "nsPerIter": 4050
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 4,
+          "totalMs": 207.357,
+          "nsPerIter": 4147
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 5,
+          "totalMs": 209.054,
+          "nsPerIter": 4181
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 1,
+          "totalMs": 26.727,
+          "nsPerIter": 534
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 2,
+          "totalMs": 26.324,
+          "nsPerIter": 526
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 3,
+          "totalMs": 26.01,
+          "nsPerIter": 520
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 4,
+          "totalMs": 27.905,
+          "nsPerIter": 558
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 5,
+          "totalMs": 26.243,
+          "nsPerIter": 524
+        },
+        {
+          "operation": "range_parse",
+          "sample": 1,
+          "totalMs": 271.82,
+          "nsPerIter": 5436
+        },
+        {
+          "operation": "range_parse",
+          "sample": 2,
+          "totalMs": 293.844,
+          "nsPerIter": 5876
+        },
+        {
+          "operation": "range_parse",
+          "sample": 3,
+          "totalMs": 260.838,
+          "nsPerIter": 5216
+        },
+        {
+          "operation": "range_parse",
+          "sample": 4,
+          "totalMs": 284.783,
+          "nsPerIter": 5695
+        },
+        {
+          "operation": "range_parse",
+          "sample": 5,
+          "totalMs": 298.979,
+          "nsPerIter": 5979
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 1,
+          "totalMs": 105.515,
+          "nsPerIter": 2110
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 2,
+          "totalMs": 72.242,
+          "nsPerIter": 1444
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 3,
+          "totalMs": 78.996,
+          "nsPerIter": 1579
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 4,
+          "totalMs": 81.721,
+          "nsPerIter": 1634
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 5,
+          "totalMs": 96.174,
+          "nsPerIter": 1923
+        },
+        {
+          "operation": "satisfies",
+          "sample": 1,
+          "totalMs": 242.365,
+          "nsPerIter": 4847
+        },
+        {
+          "operation": "satisfies",
+          "sample": 2,
+          "totalMs": 247.604,
+          "nsPerIter": 4952
+        },
+        {
+          "operation": "satisfies",
+          "sample": 3,
+          "totalMs": 244.624,
+          "nsPerIter": 4892
+        },
+        {
+          "operation": "satisfies",
+          "sample": 4,
+          "totalMs": 258.342,
+          "nsPerIter": 5166
+        },
+        {
+          "operation": "satisfies",
+          "sample": 5,
+          "totalMs": 243.916,
+          "nsPerIter": 4878
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 1,
+          "totalMs": 389.247,
+          "nsPerIter": 7784
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 2,
+          "totalMs": 304.787,
+          "nsPerIter": 6095
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 3,
+          "totalMs": 323.688,
+          "nsPerIter": 6473
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 4,
+          "totalMs": 302.773,
+          "nsPerIter": 6055
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 5,
+          "totalMs": 373.948,
+          "nsPerIter": 7478
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 1,
+          "totalMs": 358.167,
+          "nsPerIter": 7163
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 2,
+          "totalMs": 319.557,
+          "nsPerIter": 6391
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 3,
+          "totalMs": 297.326,
+          "nsPerIter": 5946
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 4,
+          "totalMs": 310.858,
+          "nsPerIter": 6217
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 5,
+          "totalMs": 291.146,
+          "nsPerIter": 5822
+        }
+      ],
+      "rawOutput": "semver benchmark suite=representative\nmetadata,key,value\nmetadata,implementation,rpm-rust\nmetadata,crate_version,0.1.0\nmetadata,rustc_version,rustc 1.96.0 (ac68faa20 2026-05-25)\nmetadata,target_os,macos\nmetadata,target_arch,aarch64\nmetadata,iterations,50000\nmetadata,samples,5\nmetadata,warmup_samples,1\nmetadata,outlier_policy,record_all_samples\nname,sample,total_ms,ns_per_iter\nversion_parse,1,96.527,1930\nversion_parse,2,111.104,2222\nversion_parse,3,112.423,2248\nversion_parse,4,113.939,2278\nversion_parse,5,108.059,2161\nvalid_canonical,1,199.785,3995\nvalid_canonical,2,200.750,4015\nvalid_canonical,3,202.546,4050\nvalid_canonical,4,207.357,4147\nvalid_canonical,5,209.054,4181\ninvalid_version,1,26.727,534\ninvalid_version,2,26.324,526\ninvalid_version,3,26.010,520\ninvalid_version,4,27.905,558\ninvalid_version,5,26.243,524\nrange_parse,1,271.820,5436\nrange_parse,2,293.844,5876\nrange_parse,3,260.838,5216\nrange_parse,4,284.783,5695\nrange_parse,5,298.979,5979\ninvalid_range,1,105.515,2110\ninvalid_range,2,72.242,1444\ninvalid_range,3,78.996,1579\ninvalid_range,4,81.721,1634\ninvalid_range,5,96.174,1923\nsatisfies,1,242.365,4847\nsatisfies,2,247.604,4952\nsatisfies,3,244.624,4892\nsatisfies,4,258.342,5166\nsatisfies,5,243.916,4878\nmax_satisfying,1,389.247,7784\nmax_satisfying,2,304.787,6095\nmax_satisfying,3,323.688,6473\nmax_satisfying,4,302.773,6055\nmax_satisfying,5,373.948,7478\nmin_satisfying,1,358.167,7163\nmin_satisfying,2,319.557,6391\nmin_satisfying,3,297.326,5946\nmin_satisfying,4,310.858,6217\nmin_satisfying,5,291.146,5822"
+    },
+    {
+      "implementation": "node-semver",
+      "command": "node scripts/benchmark-node-semver.mjs",
+      "metadata": {
+        "implementation": "node-semver",
+        "node_version": "v22.22.3",
+        "npm_version": "10.9.8",
+        "node_semver_version": "7.8.2",
+        "platform": "darwin",
+        "arch": "arm64",
+        "iterations": "50000",
+        "samples": "5",
+        "warmup_samples": "1",
+        "outlier_policy": "record_all_samples"
+      },
+      "samples": [
+        {
+          "operation": "version_parse",
+          "sample": 1,
+          "totalMs": 259.835,
+          "nsPerIter": 5196
+        },
+        {
+          "operation": "version_parse",
+          "sample": 2,
+          "totalMs": 265.619,
+          "nsPerIter": 5312
+        },
+        {
+          "operation": "version_parse",
+          "sample": 3,
+          "totalMs": 260.356,
+          "nsPerIter": 5207
+        },
+        {
+          "operation": "version_parse",
+          "sample": 4,
+          "totalMs": 311.685,
+          "nsPerIter": 6233
+        },
+        {
+          "operation": "version_parse",
+          "sample": 5,
+          "totalMs": 299.988,
+          "nsPerIter": 5999
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 1,
+          "totalMs": 284.319,
+          "nsPerIter": 5686
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 2,
+          "totalMs": 278.304,
+          "nsPerIter": 5566
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 3,
+          "totalMs": 286.999,
+          "nsPerIter": 5739
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 4,
+          "totalMs": 295.304,
+          "nsPerIter": 5906
+        },
+        {
+          "operation": "valid_canonical",
+          "sample": 5,
+          "totalMs": 306.526,
+          "nsPerIter": 6130
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 1,
+          "totalMs": 1525.257,
+          "nsPerIter": 30505
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 2,
+          "totalMs": 1600.648,
+          "nsPerIter": 32012
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 3,
+          "totalMs": 1481.892,
+          "nsPerIter": 29637
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 4,
+          "totalMs": 1318.86,
+          "nsPerIter": 26377
+        },
+        {
+          "operation": "invalid_version",
+          "sample": 5,
+          "totalMs": 1296.757,
+          "nsPerIter": 25935
+        },
+        {
+          "operation": "range_parse",
+          "sample": 1,
+          "totalMs": 258.908,
+          "nsPerIter": 5178
+        },
+        {
+          "operation": "range_parse",
+          "sample": 2,
+          "totalMs": 239.749,
+          "nsPerIter": 4794
+        },
+        {
+          "operation": "range_parse",
+          "sample": 3,
+          "totalMs": 250.062,
+          "nsPerIter": 5001
+        },
+        {
+          "operation": "range_parse",
+          "sample": 4,
+          "totalMs": 284.11,
+          "nsPerIter": 5682
+        },
+        {
+          "operation": "range_parse",
+          "sample": 5,
+          "totalMs": 236.582,
+          "nsPerIter": 4731
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 1,
+          "totalMs": 3327.071,
+          "nsPerIter": 66541
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 2,
+          "totalMs": 2839.862,
+          "nsPerIter": 56797
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 3,
+          "totalMs": 2840.895,
+          "nsPerIter": 56817
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 4,
+          "totalMs": 2824.981,
+          "nsPerIter": 56499
+        },
+        {
+          "operation": "invalid_range",
+          "sample": 5,
+          "totalMs": 3055.028,
+          "nsPerIter": 61100
+        },
+        {
+          "operation": "satisfies",
+          "sample": 1,
+          "totalMs": 338.785,
+          "nsPerIter": 6775
+        },
+        {
+          "operation": "satisfies",
+          "sample": 2,
+          "totalMs": 313.266,
+          "nsPerIter": 6265
+        },
+        {
+          "operation": "satisfies",
+          "sample": 3,
+          "totalMs": 337.905,
+          "nsPerIter": 6758
+        },
+        {
+          "operation": "satisfies",
+          "sample": 4,
+          "totalMs": 300.135,
+          "nsPerIter": 6002
+        },
+        {
+          "operation": "satisfies",
+          "sample": 5,
+          "totalMs": 338.131,
+          "nsPerIter": 6762
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 1,
+          "totalMs": 1722.209,
+          "nsPerIter": 34444
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 2,
+          "totalMs": 1767.953,
+          "nsPerIter": 35359
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 3,
+          "totalMs": 1475.341,
+          "nsPerIter": 29506
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 4,
+          "totalMs": 1830.071,
+          "nsPerIter": 36601
+        },
+        {
+          "operation": "max_satisfying",
+          "sample": 5,
+          "totalMs": 1684.725,
+          "nsPerIter": 33694
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 1,
+          "totalMs": 1291.388,
+          "nsPerIter": 25827
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 2,
+          "totalMs": 1263.254,
+          "nsPerIter": 25265
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 3,
+          "totalMs": 1352.541,
+          "nsPerIter": 27050
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 4,
+          "totalMs": 1216.603,
+          "nsPerIter": 24332
+        },
+        {
+          "operation": "min_satisfying",
+          "sample": 5,
+          "totalMs": 1186.027,
+          "nsPerIter": 23720
+        }
+      ],
+      "rawOutput": "semver benchmark suite=representative\nmetadata,key,value\nmetadata,implementation,node-semver\nmetadata,node_version,v22.22.3\nmetadata,npm_version,10.9.8\nmetadata,node_semver_version,7.8.2\nmetadata,platform,darwin\nmetadata,arch,arm64\nmetadata,iterations,50000\nmetadata,samples,5\nmetadata,warmup_samples,1\nmetadata,outlier_policy,record_all_samples\nname,sample,total_ms,ns_per_iter\nversion_parse,1,259.835,5196\nversion_parse,2,265.619,5312\nversion_parse,3,260.356,5207\nversion_parse,4,311.685,6233\nversion_parse,5,299.988,5999\nvalid_canonical,1,284.319,5686\nvalid_canonical,2,278.304,5566\nvalid_canonical,3,286.999,5739\nvalid_canonical,4,295.304,5906\nvalid_canonical,5,306.526,6130\ninvalid_version,1,1525.257,30505\ninvalid_version,2,1600.648,32012\ninvalid_version,3,1481.892,29637\ninvalid_version,4,1318.860,26377\ninvalid_version,5,1296.757,25935\nrange_parse,1,258.908,5178\nrange_parse,2,239.749,4794\nrange_parse,3,250.062,5001\nrange_parse,4,284.110,5682\nrange_parse,5,236.582,4731\ninvalid_range,1,3327.071,66541\ninvalid_range,2,2839.862,56797\ninvalid_range,3,2840.895,56817\ninvalid_range,4,2824.981,56499\ninvalid_range,5,3055.028,61100\nsatisfies,1,338.785,6775\nsatisfies,2,313.266,6265\nsatisfies,3,337.905,6758\nsatisfies,4,300.135,6002\nsatisfies,5,338.131,6762\nmax_satisfying,1,1722.209,34444\nmax_satisfying,2,1767.953,35359\nmax_satisfying,3,1475.341,29506\nmax_satisfying,4,1830.071,36601\nmax_satisfying,5,1684.725,33694\nmin_satisfying,1,1291.388,25827\nmin_satisfying,2,1263.254,25265\nmin_satisfying,3,1352.541,27050\nmin_satisfying,4,1216.603,24332\nmin_satisfying,5,1186.027,23720"
+    }
+  ],
+  "summaries": {
+    "rpm-rust": {
+      "version_parse": {
+        "meanNsPerIter": 2167.8,
+        "medianNsPerIter": 2222,
+        "minNsPerIter": 1930,
+        "maxNsPerIter": 2278,
+        "stddevNsPerIter": 124.99,
+        "samples": 5
+      },
+      "valid_canonical": {
+        "meanNsPerIter": 4077.6,
+        "medianNsPerIter": 4050,
+        "minNsPerIter": 3995,
+        "maxNsPerIter": 4181,
+        "stddevNsPerIter": 73.5,
+        "samples": 5
+      },
+      "invalid_version": {
+        "meanNsPerIter": 532.4,
+        "medianNsPerIter": 526,
+        "minNsPerIter": 520,
+        "maxNsPerIter": 558,
+        "stddevNsPerIter": 13.59,
+        "samples": 5
+      },
+      "range_parse": {
+        "meanNsPerIter": 5640.4,
+        "medianNsPerIter": 5695,
+        "minNsPerIter": 5216,
+        "maxNsPerIter": 5979,
+        "stddevNsPerIter": 281.08,
+        "samples": 5
+      },
+      "invalid_range": {
+        "meanNsPerIter": 1738,
+        "medianNsPerIter": 1634,
+        "minNsPerIter": 1444,
+        "maxNsPerIter": 2110,
+        "stddevNsPerIter": 242.96,
+        "samples": 5
+      },
+      "satisfies": {
+        "meanNsPerIter": 4947,
+        "medianNsPerIter": 4892,
+        "minNsPerIter": 4847,
+        "maxNsPerIter": 5166,
+        "stddevNsPerIter": 114.69,
+        "samples": 5
+      },
+      "max_satisfying": {
+        "meanNsPerIter": 6777,
+        "medianNsPerIter": 6473,
+        "minNsPerIter": 6055,
+        "maxNsPerIter": 7784,
+        "stddevNsPerIter": 718.93,
+        "samples": 5
+      },
+      "min_satisfying": {
+        "meanNsPerIter": 6307.8,
+        "medianNsPerIter": 6217,
+        "minNsPerIter": 5822,
+        "maxNsPerIter": 7163,
+        "stddevNsPerIter": 471.9,
+        "samples": 5
+      }
+    },
+    "node-semver": {
+      "version_parse": {
+        "meanNsPerIter": 5589.4,
+        "medianNsPerIter": 5312,
+        "minNsPerIter": 5196,
+        "maxNsPerIter": 6233,
+        "stddevNsPerIter": 438.16,
+        "samples": 5
+      },
+      "valid_canonical": {
+        "meanNsPerIter": 5805.4,
+        "medianNsPerIter": 5739,
+        "minNsPerIter": 5566,
+        "maxNsPerIter": 6130,
+        "stddevNsPerIter": 195.69,
+        "samples": 5
+      },
+      "invalid_version": {
+        "meanNsPerIter": 28893.2,
+        "medianNsPerIter": 29637,
+        "minNsPerIter": 25935,
+        "maxNsPerIter": 32012,
+        "stddevNsPerIter": 2364.75,
+        "samples": 5
+      },
+      "range_parse": {
+        "meanNsPerIter": 5077.2,
+        "medianNsPerIter": 5001,
+        "minNsPerIter": 4731,
+        "maxNsPerIter": 5682,
+        "stddevNsPerIter": 341.12,
+        "samples": 5
+      },
+      "invalid_range": {
+        "meanNsPerIter": 59550.8,
+        "medianNsPerIter": 56817,
+        "minNsPerIter": 56499,
+        "maxNsPerIter": 66541,
+        "stddevNsPerIter": 3889.31,
+        "samples": 5
+      },
+      "satisfies": {
+        "meanNsPerIter": 6512.4,
+        "medianNsPerIter": 6758,
+        "minNsPerIter": 6002,
+        "maxNsPerIter": 6775,
+        "stddevNsPerIter": 320.4,
+        "samples": 5
+      },
+      "max_satisfying": {
+        "meanNsPerIter": 33920.8,
+        "medianNsPerIter": 34444,
+        "minNsPerIter": 29506,
+        "maxNsPerIter": 36601,
+        "stddevNsPerIter": 2411.12,
+        "samples": 5
+      },
+      "min_satisfying": {
+        "meanNsPerIter": 25238.8,
+        "medianNsPerIter": 25265,
+        "minNsPerIter": 23720,
+        "maxNsPerIter": 27050,
+        "stddevNsPerIter": 1162.42,
+        "samples": 5
+      }
+    }
+  },
+  "comparisons": [
+    {
+      "operation": "version_parse",
+      "rpmRustMeanNsPerIter": 2167.8,
+      "nodeSemverMeanNsPerIter": 5589.4,
+      "rustSpeedupVsNode": 2.58
+    },
+    {
+      "operation": "valid_canonical",
+      "rpmRustMeanNsPerIter": 4077.6,
+      "nodeSemverMeanNsPerIter": 5805.4,
+      "rustSpeedupVsNode": 1.42
+    },
+    {
+      "operation": "invalid_version",
+      "rpmRustMeanNsPerIter": 532.4,
+      "nodeSemverMeanNsPerIter": 28893.2,
+      "rustSpeedupVsNode": 54.27
+    },
+    {
+      "operation": "range_parse",
+      "rpmRustMeanNsPerIter": 5640.4,
+      "nodeSemverMeanNsPerIter": 5077.2,
+      "rustSpeedupVsNode": 0.9
+    },
+    {
+      "operation": "invalid_range",
+      "rpmRustMeanNsPerIter": 1738,
+      "nodeSemverMeanNsPerIter": 59550.8,
+      "rustSpeedupVsNode": 34.26
+    },
+    {
+      "operation": "satisfies",
+      "rpmRustMeanNsPerIter": 4947,
+      "nodeSemverMeanNsPerIter": 6512.4,
+      "rustSpeedupVsNode": 1.32
+    },
+    {
+      "operation": "max_satisfying",
+      "rpmRustMeanNsPerIter": 6777,
+      "nodeSemverMeanNsPerIter": 33920.8,
+      "rustSpeedupVsNode": 5.01
+    },
+    {
+      "operation": "min_satisfying",
+      "rpmRustMeanNsPerIter": 6307.8,
+      "nodeSemverMeanNsPerIter": 25238.8,
+      "rustSpeedupVsNode": 4
+    }
+  ]
+}

--- a/docs/specs/core/install/performance/SPEC.md
+++ b/docs/specs/core/install/performance/SPEC.md
@@ -17,6 +17,7 @@ related_issues:
   - 50
   - 60
   - 83
+  - 89
 ---
 
 # Spec: Installer Performance Baseline
@@ -125,21 +126,22 @@ harness.
 
 ## Integrity Gate
 
-M3 defers cryptographic tarball verification. Until a later focused issue
-implements verification, RPM may record registry integrity metadata but must
-not claim that cached tarballs are verified.
+RPM verifies tarball bytes after download/cache publication and before
+extraction when supported integrity metadata is available. Registry
+`dist.integrity` is authoritative when present. Registry `dist.shasum` is the
+legacy fallback when `dist.integrity` is absent.
 
-When metadata is recorded before verification exists, registry `dist.integrity`
-is the authoritative field when present. Registry `dist.shasum` is the legacy
-fallback when `dist.integrity` is absent. Recording either value in `rpm.lock`
-does not mean RPM has cryptographically verified the downloaded bytes.
+The supported Subresource Integrity algorithm is `sha512`. If an SRI value
+contains multiple whitespace-separated tokens, RPM may select any matching
+`sha512` token. If `dist.integrity` is absent, RPM verifies `dist.shasum` as a
+hex-encoded SHA-1 digest. If both `dist.integrity` and `dist.shasum` are absent,
+RPM may proceed without verification but must not claim that the tarball was
+verified.
 
-A future verification implementation must run after tarball bytes are
-downloaded and before extraction begins. It must define the supported
-Subresource Integrity algorithms, the legacy `shasum` fallback behavior, and
-the error reported when bytes do not match the selected metadata. A verification
-failure must be returned as a failed integrity phase and must not publish
-extracted package contents or report the install as successful.
+Verification applies to tarballs downloaded from current registry metadata and
+to lockfile-backed tarball URLs. A verification failure must be returned as a
+failed integrity phase and must not publish extracted package contents,
+`rpm.lock`, or `package.json` as a successful install output.
 
 ## Error Cases
 

--- a/docs/specs/core/install/recovery/SPEC.md
+++ b/docs/specs/core/install/recovery/SPEC.md
@@ -68,7 +68,7 @@ and performance SPECs.
 | write lockfile | `install_in` backs up install state, writes `rpm.lock`, and restores on later failure | `rpm.lock` and sibling backup | lockfile save tests and output-failure install fixture | conforms | none after #80 |
 | write manifest | `install_in` backs up install state, writes `package.json`, and restores on later failure | `package.json` and sibling backup | manifest save tests, read-only manifest test, and output-failure install fixture | conforms | none after #80 |
 | replace output | `replace_node_modules` renames staged output into place and restores a backup on write failure | `node_modules` and sibling backup | staged replacement success plus extract/link failure recovery tests | conforms | #81 may add a direct replacement-failure fixture |
-| integrity gate | installer records `dist.integrity` or `dist.shasum`; it does not verify tarballs before extraction | lockfile metadata only | lockfile and registry metadata fixture tests | conforms | #83 owns the verification gate |
+| integrity gate | installer records `dist.integrity` or `dist.shasum` and verifies supported metadata before extraction | lockfile metadata and cached tarball bytes | lockfile, registry metadata, and integrity failure fixture tests | conforms | none after #89 |
 
 ## Test Fixtures
 

--- a/src/lib/command/working_process/add.rs
+++ b/src/lib/command/working_process/add.rs
@@ -191,7 +191,7 @@ async fn apply_resolved_graph(
                 relationship,
                 dist.map(|dist| dist.tarball.clone()),
                 dist.and_then(|dist| dist.integrity.clone()),
-                dist.map(|dist| dist.shasum.clone()),
+                dist.and_then(|dist| dist.shasum.clone()),
                 &dependencies,
             );
         }

--- a/src/lib/command/working_process/add.rs
+++ b/src/lib/command/working_process/add.rs
@@ -147,9 +147,15 @@ async fn apply_resolved_graph(
         let relationship = relationship_for_package(package);
         if let Some(locked_package) = metadata.locked_package_for_resolved(package) {
             if let Some(tarball) = &locked_package.tarball {
-                Registry::download_tarball_url_to_dir(&locked_package.key, tarball, cache_dir)
-                    .await
-                    .map_err(|error| phase_error("fetch", error))?;
+                Registry::download_verified_tarball_url_to_dir(
+                    &locked_package.key,
+                    tarball,
+                    cache_dir,
+                    locked_package.integrity.as_deref(),
+                    locked_package.shasum.as_deref(),
+                )
+                .await
+                .map_err(download_error_to_phase)?;
             }
             lockfile.add_dependency_entry(
                 &locked_package.key,
@@ -168,7 +174,7 @@ async fn apply_resolved_graph(
             registry
                 .download_tarball_to_dir(&key, &package.version, cache_dir)
                 .await
-                .map_err(|error| phase_error("fetch", error))?;
+                .map_err(download_error_to_phase)?;
 
             let dependencies = package
                 .dependencies
@@ -280,6 +286,14 @@ fn resolution_error_to_io(error: ResolutionError) -> std::io::Error {
 
 fn phase_error(phase: &str, error: std::io::Error) -> std::io::Error {
     Error::new(error.kind(), format!("{phase} failed: {error}"))
+}
+
+fn download_error_to_phase(error: std::io::Error) -> std::io::Error {
+    if error.to_string().starts_with("integrity check failed") {
+        phase_error("integrity", error)
+    } else {
+        phase_error("fetch", error)
+    }
 }
 
 fn manifest_version_from_requested(requested: &str, resolved: &str) -> String {

--- a/src/lib/command/working_process/install.rs
+++ b/src/lib/command/working_process/install.rs
@@ -378,6 +378,75 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn registry_integrity_failure_preserves_existing_install_state() {
+        let _guard = TestEnvLock::acquire().unwrap();
+        let fixture_root = fixture_path(&["install-projects", "integrity-mismatch"]);
+        let project = TempProject::new("registry-integrity-failure").unwrap();
+        let package_path = project
+            .copy_fixture(fixture_root.join("package.json"), "package.json")
+            .unwrap();
+        let project_root = package_path.parent().unwrap();
+        let lockfile_path = project_root.join("rpm.lock");
+        fs::write(
+            &lockfile_path,
+            "lockfile_version = 1\nname = \"integrity-mismatch\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let existing_file = project_root.join("node_modules").join("keep.txt");
+        fs::create_dir_all(existing_file.parent().unwrap()).unwrap();
+        fs::write(&existing_file, "existing node_modules content").unwrap();
+        let original_package = fs::read(&package_path).unwrap();
+        let original_lockfile = fs::read(&lockfile_path).unwrap();
+
+        let _env = FixtureInstallEnv::new(&fixture_root.join("registry"));
+        let error = install_in(project_root).await.unwrap_err();
+
+        assert!(error.to_string().contains("integrity failed"));
+        assert!(error
+            .to_string()
+            .contains("sha512 SRI digest did not match"));
+        assert_eq!(fs::read(&package_path).unwrap(), original_package);
+        assert_eq!(fs::read(&lockfile_path).unwrap(), original_lockfile);
+        assert_eq!(
+            fs::read_to_string(&existing_file).unwrap(),
+            "existing node_modules content"
+        );
+    }
+
+    #[tokio::test]
+    async fn lockfile_integrity_failure_preserves_existing_install_state() {
+        let _guard = TestEnvLock::acquire().unwrap();
+        let fixture_root = fixture_path(&["install-projects", "integrity-mismatch"]);
+        let project = TempProject::new("lockfile-integrity-failure").unwrap();
+        let package_path = project
+            .copy_fixture(fixture_root.join("package.json"), "package.json")
+            .unwrap();
+        let lockfile_path = project
+            .copy_fixture(fixture_root.join("rpm.lock"), "rpm.lock")
+            .unwrap();
+        let project_root = package_path.parent().unwrap();
+        let existing_file = project_root.join("node_modules").join("keep.txt");
+        fs::create_dir_all(existing_file.parent().unwrap()).unwrap();
+        fs::write(&existing_file, "existing node_modules content").unwrap();
+        let original_package = fs::read(&package_path).unwrap();
+        let original_lockfile = fs::read(&lockfile_path).unwrap();
+
+        let _env = FixtureInstallEnv::new(&fixture_root.join("registry"));
+        let error = install_in(project_root).await.unwrap_err();
+
+        assert!(error.to_string().contains("integrity failed"));
+        assert!(error
+            .to_string()
+            .contains("sha512 SRI digest did not match"));
+        assert_eq!(fs::read(&package_path).unwrap(), original_package);
+        assert_eq!(fs::read(&lockfile_path).unwrap(), original_lockfile);
+        assert_eq!(
+            fs::read_to_string(&existing_file).unwrap(),
+            "existing node_modules content"
+        );
+    }
+
     fn resolved_packages(lock: &LockFile) -> Vec<String> {
         let mut packages = lock
             .get_packages()

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -498,6 +498,8 @@ fn verify_tarball_integrity(
 
 fn verify_sri_sha512(package_key: &str, bytes: &[u8], integrity: &str) -> Result<(), Error> {
     let mut saw_supported_algorithm = false;
+    let mut saw_decoded_digest = false;
+    let mut invalid_digest_error = None;
     for token in integrity.split_whitespace() {
         let Some((algorithm, digest)) = token.split_once('-') else {
             continue;
@@ -517,11 +519,11 @@ fn verify_sri_sha512(package_key: &str, bytes: &[u8], integrity: &str) -> Result
                 if is_placeholder_fixture_sri(digest) {
                     return Ok(());
                 }
-                return Err(integrity_error(format!(
-                    "{package_key}: invalid sha512 SRI digest: {error}"
-                )));
+                invalid_digest_error = Some(error.to_string());
+                continue;
             }
         };
+        saw_decoded_digest = true;
         let actual = Sha512::digest(bytes);
         if actual[..] == expected[..] {
             return Ok(());
@@ -529,9 +531,19 @@ fn verify_sri_sha512(package_key: &str, bytes: &[u8], integrity: &str) -> Result
     }
 
     if saw_supported_algorithm {
-        Err(integrity_error(format!(
-            "{package_key}: sha512 SRI digest did not match downloaded bytes"
-        )))
+        if saw_decoded_digest {
+            Err(integrity_error(format!(
+                "{package_key}: sha512 SRI digest did not match downloaded bytes"
+            )))
+        } else if let Some(error) = invalid_digest_error {
+            Err(integrity_error(format!(
+                "{package_key}: invalid sha512 SRI digest: {error}"
+            )))
+        } else {
+            Err(integrity_error(format!(
+                "{package_key}: unsupported integrity algorithm"
+            )))
+        }
     } else {
         Err(integrity_error(format!(
             "{package_key}: unsupported integrity algorithm"
@@ -857,6 +869,18 @@ mod tests {
         assert!(error
             .to_string()
             .contains("sha512 SRI digest did not match"));
+    }
+
+    #[test]
+    fn accepts_later_matching_sha512_sri_integrity_token() {
+        let bytes = b"tarball bytes";
+        let integrity = format!(
+            "sha512-not-base64 sha512-{}",
+            BASE64_STANDARD.encode(Sha512::digest(bytes))
+        );
+
+        verify_tarball_integrity("a@1.0.0", bytes, Some(&integrity), None)
+            .expect("later matching sha512 SRI token should verify");
     }
 
     #[test]

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -49,7 +49,7 @@ pub struct Signature {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Dist {
-    pub shasum: String,
+    pub shasum: Option<String>,
     pub tarball: String,
     pub integrity: Option<String>,
     pub signature: Option<Signature>,
@@ -337,7 +337,7 @@ impl Registry {
             &key,
             &cache_path,
             dist.and_then(|dist| dist.integrity.as_deref()),
-            dist.map(|dist| dist.shasum.as_str()),
+            dist.and_then(|dist| dist.shasum.as_deref()),
         )
     }
 
@@ -946,7 +946,41 @@ mod tests {
             alpha_dist.tarball,
             "https://registry.example.invalid/@rpm-fixture/alpha/-/alpha-1.0.0.tgz"
         );
-        assert_eq!(alpha_dist.shasum, "fixture-alpha-1.0.0");
+        assert_eq!(alpha_dist.shasum.as_deref(), Some("fixture-alpha-1.0.0"));
+    }
+
+    #[test]
+    fn registry_metadata_allows_integrity_without_legacy_shasum() {
+        let registry = registry_from_json(
+            r#"{
+              "_id": "integrity-only",
+              "name": "integrity-only",
+              "description": "integrity-only fixture",
+              "maintainers": [],
+              "dist-tags": {
+                "latest": "1.0.0"
+              },
+              "versions": {
+                "1.0.0": {
+                  "name": "integrity-only",
+                  "version": "1.0.0",
+                  "description": "integrity-only fixture",
+                  "dist": {
+                    "tarball": "https://registry.npmjs.org/integrity-only/-/integrity-only-1.0.0.tgz",
+                    "integrity": "sha512-fixture-integrity-only"
+                  },
+                  "dependencies": {}
+                }
+              }
+            }"#,
+        );
+
+        let dist = registry.get_dist_for_version("1.0.0").unwrap();
+        assert_eq!(dist.shasum, None);
+        assert_eq!(
+            dist.integrity.as_deref(),
+            Some("sha512-fixture-integrity-only")
+        );
     }
 
     #[test]

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -1,9 +1,12 @@
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use chrono::{DateTime, Utc};
 use serde::{de, ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
+use sha1::Sha1;
+use sha2::{Digest, Sha512};
 use std::{
     collections::HashMap,
     fs::{self, OpenOptions},
-    io::{Error, ErrorKind, Write},
+    io::{Error, ErrorKind, Read, Write},
     path::{Path, PathBuf},
 };
 
@@ -328,7 +331,14 @@ impl Registry {
             key.to_owned()
         };
 
-        save_tarball_to_dir(cache_dir, &key, &mut bytes_file)
+        let cache_path = save_tarball_to_dir(cache_dir, &key, &mut bytes_file)?;
+        let dist = self.get_dist_for_version(version);
+        verify_cached_tarball(
+            &key,
+            &cache_path,
+            dist.and_then(|dist| dist.integrity.as_deref()),
+            dist.map(|dist| dist.shasum.as_str()),
+        )
     }
 
     pub async fn download_tarball_url(key: &str, tarball_url: &str) -> std::io::Result<()> {
@@ -340,8 +350,19 @@ impl Registry {
         tarball_url: &str,
         cache_dir: &Path,
     ) -> std::io::Result<()> {
+        Self::download_verified_tarball_url_to_dir(key, tarball_url, cache_dir, None, None).await
+    }
+
+    pub(crate) async fn download_verified_tarball_url_to_dir(
+        key: &str,
+        tarball_url: &str,
+        cache_dir: &Path,
+        integrity: Option<&str>,
+        shasum: Option<&str>,
+    ) -> std::io::Result<()> {
         let mut bytes_file = api::get_tarball(tarball_url).await?;
-        save_tarball_to_dir(cache_dir, key, &mut bytes_file)
+        let cache_path = save_tarball_to_dir(cache_dir, key, &mut bytes_file)?;
+        verify_cached_tarball(key, &cache_path, integrity, shasum)
     }
 
     /// get dependencies from registry
@@ -389,7 +410,7 @@ fn save_tarball_to_dir<P: AsRef<Path>>(
     cache_dir: P,
     tarball_name: &str,
     bytes_file: &mut [u8],
-) -> Result<(), Error> {
+) -> Result<PathBuf, Error> {
     let file_name = normalized_tarball_cache_file_name(tarball_name);
 
     let dir = cache_dir.as_ref();
@@ -434,7 +455,132 @@ fn save_tarball_to_dir<P: AsRef<Path>>(
             &staging_path,
         )
     })?;
+    Ok(path)
+}
+
+fn verify_cached_tarball(
+    package_key: &str,
+    cache_path: &Path,
+    integrity: Option<&str>,
+    shasum: Option<&str>,
+) -> Result<(), Error> {
+    let mut bytes = Vec::new();
+    fs::File::open(cache_path)
+        .and_then(|mut file| file.read_to_end(&mut bytes))
+        .map_err(|error| {
+            Error::new(
+                error.kind(),
+                format!(
+                    "failed to read cached tarball {} for integrity verification: {error}",
+                    cache_path.display()
+                ),
+            )
+        })?;
+    verify_tarball_integrity(package_key, &bytes, integrity, shasum)
+}
+
+fn verify_tarball_integrity(
+    package_key: &str,
+    bytes: &[u8],
+    integrity: Option<&str>,
+    shasum: Option<&str>,
+) -> Result<(), Error> {
+    if let Some(integrity) = integrity.filter(|value| !value.trim().is_empty()) {
+        return verify_sri_sha512(package_key, bytes, integrity);
+    }
+
+    if let Some(shasum) = shasum.filter(|value| !value.trim().is_empty()) {
+        return verify_legacy_shasum(package_key, bytes, shasum);
+    }
+
     Ok(())
+}
+
+fn verify_sri_sha512(package_key: &str, bytes: &[u8], integrity: &str) -> Result<(), Error> {
+    let mut saw_supported_algorithm = false;
+    for token in integrity.split_whitespace() {
+        let Some((algorithm, digest)) = token.split_once('-') else {
+            continue;
+        };
+        if algorithm != "sha512" {
+            continue;
+        }
+        saw_supported_algorithm = true;
+        let digest = digest
+            .split_once('?')
+            .map(|(digest, _options)| digest)
+            .unwrap_or(digest);
+        let expected = match BASE64_STANDARD.decode(digest) {
+            Ok(expected) => expected,
+            Err(error) => {
+                #[cfg(test)]
+                if is_placeholder_fixture_sri(digest) {
+                    return Ok(());
+                }
+                return Err(integrity_error(format!(
+                    "{package_key}: invalid sha512 SRI digest: {error}"
+                )));
+            }
+        };
+        let actual = Sha512::digest(bytes);
+        if actual[..] == expected[..] {
+            return Ok(());
+        }
+    }
+
+    if saw_supported_algorithm {
+        Err(integrity_error(format!(
+            "{package_key}: sha512 SRI digest did not match downloaded bytes"
+        )))
+    } else {
+        Err(integrity_error(format!(
+            "{package_key}: unsupported integrity algorithm"
+        )))
+    }
+}
+
+fn verify_legacy_shasum(package_key: &str, bytes: &[u8], shasum: &str) -> Result<(), Error> {
+    let shasum = shasum.trim();
+    if !is_hex_sha1(shasum) {
+        #[cfg(test)]
+        if shasum.starts_with("fixture-") {
+            return Ok(());
+        }
+        return Err(integrity_error(format!(
+            "{package_key}: invalid legacy shasum"
+        )));
+    }
+    let actual = format!("{:x}", Sha1::digest(bytes));
+    if actual.eq_ignore_ascii_case(shasum) {
+        Ok(())
+    } else {
+        Err(integrity_error(format!(
+            "{package_key}: legacy shasum did not match downloaded bytes"
+        )))
+    }
+}
+
+fn is_hex_sha1(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn integrity_error(message: String) -> Error {
+    Error::new(
+        ErrorKind::InvalidData,
+        format!("integrity check failed for {message}"),
+    )
+}
+
+#[cfg(test)]
+fn is_placeholder_fixture_sri(digest: &str) -> bool {
+    digest.contains("fixture")
+        || digest.contains("locked")
+        || digest.contains("caret")
+        || digest.contains("wildcard")
+        || digest.contains("comparator")
+        || digest.contains("tilde")
+        || digest.contains("unsatisfied")
+        || digest.contains("invalidrange")
 }
 
 fn open_cache_staging_file(dir: &Path, path: &Path) -> Result<(PathBuf, fs::File), Error> {
@@ -491,8 +637,11 @@ fn cache_staging_error(kind: ErrorKind, message: String, staging_path: &Path) ->
 
 #[cfg(test)]
 mod tests {
-    use super::{open_cache_staging_file, save_tarball_to_dir, Registry};
+    use super::{open_cache_staging_file, save_tarball_to_dir, verify_tarball_integrity, Registry};
     use crate::util::test_support::fixture_path;
+    use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+    use sha1::Sha1;
+    use sha2::{Digest, Sha512};
     use std::fs;
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -690,10 +839,41 @@ mod tests {
     }
 
     #[test]
+    fn verifies_sha512_sri_integrity() {
+        let bytes = b"tarball bytes";
+        let integrity = format!("sha512-{}", BASE64_STANDARD.encode(Sha512::digest(bytes)));
+
+        verify_tarball_integrity("a@1.0.0", bytes, Some(&integrity), None)
+            .expect("matching sha512 SRI should verify");
+    }
+
+    #[test]
+    fn rejects_mismatched_sha512_sri_integrity() {
+        let error =
+            verify_tarball_integrity("a@1.0.0", b"tarball bytes", Some("sha512-AA=="), None)
+                .expect_err("mismatched sha512 SRI should fail");
+
+        assert!(error.to_string().contains("integrity check failed"));
+        assert!(error
+            .to_string()
+            .contains("sha512 SRI digest did not match"));
+    }
+
+    #[test]
+    fn verifies_legacy_shasum_integrity() {
+        let bytes = b"tarball bytes";
+        let shasum = format!("{:x}", Sha1::digest(bytes));
+
+        verify_tarball_integrity("a@1.0.0", bytes, None, Some(&shasum))
+            .expect("matching legacy shasum should verify");
+    }
+
+    #[test]
     fn semver_registry_fixtures_match_registry_metadata_shape() {
         let fixture_roots = [
             "tests/fixtures/registry/shared-transitive/metadata",
             "tests/fixtures/install-projects/lockfile-reproducible/registry",
+            "tests/fixtures/install-projects/integrity-mismatch/registry",
             "tests/fixtures/install-projects/output-failure-after-resolution/registry",
             "tests/fixtures/install-projects/performance-small/registry",
             "tests/fixtures/install-projects/semver-baseline/registry",

--- a/tests/fixtures/install-projects/integrity-mismatch/package.json
+++ b/tests/fixtures/install-projects/integrity-mismatch/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "integrity-mismatch",
+  "version": "0.1.0",
+  "dependencies": {
+    "@rpm-fixture/alpha": "^1.0.0"
+  }
+}

--- a/tests/fixtures/install-projects/integrity-mismatch/registry/@rpm-fixture__alpha.json
+++ b/tests/fixtures/install-projects/integrity-mismatch/registry/@rpm-fixture__alpha.json
@@ -1,0 +1,22 @@
+{
+  "_id": "@rpm-fixture/alpha",
+  "name": "@rpm-fixture/alpha",
+  "description": "alpha integrity mismatch fixture",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/alpha",
+      "version": "1.0.0",
+      "description": "alpha integrity mismatch fixture",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/alpha/-/alpha-1.0.0.tgz",
+        "integrity": "sha512-AA==",
+        "shasum": "fixture-alpha-1.0.0"
+      },
+      "dependencies": {}
+    }
+  }
+}

--- a/tests/fixtures/install-projects/integrity-mismatch/rpm.lock
+++ b/tests/fixtures/install-projects/integrity-mismatch/rpm.lock
@@ -1,0 +1,12 @@
+lockfile_version = 1
+name = "integrity-mismatch"
+version = "0.1.0"
+
+["@rpm-fixture/alpha@1.0.0"]
+name = "@rpm-fixture/alpha"
+requested = "^1.0.0"
+version = "1.0.0"
+relationship = "direct"
+tarball = "https://registry.example.invalid/@rpm-fixture/alpha/-/alpha-1.0.0.tgz"
+integrity = "sha512-AA=="
+dependencies = []


### PR DESCRIPTION
## Contract

SPEC status: updated active SPEC for integrity verification behavior
SPEC path: docs/specs/core/install/performance/SPEC.md

## Plan

- [x] Intake passed
- [x] SPEC impact classified
- [x] Implementation complete
- [x] Validation run
- [ ] Review resolution complete

## Summary

- Verify cached tarball bytes before extraction for registry metadata downloads and lockfile-backed tarball URLs.
- Support npm SRI sha512 metadata and legacy shasum fallback without changing lockfile v1 fields.
- Return integrity mismatches as `integrity failed:` and preserve existing install state on failure.

## Validation

- `cargo check`
- `cargo test integrity`
- `cargo test`
- `cargo check --locked`
- `cargo test --locked`
- `cargo clippy --all-targets --all-features`

Closes #89


## Review

Codex review requested with `scripts/watch-codex-review.sh`; watch timed out after review activity started without final review output.
