### PR TITLE
[codex] add coverage baseline gate

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -23,3 +23,9 @@ jobs:
       run: cargo clippy --all-targets --all-features -- -D warnings
     - name: Run tests
       run: cargo test
+    - name: Install llvm tools
+      run: rustup component add llvm-tools-preview
+    - name: Install coverage tool
+      uses: taiki-e/install-action@cargo-llvm-cov
+    - name: Check coverage
+      run: rustup run stable cargo llvm-cov --locked --lib --bins --all-features --fail-under-lines 90

--- a/justfile
+++ b/justfile
@@ -47,6 +47,12 @@ test *args:
     cargo test --locked --all-targets {{args}}
     @echo "::rpm::end test"
 
+# Enforce the repository line coverage floor.
+coverage:
+    @echo "::rpm::begin coverage rustup run stable cargo llvm-cov --fail-under-lines 90"
+    rustup run stable cargo llvm-cov --locked --lib --bins --all-features --fail-under-lines 90
+    @echo "::rpm::end coverage"
+
 # Build documentation and fail on rustdoc warnings.
 docs:
     @echo "::rpm::begin docs RUSTDOCFLAGS=-Dwarnings cargo doc --locked --no-deps"

--- a/src/lib/api/mod.rs
+++ b/src/lib/api/mod.rs
@@ -123,3 +123,155 @@ fn package_name_from_tarball_url(tarball_url: &str) -> std::io::Result<String> {
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_support::fixture_path;
+    use std::{
+        ffi::OsString,
+        io,
+        path::PathBuf,
+        thread,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    struct FixtureRoot {
+        previous: Option<OsString>,
+        lock_path: PathBuf,
+    }
+
+    impl FixtureRoot {
+        fn set(path: impl AsRef<std::path::Path>) -> Self {
+            let lock_path = acquire_env_lock().expect("fixture env lock should be available");
+            let previous = std::env::var_os("RPM_REGISTRY_FIXTURE_ROOT");
+            std::env::set_var("RPM_REGISTRY_FIXTURE_ROOT", path.as_ref());
+            Self {
+                previous,
+                lock_path,
+            }
+        }
+
+        fn unset() -> Self {
+            let lock_path = acquire_env_lock().expect("fixture env lock should be available");
+            let previous = std::env::var_os("RPM_REGISTRY_FIXTURE_ROOT");
+            std::env::remove_var("RPM_REGISTRY_FIXTURE_ROOT");
+            Self {
+                previous,
+                lock_path,
+            }
+        }
+    }
+
+    impl Drop for FixtureRoot {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var("RPM_REGISTRY_FIXTURE_ROOT", value),
+                None => std::env::remove_var("RPM_REGISTRY_FIXTURE_ROOT"),
+            }
+            let _ = fs::remove_dir(&self.lock_path);
+        }
+    }
+
+    fn acquire_env_lock() -> io::Result<PathBuf> {
+        let path = std::env::temp_dir().join("rpm-install-test-env-lock");
+        loop {
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(path),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let path = std::env::temp_dir().join(format!("rpm-api-{prefix}-{nanos}"));
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[tokio::test]
+    async fn get_registry_reads_scoped_fixture_from_env_root() {
+        let _fixture_root =
+            FixtureRoot::set(fixture_path(&["registry", "shared-transitive", "metadata"]));
+
+        let registry = get_registry("@rpm-fixture/alpha", "^1.0.0")
+            .await
+            .expect("fixture registry should load");
+
+        assert_eq!(registry.name, "@rpm-fixture/alpha");
+        assert_eq!(registry.select_version("^1.0.0").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn read_registry_fixture_returns_none_without_env_root() {
+        let _fixture_root = FixtureRoot::unset();
+
+        assert!(read_registry_fixture("@rpm-fixture/alpha")
+            .expect("missing env should not fail")
+            .is_none());
+    }
+
+    #[test]
+    fn read_registry_fixture_reports_missing_and_invalid_fixtures() {
+        let temp = temp_dir("invalid-fixture");
+        let _fixture_root = FixtureRoot::set(&temp);
+
+        let missing = read_registry_fixture("@scope/missing")
+            .expect_err("missing fixture should include path context");
+        assert!(missing.to_string().contains("@scope__missing.json"));
+
+        fs::write(temp.join("@scope__broken.json"), "{").unwrap();
+        let invalid =
+            read_registry_fixture("@scope/broken").expect_err("invalid fixture JSON should fail");
+        assert_eq!(invalid.kind(), ErrorKind::InvalidData);
+        assert!(invalid.to_string().contains("@scope__broken.json"));
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn fixture_tarball_builds_minimal_package_archive() {
+        let bytes =
+            fixture_tarball("https://registry.example.invalid/@rpm-fixture/alpha/-/alpha.tgz")
+                .expect("fixture tarball should be generated");
+
+        let decoder = flate2::read::GzDecoder::new(bytes.as_slice());
+        let mut archive = tar::Archive::new(decoder);
+        let package_json = archive
+            .entries()
+            .unwrap()
+            .find_map(|entry| {
+                let mut entry = entry.unwrap();
+                if entry.path().unwrap() == std::path::Path::new("package/package.json") {
+                    let mut text = String::new();
+                    use std::io::Read;
+                    entry.read_to_string(&mut text).unwrap();
+                    Some(text)
+                } else {
+                    None
+                }
+            })
+            .expect("package.json should exist in generated archive");
+
+        assert_eq!(package_json, r#"{"name":"@rpm-fixture/alpha"}"#);
+    }
+
+    #[test]
+    fn package_name_from_tarball_url_rejects_invalid_fixture_urls() {
+        let error = package_name_from_tarball_url("not-a-url").unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("invalid fixture tarball URL"));
+
+        let error = package_name_from_tarball_url("https://registry.example.invalid/").unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        assert!(error
+            .to_string()
+            .contains("invalid fixture tarball URL path"));
+    }
+}

--- a/src/lib/package_manifest/mod.rs
+++ b/src/lib/package_manifest/mod.rs
@@ -272,4 +272,55 @@ mod package_json_test {
         let dependencies = saved.get_dependencies();
         assert!(dependencies.contains(&("socket-store".to_owned(), "^0.1.0".to_owned())));
     }
+
+    #[test]
+    fn accessors_return_defaults_for_empty_manifest() {
+        let package = PackageManifest::default();
+
+        assert_eq!(package.get_name(), "");
+        assert_eq!(package.get_version(), "");
+        assert_eq!(package.get_bin(), None);
+        assert!(package.get_dependencies().is_empty());
+        assert!(package.get_dev_dependencies().is_empty());
+        assert!(package.get_scripts().is_empty());
+    }
+
+    #[test]
+    fn dependency_mutators_create_and_extend_dependency_sets() {
+        let mut package = PackageManifest::default();
+
+        package.add_dependency("left-pad".to_owned(), "^1.0.0".to_owned());
+        package.add_dev_dependency("typescript".to_owned(), "^5.0.0".to_owned());
+        package.add_dev_dependency("vitest".to_owned(), "^2.0.0".to_owned());
+
+        assert_eq!(
+            package.get_dependencies(),
+            vec![("left-pad".to_owned(), "^1.0.0".to_owned())]
+        );
+        let dev_dependencies = package.get_dev_dependencies();
+        assert!(dev_dependencies.contains(&("typescript".to_owned(), "^5.0.0".to_owned())));
+        assert!(dev_dependencies.contains(&("vitest".to_owned(), "^2.0.0".to_owned())));
+    }
+
+    #[test]
+    fn save_to_path_reports_open_errors_with_manifest_path() {
+        let temp_project = TempProject::new("package-manifest-save-error").unwrap();
+        let directory_path = temp_project
+            .copy_fixture(
+                fixture_path(&["package_manifest", "manifest-minimal.json"]),
+                "nested/package.json",
+            )
+            .unwrap()
+            .with_file_name("directory-target");
+        std::fs::create_dir_all(&directory_path).unwrap();
+
+        let error = PackageManifest::default()
+            .save_to_path(&directory_path)
+            .expect_err("saving to a directory should fail");
+
+        assert!(error
+            .to_string()
+            .contains("failed to open package manifest"));
+        assert!(error.to_string().contains("directory-target"));
+    }
 }

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -649,7 +649,10 @@ fn cache_staging_error(kind: ErrorKind, message: String, staging_path: &Path) ->
 
 #[cfg(test)]
 mod tests {
-    use super::{open_cache_staging_file, save_tarball_to_dir, verify_tarball_integrity, Registry};
+    use super::{
+        open_cache_staging_file, save_tarball_to_dir, verify_cached_tarball,
+        verify_tarball_integrity, Registry,
+    };
     use crate::util::test_support::fixture_path;
     use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
     use sha1::Sha1;
@@ -981,6 +984,201 @@ mod tests {
             dist.integrity.as_deref(),
             Some("sha512-fixture-integrity-only")
         );
+    }
+
+    #[test]
+    fn root_metadata_fallbacks_cover_legacy_registry_shape() {
+        let registry = registry_from_json(
+            r#"{
+              "_id": "legacy-shape",
+              "name": "legacy-shape",
+              "version": "2.0.0",
+              "description": "legacy fixture",
+              "maintainers": [],
+              "dist": {
+                "tarball": "https://registry.example.invalid/legacy-shape/-/legacy-shape-2.0.0.tgz",
+                "shasum": "fixture-legacy-shape"
+              },
+              "dependencies": {
+                "left-pad": "^1.0.0",
+                "@scope/tool": "~2.0.0"
+              }
+            }"#,
+        );
+
+        assert_eq!(
+            registry.get_latest_version().map(String::as_str),
+            Some("2.0.0")
+        );
+        assert_eq!(registry.select_version("").unwrap(), "2.0.0");
+        assert_eq!(registry.select_version("latest").unwrap(), "2.0.0");
+        assert_eq!(registry.select_version("2.0.0").unwrap(), "2.0.0");
+        assert!(registry.select_version("1.0.0").is_err());
+        assert_eq!(
+            registry.get_tarball_url().as_deref(),
+            Some("https://registry.example.invalid/legacy-shape/-/legacy-shape-2.0.0.tgz")
+        );
+        assert_eq!(
+            registry
+                .get_dist_for_version("2.0.0")
+                .unwrap()
+                .shasum
+                .as_deref(),
+            Some("fixture-legacy-shape")
+        );
+
+        let dependencies = registry.get_dependencies();
+        assert!(dependencies.contains(&"left-pad@^1.0.0".to_owned()));
+        assert!(dependencies.contains(&"@scope/tool@~2.0.0".to_owned()));
+    }
+
+    #[test]
+    fn versioned_metadata_fallbacks_cover_dist_tags_and_missing_values() {
+        let registry = registry_from_json(
+            r#"{
+              "_id": "tagged",
+              "name": "tagged",
+              "description": "tagged fixture",
+              "maintainers": [],
+              "dist-tags": {
+                "latest": "1.0.0",
+                "beta": "2.0.0-beta.1"
+              },
+              "versions": {
+                "1.0.0": {
+                  "name": "tagged",
+                  "version": "1.0.0",
+                  "description": "stable",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/tagged/-/tagged-1.0.0.tgz",
+                    "shasum": "fixture-tagged-stable"
+                  },
+                  "dependencies": {
+                    "stable-child": "^1.0.0"
+                  }
+                },
+                "2.0.0-beta.1": {
+                  "name": "tagged",
+                  "version": "2.0.0-beta.1",
+                  "description": "beta",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/tagged/-/tagged-2.0.0-beta.1.tgz",
+                    "shasum": "fixture-tagged-beta"
+                  }
+                }
+              }
+            }"#,
+        );
+
+        assert_eq!(registry.select_version("beta").unwrap(), "2.0.0-beta.1");
+        assert_eq!(
+            registry.get_tarball_url().as_deref(),
+            Some("https://registry.example.invalid/tagged/-/tagged-1.0.0.tgz")
+        );
+        assert_eq!(
+            registry.get_dependencies(),
+            vec!["stable-child@^1.0.0".to_owned()]
+        );
+        assert!(registry
+            .get_dependencies_for_version("2.0.0-beta.1")
+            .is_empty());
+
+        let missing_latest = registry_from_json(
+            r#"{
+              "_id": "missing-latest",
+              "name": "missing-latest",
+              "description": "missing latest fixture",
+              "maintainers": [],
+              "dist-tags": {},
+              "versions": {}
+            }"#,
+        );
+        assert_eq!(missing_latest.get_latest_version(), None);
+        assert_eq!(missing_latest.get_tarball_name(), None);
+        assert_eq!(missing_latest.get_tarball_url(), None);
+    }
+
+    #[tokio::test]
+    async fn tarball_download_reports_missing_dist_before_fetching() {
+        let registry = registry_from_json(
+            r#"{
+              "_id": "downloadable",
+              "name": "downloadable",
+              "description": "download fixture",
+              "maintainers": [],
+              "dist-tags": {
+                "latest": "1.0.0"
+              },
+              "versions": {
+                "1.0.0": {
+                  "name": "downloadable",
+                  "version": "1.0.0",
+                  "description": "download fixture",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/downloadable/-/downloadable-1.0.0.tgz",
+                    "shasum": "fixture-downloadable"
+                  }
+                }
+              }
+            }"#,
+        );
+        let missing = registry
+            .download_tarball_to_dir("downloadable", "9.9.9", Path::new("unused"))
+            .await
+            .expect_err("missing version dist should fail before network");
+        assert!(missing.to_string().contains("missing tarball URL"));
+    }
+
+    #[test]
+    fn integrity_verification_reports_invalid_variants() {
+        let invalid_sri = verify_tarball_integrity("pkg@1.0.0", b"bytes", Some("sha512-@@@"), None)
+            .expect_err("invalid base64 SRI should fail");
+        assert!(invalid_sri
+            .to_string()
+            .contains("invalid sha512 SRI digest"));
+
+        let unsupported_sri =
+            verify_tarball_integrity("pkg@1.0.0", b"bytes", Some("sha256-abcd"), None)
+                .expect_err("unsupported SRI algorithm should fail");
+        assert!(unsupported_sri
+            .to_string()
+            .contains("unsupported integrity algorithm"));
+
+        let invalid_shasum = verify_tarball_integrity("pkg@1.0.0", b"bytes", None, Some("not-hex"))
+            .expect_err("invalid shasum should fail");
+        assert!(invalid_shasum.to_string().contains("invalid legacy shasum"));
+
+        let mismatched_shasum = verify_tarball_integrity(
+            "pkg@1.0.0",
+            b"bytes",
+            None,
+            Some("0000000000000000000000000000000000000000"),
+        )
+        .expect_err("mismatched shasum should fail");
+        assert!(mismatched_shasum
+            .to_string()
+            .contains("legacy shasum did not match"));
+    }
+
+    #[test]
+    fn verify_cached_tarball_reports_read_errors_with_path() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let temp = std::env::temp_dir().join(format!(
+            "rpm-registry-verify-cache-error-{}-{nanos}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&temp).unwrap();
+        let missing = temp.join("missing.tgz");
+
+        let error = verify_cached_tarball("pkg@1.0.0", &missing, None, None)
+            .expect_err("missing cached tarball should fail");
+
+        assert!(error.to_string().contains("failed to read cached tarball"));
+        assert!(error.to_string().contains("missing.tgz"));
+        let _ = fs::remove_dir_all(temp);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a cargo-llvm-cov based coverage recipe and CI gate at a 90% line coverage baseline
- add hermetic fixture coverage for registry API fixture loading, package manifest accessors, and registry metadata/cache integrity paths
- keep benchmark targets out of the coverage gate by using --lib --bins

## Validation
- cargo fmt --all --check
- cargo test --locked --lib
- cargo check --locked --all-targets
- cargo clippy --locked --all-targets --all-features -- -D warnings
- just coverage (91.63% line coverage, 90% gate)

## Notes
- M4 implementation changes remain stashed locally and are not included in this PR.
- Coverage will ratchet upward in later M4/M5 work.