### PR TITLE
feat(agents): run the backlog loop on cloud schedules with a gated merge

### DIFF
--- a/.agents/docs/automation-prompts.md
+++ b/.agents/docs/automation-prompts.md
@@ -1,7 +1,8 @@
 # RPM Scheduled Workflow Prompts
 
-Use these prompts after both skills pass once in a normal interactive task.
-Create the research and execution schedules as separate standalone tasks.
+Use these prompts after the related skills pass once in a normal interactive
+task. Local backlog preparation, Cloud execution, Cloud review reconciliation,
+and Cloud gated merge are separate workflows.
 
 ## Capture An Idea
 
@@ -21,41 +22,99 @@ the managed research section. Register the issue in Project #7 with the
 policy-defined research state.
 ```
 
-## Scheduled Backlog Research
+## Local Backlog Research
 
 ```text
 Use $prepare-backlog in research-cycle mode for nerdchanii/rpm.
 
 Follow .agents/workflows/backlog-policy.json. Run the backlog access preflight,
-inventory Project #7, and process at most the configured research batch. Gather
+inventory Project #7 locally, and process at most the configured research batch. Gather
 current repository, SPEC, ADR, issue, PR, dependency, and necessary primary
 external evidence. Update only the managed research section and an allowed
 lifecycle label. Treat no-work as success. Do not implement code, create a pull
 request, merge, or request Codex review.
 ```
 
-## Scheduled Ticket Execution
+## Cloud Backlog Executor
+
+Recommended interval: every 2 hours.
 
 ```text
 Use $take-ticket in scheduled mode for nerdchanii/rpm.
 
-Follow .agents/workflows/backlog-policy.json. Run the intake and backlog access
-preflights, claim at most one ready issue, and execute it in an isolated
-worktree. Keep follow-up issue creation disabled. Complete the Draft PR
-checkpoint, targeted tests, just validate, internal adversarial review,
-intentional commits, push, PR body/checklist, ready state, and final workflow
-audit. Treat no-work as success. Never merge or request Codex review.
+Follow .agents/workflows/backlog-policy.json. Use the connected GitHub plugin
+and the open issue lifecycle-label queue. Do not require gh, GH_TOKEN, or
+Project access. If any open issue is agent:claimed or agent:review-pending,
+return no-work without mutation. Otherwise select at most one agent:ready issue
+in issue-number ascending order, refetch it, preserve ordinary labels, and
+replace agent:ready with agent:claimed. Skip an issue already closed by an open
+PR. Execute it in an isolated worktree, complete contract review, tests,
+just validate, internal adversarial review, intentional commits, push, and PR
+publication. Mark the PR review-ready for repository-configured Codex Automatic
+reviews, then transition the linked issue to agent:review-pending. Treat
+no-work as a healthy idempotent result. Never merge or request @codex review.
+```
+
+## Cloud PR Feedback Reconciler
+
+Recommended interval: every 1 hour. Claude Code routines enforce a one-hour
+minimum interval; stagger the three Cloud schedules within the hour so they
+serialize through the lifecycle labels.
+
+```text
+Use $pr-review-resolution in scheduled mode for nerdchanii/rpm.
+
+Follow .agents/workflows/backlog-policy.json. Use the connected GitHub plugin
+to select at most one open PR linked to an open agent:review-pending issue,
+ordered by issue number. Collect the latest Codex Automatic review and
+unresolved review comments. If the review has not arrived, return no-work
+without mutation. Classify findings against the issue, owning SPEC, tests, and
+repository invariants. Apply only accepted in-scope findings, run focused
+validation and the appropriate repository gate, perform internal adversarial
+review, and push one intentional commit to the same PR branch. Do not assume
+Automatic review reruns after the push. Keep agent:review-pending while
+actionable P0/P1 findings remain. Otherwise remove agent:review-pending and any
+stale agent:claimed label, preserve ordinary labels, and add
+agent:awaiting-merge. Treat no-work as a healthy idempotent result. Never merge
+or request @codex review.
+```
+
+## Cloud Merge Gatekeeper
+
+Recommended interval: every 1 hour.
+
+```text
+Use $merge-gatekeeper in scheduled mode for nerdchanii/rpm.
+
+Follow .agents/workflows/backlog-policy.json merge_gate. Use the connected
+GitHub plugin to select at most one open agent:awaiting-merge issue in
+issue-number ascending order with exactly one open closing PR. Collect required
+check conclusions, mergeability, and unresolved P0/P1 review threads, normalize
+them, and confirm the decision with scripts/check-merge-gate.py. On a merge
+verdict, squash-merge through the GitHub plugin and verify the issue closed. On
+checks-pending or an unknown mergeability, return no-work without mutation. On
+a blocked verdict, transition the issue from agent:awaiting-merge to
+agent:blocked, preserve ordinary labels, and post one comment naming the exact
+reason. Treat no-work as a healthy idempotent result. Never bypass required
+checks and never request @codex review.
 ```
 
 ## Initial Rollout
 
 1. Run capture manually with one sample idea.
 2. Run one research cycle manually and inspect the issue-body diff.
-3. Move one fully refined issue to the ready state.
+3. Confirm the research cycle promoted one fully refined issue to the ready
+   state on its own; intervene only when the readiness verdict is wrong.
 4. Run scheduled ticket execution manually and inspect its Draft PR.
-5. Enable recurring research first.
-6. Enable recurring execution after the first research runs are stable.
+5. Configure branch protection on `main`: require the `verify` and `metadata`
+   checks and forbid direct pushes, so the merge gate is enforced server-side.
+6. Run the merge gatekeeper manually against one awaiting-merge issue and
+   inspect the merged result before enabling its schedule.
+7. Keep Project capture and research on the authenticated local environment.
+8. Enable the three Cloud schedules after one manual executor, reconciler, and
+   gatekeeper run.
 
-Start with one research run and one execution run per day. Stagger execution
-after research, and keep both policy batch limits at one until the run history
-is consistently clean.
+Keep both policy batch limits at one. Run only one backlog executor at a time;
+the active claimed/review-pending guard is the workflow concurrency boundary.
+The gatekeeper merges at most one PR per run, so executor, reconciler, and
+gatekeeper stay serialized through the lifecycle labels.

--- a/.agents/docs/backlog-agent-workflow.md
+++ b/.agents/docs/backlog-agent-workflow.md
@@ -38,10 +38,16 @@ flowchart LR
     E -- "Actionable" --> G["Ready state"]
     G --> H["Scheduled single-ticket claim"]
     H --> I["Claimed state"]
-    I --> J["Per-issue execution"]
+    I --> J["Per-issue execution and review-ready PR"]
+    J --> K["Review pending"]
+    K --> L["Scheduled review reconciliation"]
+    L --> M["Awaiting merge"]
+    M --> N["Scheduled gated merge"]
+    N --> O["Merged, issue closed"]
 ```
 
-GitHub Project #7 is the public backlog inventory. Lifecycle labels encode the
+GitHub Project #7 is the local roadmap and backlog-preparation inventory.
+Open GitHub issue lifecycle labels are the Cloud execution queue and encode the
 agent state. The policy file owns their exact values and transitions.
 
 ## Capture Contract
@@ -71,7 +77,7 @@ user-authored text outside the markers remains unchanged.
 
 ## Research-Cycle Contract
 
-`$prepare-backlog research-cycle` runs manually or on a schedule:
+`$prepare-backlog research-cycle` runs in the authenticated local environment:
 
 1. Inventory Project #7 before filtering.
 2. Select at most the policy research batch with
@@ -89,11 +95,17 @@ terminal result.
 
 ## Claim-and-Execute Contract
 
-`$take-ticket scheduled` inventories ready candidates, claims at most the policy
-execution batch through `scripts/backlog-gen --state ready --format jsonl`, and
-starts the per-issue workflow for the claimed issue. The
-claimer changes only the ready lifecycle label to the claimed lifecycle label.
-It does not assign a user, edit the issue body, or change Project fields.
+`$take-ticket scheduled` uses the connected GitHub plugin to inventory open
+issues with lifecycle labels. Project membership is not an execution
+condition. It returns `no-work` while any open issue is claimed or
+review-pending. Otherwise it rejects conflicting lifecycle labels, sorts ready
+issues by issue number, selects at most one, refetches it, checks for an
+existing closing open PR, and replaces ready with claimed while preserving
+ordinary labels.
+
+After implementation and validation, the caller publishes the PR, marks it
+review-ready, and replaces claimed with review-pending. Repository-configured
+Codex Automatic reviews then run asynchronously.
 
 `$take-ticket explicit <issue>` executes a user-selected issue without running
 the scheduled candidate claim flow.
@@ -101,14 +113,42 @@ the scheduled candidate claim flow.
 Scheduled runs do not post, request, or wait for `@codex review`. Repository
 code-review settings run independently after a pull request is published.
 
+## Review-Reconciliation Contract
+
+`$pr-review-resolution` scheduled mode selects at most one open PR linked to an
+open review-pending issue. It returns `no-work` when no candidate exists or the
+Codex review has not arrived. Accepted findings receive minimal changes,
+focused validation, the appropriate repository gate, an intentional commit,
+and internal adversarial review. Actionable P0/P1 findings keep the issue
+review-pending. Exhausted actionable feedback transitions the issue to
+awaiting-merge. This workflow never merges and never requests `@codex review`.
+
+## Merge-Gate Contract
+
+`$merge-gatekeeper` scheduled mode is the single authorized merge path. It
+selects at most one open awaiting-merge issue with exactly one open closing PR
+and confirms the verdict with `scripts/check-merge-gate.py` against the policy
+`merge_gate`: required checks concluded successfully, the PR is mergeable, and
+no unresolved P0/P1 review thread remains. A `merge` verdict squash-merges
+through the GitHub plugin and lets GitHub close the linked issue; lifecycle
+labels on closed issues are inert. Pending checks or unknown mergeability
+return `no-work`. Failed checks, an unmergeable PR, remaining findings, or a
+closing-PR anomaly demote the issue to blocked with one explanatory comment.
+The gatekeeper runs only as the top-level session; the tool policy hook keeps
+every subagent merge-forbidden. The workflow automation flag
+`automation.merge_pull_requests` stays `false`: subagent workflows never merge.
+
 ## Suggested Automation Split
 
-Use two independent recurring jobs:
+Use three independent Cloud recurring jobs while local backlog preparation runs
+separately:
 
 | Job | Entry | Healthy empty result |
 |---|---|---|
-| Backlog research | `$prepare-backlog research-cycle` | `no-work` |
-| Ticket execution | `$take-ticket scheduled` | `no-work` |
+| Local backlog research | `$prepare-backlog research-cycle` | `no-work` |
+| Cloud ticket execution | `$take-ticket scheduled` | `no-work` |
+| Cloud PR feedback reconciliation | `$pr-review-resolution` scheduled mode | `no-work` |
+| Cloud gated merge | `$merge-gatekeeper` scheduled mode | `no-work` |
 
 Capture remains an intent-driven action through
 `$prepare-backlog capture <idea>`. A scheduled capture source must provide a
@@ -121,23 +161,32 @@ whole backlog.
 
 ## Automation Prerequisites
 
-Both jobs run the read-only preflight:
+Local capture and research run the read-only Project preflight:
 
 ```sh
 bash scripts/check-agent-backlog-access.sh --format jsonl
 ```
 
-The GitHub identity used by the scheduled task needs repository issue access
-and Project read/write access. For a local `gh` login, grant the required
-Project scopes interactively:
+The local GitHub identity needs repository issue access and Project read/write
+access. For a local `gh` login, grant the required Project scopes
+interactively:
 
 ```sh
 gh auth refresh -s read:project -s project
 ```
 
-The queue labels must exist before the first run. Their exact names live in the
-policy file. Run ticket execution in a dedicated worktree so background changes
-remain isolated from the main checkout.
+Cloud execution, review reconciliation, and gated merge use the connected
+GitHub plugin. They do not run this preflight and do not require `gh`,
+`GH_TOKEN`, or Project access. The six lifecycle labels must exist before the
+first run. Their exact names live in the policy file. Run ticket execution in
+a dedicated worktree so background changes remain isolated from the main
+checkout.
+
+Before enabling the merge gatekeeper, protect `main` with the required status
+checks named in the policy `merge_gate` and forbid direct pushes. The
+deterministic gate script and the server-side branch protection must agree, so
+the gate cannot pass locally while GitHub would still accept an unchecked
+merge.
 
 ## Mutation Boundaries
 
@@ -146,7 +195,12 @@ remain isolated from the main checkout.
 | Idea issue creator | New issue body, initial lifecycle label, Project registration |
 | Issue refiner | Managed research region and allowed lifecycle label transition |
 | Ready-ticket claimer | Ready-to-claimed lifecycle transition |
+| Ticket publication caller | Claimed-to-review-pending transition |
+| Review reconciliation caller | Review-pending-to-awaiting-merge transition |
+| Merge gatekeeper | Gate-passed squash merge, awaiting-merge-to-blocked demotion, one blocked-reason comment |
 | All backlog readers and judges | None |
 
 Repository source, SPEC, tests, fixtures, branches, commits, pull requests, and
-reviews remain outside the backlog workflow.
+reviews remain outside the backlog workflow. The merge gatekeeper is a separate
+top-level workflow; its only repository mutation is the gate-passed merge
+itself.

--- a/.agents/docs/issue-agent-workflow.md
+++ b/.agents/docs/issue-agent-workflow.md
@@ -95,6 +95,8 @@ repository patch tools. Writer patches are constrained by role:
 - SPEC updater: `docs/specs/**`
 - test author: `tests/**` and explicitly scoped test modules under `src/**`
 - implementer: production paths, excluding tests, SPECs, and agent configuration
+- PR review resolver: accepted review fixes across production, test, and SPEC
+  paths, excluding agent configuration
 
 MCP calls are limited by the project tool-policy hook to each role's assigned
 read or mutation boundary. Backlog GitHub writers, issue intake, and authorized
@@ -116,9 +118,11 @@ until `may_create_followup_issues=true` is supplied.
 ## Review Boundary
 
 The adversarial reviewer is an internal correctness gate over the issue, SPEC,
-diff, tests, and validation evidence. The ticket workflow does not post,
-request, or wait for `@codex review`. Repository-configured code review runs
-independently after the pull request is published.
+diff, tests, and validation evidence. The ticket workflow marks the validated
+PR review-ready and moves the linked issue to review-pending. It does not post,
+request, or wait for `@codex review`. Repository-configured Codex Automatic
+review runs independently. The scheduled reconciliation workflow applies
+accepted findings and moves an exhausted review to awaiting-merge.
 
 ## Completion Enforcement
 

--- a/.agents/fixtures/backlog/cloud-active.json
+++ b/.agents/fixtures/backlog/cloud-active.json
@@ -1,0 +1,16 @@
+{
+  "issues": [
+    {
+      "number": 4,
+      "state": "OPEN",
+      "labels": ["agent:claimed", "kind:bug"],
+      "closing_prs": []
+    },
+    {
+      "number": 6,
+      "state": "OPEN",
+      "labels": ["agent:ready"],
+      "closing_prs": []
+    }
+  ]
+}

--- a/.agents/fixtures/backlog/cloud-invalid.json
+++ b/.agents/fixtures/backlog/cloud-invalid.json
@@ -1,0 +1,10 @@
+{
+  "issues": [
+    {
+      "number": 5,
+      "state": "OPEN",
+      "labels": ["agent:ready", "agent:claimed", "kind:bug"],
+      "closing_prs": []
+    }
+  ]
+}

--- a/.agents/fixtures/backlog/cloud-issues.json
+++ b/.agents/fixtures/backlog/cloud-issues.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "number": 9,
+      "url": "https://github.com/nerdchanii/rpm/issues/9",
+      "state": "OPEN",
+      "labels": ["agent:ready", "kind:feature"],
+      "closing_prs": []
+    },
+    {
+      "number": 3,
+      "url": "https://github.com/nerdchanii/rpm/issues/3",
+      "state": "OPEN",
+      "labels": ["agent:ready", "priority:high"],
+      "closing_prs": []
+    },
+    {
+      "number": 2,
+      "url": "https://github.com/nerdchanii/rpm/issues/2",
+      "state": "CLOSED",
+      "labels": ["agent:ready"],
+      "closing_prs": []
+    }
+  ]
+}

--- a/.agents/fixtures/backlog/cloud-review-ready.json
+++ b/.agents/fixtures/backlog/cloud-review-ready.json
@@ -1,0 +1,11 @@
+{
+  "issues": [
+    {
+      "number": 12,
+      "state": "OPEN",
+      "labels": ["agent:review-pending", "kind:feature"],
+      "closing_prs": [{"number": 44, "state": "OPEN"}],
+      "codex_review_present": true
+    }
+  ]
+}

--- a/.agents/fixtures/backlog/cloud-review.json
+++ b/.agents/fixtures/backlog/cloud-review.json
@@ -1,0 +1,18 @@
+{
+  "issues": [
+    {
+      "number": 12,
+      "state": "OPEN",
+      "labels": ["agent:review-pending", "kind:feature"],
+      "closing_prs": [{"number": 44, "state": "OPEN"}],
+      "codex_review_present": false
+    },
+    {
+      "number": 14,
+      "state": "OPEN",
+      "labels": ["agent:review-pending"],
+      "closing_prs": [{"number": 45, "state": "OPEN"}],
+      "codex_review_present": true
+    }
+  ]
+}

--- a/.agents/fixtures/backlog/merge-checks-failed.json
+++ b/.agents/fixtures/backlog/merge-checks-failed.json
@@ -1,0 +1,18 @@
+{
+  "issues": [
+    {
+      "number": 12,
+      "state": "OPEN",
+      "labels": ["agent:awaiting-merge", "kind:feature"],
+      "closing_prs": [
+        {
+          "number": 44,
+          "state": "OPEN",
+          "mergeable": true,
+          "checks": {"metadata": "success", "verify": "failure"},
+          "unresolved_p0_p1": false
+        }
+      ]
+    }
+  ]
+}

--- a/.agents/fixtures/backlog/merge-checks-pending.json
+++ b/.agents/fixtures/backlog/merge-checks-pending.json
@@ -1,0 +1,18 @@
+{
+  "issues": [
+    {
+      "number": 12,
+      "state": "OPEN",
+      "labels": ["agent:awaiting-merge", "kind:feature"],
+      "closing_prs": [
+        {
+          "number": 44,
+          "state": "OPEN",
+          "mergeable": true,
+          "checks": {"metadata": "success", "verify": "in_progress"},
+          "unresolved_p0_p1": false
+        }
+      ]
+    }
+  ]
+}

--- a/.agents/fixtures/backlog/merge-ready.json
+++ b/.agents/fixtures/backlog/merge-ready.json
@@ -1,0 +1,24 @@
+{
+  "issues": [
+    {
+      "number": 12,
+      "state": "OPEN",
+      "labels": ["agent:awaiting-merge", "kind:feature"],
+      "closing_prs": [
+        {
+          "number": 44,
+          "state": "OPEN",
+          "mergeable": true,
+          "checks": {"metadata": "success", "verify": "success"},
+          "unresolved_p0_p1": false
+        }
+      ]
+    },
+    {
+      "number": 16,
+      "state": "OPEN",
+      "labels": ["agent:ready"],
+      "closing_prs": []
+    }
+  ]
+}

--- a/.agents/fixtures/backlog/readiness-ready.md
+++ b/.agents/fixtures/backlog/readiness-ready.md
@@ -4,7 +4,8 @@ RPM needs a deterministic queue for scheduled issue work.
 
 ## Research
 
-Project #7 and the four agent state labels are the authoritative queue.
+Project #7 is the local research inventory, and open issue lifecycle labels are
+the Cloud execution queue.
 
 ## Contract
 

--- a/.agents/fixtures/backlog/readiness-unresolved.md
+++ b/.agents/fixtures/backlog/readiness-unresolved.md
@@ -4,7 +4,7 @@ RPM needs a deterministic queue for scheduled issue work.
 
 ## Research
 
-Project #7 contains the candidate issue.
+Project #7 contains the local research candidate.
 
 ## Contract
 

--- a/.agents/skills/merge-gatekeeper/SKILL.md
+++ b/.agents/skills/merge-gatekeeper/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: merge-gatekeeper
+description: Gated scheduled merge for RPM. Selects at most one awaiting-merge issue, verifies the deterministic merge gate, and squash-merges the linked PR or demotes the issue to blocked.
+argument-hint: "[scheduled]"
+disable-model-invocation: true
+---
+
+# Merge Gatekeeper
+
+요구 도구: Read·Bash·GitHub plugin.
+
+## Role
+
+Own the single authorized merge path for the RPM autonomous loop. This skill
+runs only as the top-level scheduled Cloud session. RPM subagents remain
+merge-forbidden by the tool policy hook; do not delegate the merge decision or
+the merge action to any subagent.
+
+The policy gate in `.agents/workflows/backlog-policy.json` under `merge_gate`
+is the complete authority for what may merge. The deterministic checker is the
+decision procedure; this skill only gathers evidence and applies the checker's
+verdict.
+
+## Scheduled Workflow
+
+1. Read `.agents/workflows/backlog-policy.json`. If `merge_gate.enabled` is not
+   exactly `true`, return `no-work` without mutation.
+2. Use the connected GitHub plugin to inventory open issues carrying the
+   `agent:awaiting-merge` label, ordered by issue number ascending. Do not
+   require `gh` or `GH_TOKEN`. Select at most the gate batch limit.
+3. Refetch the selected issue and its closing PRs. Collect for the open closing
+   PR: required check conclusions named in `merge_gate.required_checks`,
+   mergeability, and whether unresolved P0/P1 review threads remain.
+4. Normalize that evidence into the connector fixture shape and confirm the
+   decision with
+   `python3 scripts/check-merge-gate.py --issues-file <normalized-file> --operation select-merge`.
+   The script verdict is authoritative; do not merge on your own judgment.
+5. On `merge`: squash-merge the PR through the GitHub plugin using the policy
+   method, delete the branch when the gate configures it, and verify the linked
+   issue closed. Lifecycle labels on the closed issue are inert; leave them.
+6. On `no-work` (`checks-pending`, `mergeability-unknown`,
+   `no-awaiting-merge-candidate`, `merge-gate-disabled`): report and make no
+   mutation. `no-work` is a healthy idempotent result.
+7. On `blocked` (`checks-failed`, `not-mergeable`, `review-findings-remain`,
+   `multiple-lifecycle-labels`, `no-open-closing-pr`,
+   `multiple-open-closing-prs`): verify the label change with
+   `python3 scripts/check-cloud-queue-contract.py --issues-file <normalized-file> --operation transition --issue <n> --from-state awaiting-merge --to-state blocked`,
+   apply it while preserving ordinary labels, and post exactly one issue
+   comment naming the blocked reason and the evidence.
+
+## Boundaries
+
+- At most one merge per run.
+- Never bypass, override, or re-run required checks; never force a merge over
+  a failed or pending gate.
+- Never edit PR title, body, code, or review threads.
+- Never post or request `@codex review`.
+- Never reopen, retitle, or rewrite issues; the only issue mutations are the
+  blocked transition and its single explanatory comment.
+
+## Tool Surface
+
+- GitHub plugin issue, label, check, review-thread, and PR tools
+- `python3 scripts/check-merge-gate.py --issues-file <file> --operation select-merge`
+- `python3 scripts/check-cloud-queue-contract.py --issues-file <file> --operation transition --issue <n> --from-state awaiting-merge --to-state blocked`
+
+Use `/tmp/rpm-merge-gate-issue<n>.json` for the normalized evidence file. Do
+not commit it.

--- a/.agents/skills/pr-review-resolution/SKILL.md
+++ b/.agents/skills/pr-review-resolution/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pr-review-resolution
-description: Resolve RPM PR review feedback. Use after Codex or human PR comments arrive to collect review context, classify feedback, apply only accepted in-scope fixes, validate, and draft/create deferred follow-up issues when explicitly allowed.
+description: Resolve RPM PR review feedback. Use after Codex or human PR comments arrive, or on a scheduled reconciliation run, to collect review context, classify feedback, apply only accepted in-scope fixes, validate, and advance the linked issue.
 ---
 
 # PR Review Resolution
 
-요구 도구: Agent·Read·Bash.
+요구 도구: Agent·Read·Bash·GitHub plugin.
 
 ## Role
 
@@ -13,7 +13,7 @@ Own PR review feedback resolution. Keep `take-ticket` thin and keep final decisi
 
 ## Required Inputs
 
-Require a clean JSONL `review_input` event before starting:
+For an explicit or local/manual run, require a clean JSONL `review_input` event:
 
 - `pr`
 - `ticket_scope`
@@ -24,16 +24,23 @@ Require a clean JSONL `review_input` event before starting:
 
 If `may_create_followup_issues` is not exactly `true`, draft follow-up issue bodies only.
 
+For a scheduled run, read `.agents/workflows/backlog-policy.json` and discover
+the single review-pending issue and linked open PR through the GitHub plugin.
+Use issue-authored scope, the linked PR, and repository evidence as the input;
+do not invent missing product intent.
+
 ## Core Workflow
 
-1. Start after the configured external review system has produced review comments or checks.
-2. Collect existing context with `bash scripts/collect-pr-review-context.sh <pr> --format jsonl`.
-3. Return a no-work result when the collected snapshot contains no actionable feedback.
+1. In scheduled mode, use the GitHub plugin to select at most one open PR linked to an open issue in `agent:review-pending`, ordered by issue number. Return `no-work` when none exists.
+2. Use the GitHub plugin to collect the latest Codex review and unresolved review comments. Do not require `gh` in the scheduled Cloud workflow.
+3. Return `no-work` without mutation when Codex review has not arrived.
 4. Use `pr-review-resolver` to classify actionable feedback.
 5. Apply only `accept-now` fixes.
-6. Rerun or verify the delegated validation after accepted fixes.
+6. Rerun focused validation, the appropriate repository gate, and internal adversarial review after accepted fixes. Do not assume an Automatic review reruns after a push.
 7. Draft deferred follow-up issues with `scripts/create-review-followup-issue.sh`; use `--create` only when explicitly allowed.
-8. Main session owns GitHub thread replies/resolution and final acceptance.
+8. Commit and push accepted fixes to the same PR branch.
+9. Keep `agent:review-pending` when actionable P0/P1 findings remain. When no actionable finding remains, remove `agent:review-pending` and `agent:claimed`, add `agent:awaiting-merge`, and preserve all non-lifecycle labels.
+10. Never merge or post `@codex review`.
 
 ## When To Read References
 
@@ -43,8 +50,9 @@ Read [references/templates.md](references/templates.md) when you need the resolv
 
 ## Tool Surface
 
-- `bash scripts/collect-pr-review-context.sh <pr> --format jsonl`
-- `bash scripts/collect-pr-review-context.sh <pr> --format json`
+- GitHub plugin review, thread, issue, label, and PR tools for scheduled Cloud reconciliation
+- `bash scripts/collect-pr-review-context.sh <pr> --format jsonl` as a local/manual fallback
+- `bash scripts/collect-pr-review-context.sh <pr> --format json` as a local/manual fallback
 - `bash scripts/create-review-followup-issue.sh --title "<title>" --body-file <body-file> [--label <label>] --format jsonl`
 - `bash scripts/create-review-followup-issue.sh --title "<title>" --body-file <body-file> [--label <label>] --create --format jsonl`
 

--- a/.agents/skills/pr-review-resolution/references/resolution-workflow.md
+++ b/.agents/skills/pr-review-resolution/references/resolution-workflow.md
@@ -2,16 +2,16 @@
 
 ## Steps
 
-1. Start after the configured external review system has produced review comments or checks.
-2. Collect complete review context:
-   `bash scripts/collect-pr-review-context.sh <pr-number> --format jsonl`
-3. If there is no actionable review comment, submitted review, or open review thread, return `status:"complete"` with no decisions and no changes.
+1. For a scheduled run, use the GitHub plugin to find open issues in `agent:review-pending`, ordered by issue number, and select at most one linked open PR.
+2. Return `status:"no-work"` without mutation when there is no candidate or the latest Codex Automatic review has not arrived.
+3. Collect the latest Codex review and every unresolved review comment through the GitHub plugin. The local/manual fallback is `bash scripts/collect-pr-review-context.sh <pr-number> --format jsonl`.
 4. Spawn `pr-review-resolver` using the prompt in `templates.md`.
 5. Review resolver output and current diff.
 6. If resolver applied `accept-now` fixes, verify validation actually ran or rerun it in the main session.
 7. If resolver drafted follow-up issues, decide whether to create them. Use `--create` only when `may_create_followup_issues=true`.
-8. Main session replies to or resolves GitHub threads. The resolver should not be the final authority for thread resolution.
-9. Collect context again only after the external review system produces new feedback.
+8. Commit and push accepted fixes to the same PR branch, then run internal adversarial review. Do not assume Automatic review reruns.
+9. Keep `agent:review-pending` while actionable P0/P1 findings remain. Otherwise replace it with `agent:awaiting-merge` and remove stale `agent:claimed`, preserving ordinary labels.
+10. Never merge, request `@codex review`, or make a new Automatic review a completion dependency.
 
 ## Decision Taxonomy
 

--- a/.agents/skills/pr-review-resolution/references/templates.md
+++ b/.agents/skills/pr-review-resolution/references/templates.md
@@ -39,7 +39,7 @@ Return the exact Review Resolver Output shape.
 ## Review Resolver Output
 
 ```jsonl
-{"type":"review_resolution_result","data":{"status":"complete|blocked","pr":"<number-or-url>","validation":["<command-or-not-run-with-reason>"],"decisions":[{"target":"<comment-url-or-thread-id>","classification":"<classification>","reason":"<one-line reason>","action":"<action taken>"}],"changes":[{"path":"<file>","summary":"<summary>"}],"follow_up_issues":[{"state":"opened|drafted","url":"<url-or-null>","path":"<draft-path-or-null>","title":"<title>"}],"blockers":[]}}
+{"type":"review_resolution_result","data":{"status":"complete|no-work|blocked","pr":"<number-or-url-or-empty>","issue":"<number-or-url-or-empty>","review_present":true,"validation":["<command-or-not-run-with-reason>"],"adversarial_review":"pass|findings|not-run","actionable_p0_p1_remaining":false,"final_issue_state":"review-pending|awaiting-merge|unchanged","decisions":[{"target":"<comment-url-or-thread-id>","classification":"<classification>","reason":"<one-line reason>","action":"<action taken>"}],"changes":[{"path":"<file>","summary":"<summary>"}],"follow_up_issues":[{"state":"opened|drafted","url":"<url-or-null>","path":"<draft-path-or-null>","title":"<title>"}],"blockers":[]}}
 ```
 
 ## Follow-Up Issue Body

--- a/.agents/skills/prepare-backlog/SKILL.md
+++ b/.agents/skills/prepare-backlog/SKILL.md
@@ -35,7 +35,7 @@ Use `research-cycle` manually or from a scheduled run. The router advances only 
 ## Entry Workflow
 
 1. Read `.agents/workflows/backlog-policy.json`.
-2. Run `bash scripts/check-agent-backlog-access.sh --format jsonl`.
+2. Run the local Project preflight with `bash scripts/check-agent-backlog-access.sh --format jsonl`.
 3. Spawn only `rpm_workflow_manager` with:
    - `workflow=prepare-backlog`
    - `mode=capture|research-cycle`
@@ -52,3 +52,5 @@ The router owns detailed routing. Do not duplicate its manager or leaf map here.
 ## Scheduled Use
 
 A scheduled research cycle uses the policy batch limit and may update only managed research sections and allowed lifecycle labels. Schedule ticket execution separately through `$take-ticket scheduled`. This separation keeps backlog research and implementation independently retryable.
+
+Project #7 is the local roadmap and backlog-preparation inventory. Capture and research-cycle require its registration and read/write access. Cloud ticket execution uses open issue lifecycle labels and does not consume this Project inventory.

--- a/.agents/skills/take-ticket/SKILL.md
+++ b/.agents/skills/take-ticket/SKILL.md
@@ -7,7 +7,7 @@ disable-model-invocation: true
 
 # Take Ticket
 
-요구 도구: Agent·Read·Bash.
+요구 도구: Agent·Read·Bash·GitHub plugin.
 
 ## Role
 
@@ -29,7 +29,7 @@ Use `scheduled` without an issue number. The router reads `.agents/workflows/bac
 
 1. Read `.agents/workflows/backlog-policy.json`.
 2. Run `bash scripts/check-workflow-intake.sh`.
-3. For scheduled mode, run `bash scripts/check-agent-backlog-access.sh --format jsonl`. Stop before claiming when Project #7 or lifecycle labels are unavailable.
+3. For scheduled mode, use the connected GitHub plugin to verify repository and issue-label access. Do not require `gh`, `gh auth`, `GH_TOKEN`, or Project access. Project #7 is outside the Cloud execution gate.
 4. Check the current branch and preserve unrelated worktree changes.
 5. Spawn only `rpm_workflow_manager` with:
    - `workflow=take-ticket`
@@ -50,8 +50,9 @@ Use `scheduled` without an issue number. The router reads `.agents/workflows/bac
    - stage only intended files and create atomic Conventional Commits;
    - push the issue branch;
    - update the PR body with Contract, Changes, Validation, checklist, and `Closes #<issue>`;
-   - apply an approved PR label and mark the PR ready;
-   - run `bash scripts/check-workflow-final.sh <pr-number>`.
+   - apply an approved PR label and mark the PR ready so repository-configured Codex Automatic reviews can run;
+   - replace the linked issue's `agent:claimed` lifecycle label with `agent:review-pending`, preserving every non-lifecycle label;
+   - use the GitHub plugin to verify PR state, body, approved label, closing issue, and the linked issue's `agent:review-pending` state. `bash scripts/check-workflow-final.sh <pr-number>` remains a local/manual fallback.
 9. When it returns `status:"no-work"`, finish successfully without retrying in the same run.
 10. When it returns `status:"blocked"`, resolve the stated decision or report the blocker. Do not silently substitute a different workflow.
 
@@ -69,7 +70,7 @@ Use one worktree per concurrently active issue. Sequential scheduled runs may re
 4. Whether follow-up issue creation is authorized.
 5. Final diff review, commits, pushes, PR state, final workflow audit, and user-facing summary.
 
-Never post, request, or wait for `@codex review`. Repository-configured code review is a separate asynchronous system. Do not make ticket completion depend on that external review.
+Never post, request, or wait for `@codex review`. Repository-configured Codex Automatic reviews start after the PR becomes review-ready. Do not make ticket completion depend on that asynchronous review.
 Never merge the pull request.
 
 If the router reports `blocked`, stop guessing. Supply the missing decision or report the blocker.

--- a/.agents/workflows/backlog-policy.json
+++ b/.agents/workflows/backlog-policy.json
@@ -1,15 +1,27 @@
 {
-  "version": 1,
+  "version": 3,
   "repository": "nerdchanii/rpm",
+  "execution_queue": {
+    "source": "issue-labels",
+    "open_issues_only": true,
+    "order": "issue-number-ascending",
+    "active_states": [
+      "claimed",
+      "review-pending"
+    ]
+  },
   "project": {
     "owner": "@me",
     "number": 7,
-    "required": true
+    "role": "local-roadmap",
+    "required_for_execution": false
   },
   "labels": {
     "research": "agent:research",
     "ready": "agent:ready",
     "claimed": "agent:claimed",
+    "review-pending": "agent:review-pending",
+    "awaiting-merge": "agent:awaiting-merge",
     "blocked": "agent:blocked"
   },
   "batch_limits": {
@@ -35,6 +47,15 @@
     ],
     "claimed": [
       "ready",
+      "review-pending",
+      "blocked"
+    ],
+    "review-pending": [
+      "review-pending",
+      "awaiting-merge",
+      "blocked"
+    ],
+    "awaiting-merge": [
       "blocked"
     ],
     "blocked": [
@@ -46,5 +67,19 @@
     "create_followup_issues_by_default": false,
     "merge_pull_requests": false,
     "request_codex_review": false
+  },
+  "merge_gate": {
+    "enabled": true,
+    "source_state": "awaiting-merge",
+    "order": "issue-number-ascending",
+    "batch_limit": 1,
+    "required_checks": [
+      "metadata",
+      "verify"
+    ],
+    "required_mergeable": true,
+    "forbid_unresolved_p0_p1": true,
+    "method": "squash",
+    "delete_branch": true
   }
 }

--- a/.codex/agents/pr-review-resolver.toml
+++ b/.codex/agents/pr-review-resolver.toml
@@ -1,6 +1,7 @@
 name = "pr-review-resolver"
 description = "Resolve RPM PR review feedback using pr-review-resolution rules, SPEC-aware classification, validation, and deferred follow-up issues."
 nickname_candidates = ["review-resolver", "review-worker"]
+sandbox_mode = "workspace-write"
 
 developer_instructions = """
 You are the RPM PR review resolver subagent.
@@ -16,15 +17,18 @@ Inputs must include:
 - ticket scope and intended behavior
 - SPEC status and owning SPEC paths when applicable
 - validation already run and expected validation after changes
-- JSONL output from `scripts/collect-pr-review-context.sh <pr> --format jsonl`
+- a GitHub plugin snapshot of the latest Codex review and unresolved review comments, or local/manual JSONL output from `scripts/collect-pr-review-context.sh <pr> --format jsonl`
 - `may_create_followup_issues=true|false`
 
 Rules:
 - Classify every actionable review item.
 - Patch only `accept-now` items.
+- Prioritize actionable P0/P1 findings and report whether any remain.
 - Do not change production code for rejected or deferred feedback.
 - Preview deferred follow-up issues unless issue creation is explicitly allowed.
 - Never resolve GitHub threads.
+- Never merge or request `@codex review`.
+- Do not assume Automatic review reruns after a fix commit; require regression tests, validation, and internal adversarial review evidence.
 - Do not make unrelated cleanup, broad refactors, formatting-only churn, or file moves.
 - If validation fails after an accepted change, stop and return blocked JSONL.
 

--- a/.codex/agents/rpm_backlog_manager.toml
+++ b/.codex/agents/rpm_backlog_manager.toml
@@ -10,7 +10,7 @@ You are the only RPM backlog manager for the assigned run. Do not spawn another 
 You coordinate backlog mutations through direct reports. Do not edit repository files, run implementation or validation commands, mutate GitHub state, implement issues, create pull requests, request reviews, or perform a direct report's work.
 
 Your direct reports are:
-- rpm_backlog_scout: inventories Project backlog candidates and gathers duplicate or repository context.
+- rpm_backlog_scout: inventories local Project research candidates or Cloud label-queue execution candidates and gathers duplicate or repository context.
 - rpm_idea_issue_creator: creates one approved idea issue with its initial lifecycle label and Project registration.
 - rpm_issue_researcher: produces an evidence-backed research packet for one issue.
 - rpm_issue_refiner: updates only the managed research section and policy-authorized lifecycle state.
@@ -19,7 +19,7 @@ Your direct reports are:
 
 Do not teach direct reports how another role works. Give each report only its required inputs, allowed scope, authorization, and expected output.
 
-Read `.agents/workflows/backlog-policy.json` before routing. Treat it as the mechanical authority for repository identity, Project number, lifecycle labels, batch limits, automation defaults, and allowed transitions. Do not invent a label, transition, Project, or batch limit.
+Read `.agents/workflows/backlog-policy.json` before routing. Treat it as the mechanical authority for repository identity, local-roadmap Project, execution queue, lifecycle labels, batch limits, automation defaults, and allowed transitions. Do not invent a label, transition, Project, or batch limit.
 
 Required inputs:
 - mode=capture|research-cycle|claim-ready
@@ -48,12 +48,15 @@ RESEARCH_CYCLE:
 
 CLAIM_READY:
 1. Spawn rpm_backlog_scout with mode=ready-candidates.
-2. Require the canonical `scripts/backlog-gen --state ready --format jsonl` selection. Select no more than the policy execution batch limit. The configured execution contract expects at most one issue.
-3. If there is no eligible item, return `no-work`.
-4. Spawn rpm_ready_ticket_claimer with exactly one selected issue and the policy path.
-5. Return the claimed issue only after the current GitHub state is verified.
+2. Require GitHub plugin evidence for every open issue carrying any lifecycle label. Do not run `gh`, Project queries, or Project preflights.
+3. If an open issue is already claimed or review-pending, return `no-work` without mutation.
+4. Reject candidates with zero or multiple lifecycle labels. Select open ready issues in deterministic issue-number ascending order, no more than the policy execution batch limit.
+5. If there is no eligible item, return `no-work`.
+6. Reject a selected issue when an open PR already closes it.
+7. Spawn rpm_ready_ticket_claimer with exactly one selected issue and the policy path.
+8. Return the claimed issue only after the current GitHub state is verified.
 
-Research and claim selection must inventory GitHub Project #7 through the policy-defined Project coordinates before narrowing candidates. Issue labels are lifecycle state; Project membership is required.
+Research selection must inventory GitHub Project #7 through the local-roadmap coordinates before narrowing candidates. Claim selection uses open GitHub issues and lifecycle labels as its source of truth. Project membership is not an execution eligibility condition.
 
 If a direct report returns malformed output, send one focused correction request. If it remains malformed, return BLOCKED.
 If you cannot continue, do not call a parent or another manager. Return `BLOCKED: <exact reason>` to the caller that is already waiting.

--- a/.codex/agents/rpm_backlog_scout.toml
+++ b/.codex/agents/rpm_backlog_scout.toml
@@ -1,11 +1,11 @@
 name = "rpm_backlog_scout"
-description = "Read-only RPM backlog scout for Project inventory, duplicate checks, and evidence-based candidate ordering."
+description = "Read-only RPM backlog scout for local Project research inventory, Cloud label-queue execution inventory, duplicate checks, and deterministic candidate ordering."
 nickname_candidates = ["backlog-scout", "candidate-scout"]
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 
 developer_instructions = """
-You are an RPM backlog scout. Inventory the supplied repository and GitHub Project evidence for one scouting mode. Do not edit files, mutate GitHub state, create or update issues, choose product behavior, implement code, or spawn/contact other agents.
+You are an RPM backlog scout. Inventory the supplied repository using the source defined for one scouting mode. Do not edit files, mutate GitHub state, create or update issues, choose product behavior, implement code, or spawn/contact other agents.
 
 Required inputs:
 - mode=capture|research-candidates|ready-candidates
@@ -13,7 +13,7 @@ Required inputs:
 - `.agents/workflows/backlog-policy.json`
 - idea payload when mode=capture
 
-Read the policy first. Use its repository, Project, lifecycle labels, batch limits, and eligibility constraints as mechanical authority.
+Read the policy first. Use its repository, local-roadmap Project, execution queue, lifecycle labels, batch limits, and eligibility constraints as mechanical authority.
 
 For mode=capture:
 - search open and closed issues and pull requests for semantic duplicates;
@@ -23,17 +23,18 @@ For mode=capture:
 
 For candidate modes:
 - run `scripts/backlog-gen --state research --format jsonl` for research candidates;
-- run `scripts/backlog-gen --state ready --format jsonl` for ready candidates;
-- treat the emitted Project inventory, policy state, batch limit, and issue-number order as canonical;
-- include only the command-selected open issues with the required Project membership and eligible lifecycle state;
-- report conflicting lifecycle labels, missing Project registration, existing pull requests, dependencies, and unresolved product decisions;
-- preserve the canonical deterministic issue-number order;
+- treat the emitted local Project inventory, policy state, batch limit, and issue-number order as canonical for research candidates;
+- for ready candidates, use the GitHub plugin to search open repository issues with lifecycle labels and never require Project membership, `gh`, or `GH_TOKEN`;
+- before selecting ready work, return `no-work` when any open issue is claimed or review-pending;
+- require exactly one lifecycle label on every candidate and block malformed candidates;
+- exclude ready issues already closed by an open PR;
+- sort ready candidates by issue number ascending;
 - return no more candidates than the command's policy batch limit.
 
 Do not silently repair malformed items. Report them as blocked candidates.
 
 Return exactly one JSONL event:
-{"type":"backlog_scout_result","data":{"status":"complete|no-work|blocked","mode":"capture|research-candidates|ready-candidates","selection_command":"<canonical-command-or-empty>","duplicate_candidates":[{"issue":"<number-or-url>","relationship":"duplicate|related","evidence":"<evidence>"}],"candidates":[{"issue":"<number-or-url>","state":"<policy-state>","project_item":"<id-or-url>","eligibility":"eligible|blocked","evidence":["<fact>"],"blockers":["<blocker>"]}],"repository_evidence":[{"path":"<path-or-url>","observation":"<fact>"}],"blockers":[]}}
+{"type":"backlog_scout_result","data":{"status":"complete|no-work|blocked","mode":"capture|research-candidates|ready-candidates","selection_source":"project|issue-labels","selection_command":"<canonical-local-command-or-empty>","duplicate_candidates":[{"issue":"<number-or-url>","relationship":"duplicate|related","evidence":"<evidence>"}],"candidates":[{"issue":"<number-or-url>","state":"<policy-state>","project_item":"<id-or-url-or-empty>","eligibility":"eligible|blocked","evidence":["<fact>"],"blockers":["<blocker>"]}],"repository_evidence":[{"path":"<path-or-url>","observation":"<fact>"}],"blockers":[]}}
 
 If blocked, stop with `BLOCKED: <exact reason>` inside blockers. Do not call another agent.
 """

--- a/.codex/agents/rpm_issue_fetcher.toml
+++ b/.codex/agents/rpm_issue_fetcher.toml
@@ -10,8 +10,9 @@ You are an RPM issue intake agent. Fetch evidence for exactly one supplied GitHu
 Required inputs:
 - issue number or URL
 - allowed repository
+- execution mode=explicit|scheduled
 
-Run `scripts/ticket-gen <issue-number-or-url> --format jsonl` as the canonical intake command. Preserve the emitted issue body, comments, labels, assignees, linked PRs, branch, and worktree state. Verify that the fetched repository and issue match the requested target.
+For scheduled mode, use the GitHub plugin to fetch the issue, comments, lifecycle and ordinary labels, and linked open or closed PRs. Do not run `gh`, require `GH_TOKEN`, or query Project #7. For explicit local mode, `scripts/ticket-gen <issue-number-or-url> --format jsonl` remains the canonical fallback. Preserve the issue body, comments, labels, assignees, linked PRs, branch, and worktree state. Verify that the fetched repository and issue match the requested target.
 
 Do not silently replace missing fields with guesses. If GitHub access, authentication, repository identity, or the issue target fails, return a blocked result with the exact command error.
 

--- a/.codex/agents/rpm_issue_manager.toml
+++ b/.codex/agents/rpm_issue_manager.toml
@@ -50,12 +50,13 @@ Workflow state machine:
    - Rerun targeted tests, `just validate`, and adversarial review after changes.
    - Stop after the maximum correction loops and return BLOCKED if material findings remain.
 12. FOLLOW_UP: for valid deferred work, spawn rpm_followup_issue_creator. Issue creation requires may_create_followup_issues=true. Otherwise request a draft only.
-13. COMPLETE: return one workflow result to the caller. The caller owns final scope acceptance, commits, pushes, PR creation/state, and user-facing reporting.
+13. COMPLETE: return one workflow result to the caller. The caller owns final scope acceptance, intentional commits, push, PR publication, review-ready transition, the linked issue's claimed-to-review-pending transition, and user-facing reporting.
 
 External review boundary:
 - Never request, post, wait for, or depend on `@codex review`.
 - Never resolve GitHub review threads.
 - Repository-configured code review runs independently after this workflow.
+- The caller marks the PR review-ready so Codex Automatic reviews can run.
 - Internal adversarial review evidence remains part of this workflow result and does not represent a GitHub review request.
 
 Parallelism:

--- a/.codex/agents/rpm_ready_ticket_claimer.toml
+++ b/.codex/agents/rpm_ready_ticket_claimer.toml
@@ -1,5 +1,5 @@
 name = "rpm_ready_ticket_claimer"
-description = "RPM GitHub state writer that claims exactly one ready Project issue through the policy-defined ready-to-claimed transition."
+description = "RPM GitHub state writer that claims exactly one open ready issue from the label queue through the policy-defined ready-to-claimed transition."
 nickname_candidates = ["ticket-claimer", "ready-claimer"]
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
@@ -10,19 +10,20 @@ You are an RPM ready-ticket claimer. Claim exactly one supplied issue through th
 Required inputs:
 - repository and exact issue number or URL
 - `.agents/workflows/backlog-policy.json`
-- candidate evidence showing Project membership and ready state
+- GitHub plugin candidate evidence showing open state, ready state, and no existing closing open PR
 
-Read the policy first. Immediately refetch the issue and Project item before mutation. The issue must be open, registered in the policy-defined Project, have exactly the expected ready lifecycle state, and have no conflicting lifecycle label.
+Read the policy first. Use the GitHub plugin and immediately refetch the issue before mutation. The issue must be open, have exactly the expected ready lifecycle state, have no conflicting lifecycle label, and have no open PR that closes it. Do not use `gh`, `GH_TOKEN`, or Project access.
 
 Perform only this compare-and-set style mutation:
-1. remove the policy-defined ready label;
-2. add the policy-defined claimed label;
-3. refetch and verify the resulting state.
+1. copy the full current label set;
+2. replace only the policy-defined ready label with the claimed label in one issue update;
+3. preserve every non-lifecycle label;
+4. refetch and verify the resulting state.
 
 Process at most one issue. If another actor already claimed or changed the issue, return `no-work` with race evidence. Do not repair any other state and do not claim a replacement issue.
 
 Return exactly one JSONL event:
-{"type":"ready_ticket_claim_result","data":{"status":"claimed|no-work|blocked","issue":"<number-or-url>","before_state":"<policy-state>","after_state":"<policy-state-or-empty>","project_item":"<id-or-url>","verified":true,"race_evidence":["<fact>"],"blockers":[]}}
+{"type":"ready_ticket_claim_result","data":{"status":"claimed|no-work|blocked","issue":"<number-or-url>","before_state":"<policy-state>","after_state":"<policy-state-or-empty>","preserved_labels":["<non-lifecycle-label>"],"verified":true,"race_evidence":["<fact>"],"blockers":[]}}
 
 If blocked, stop with `BLOCKED: <exact reason>` inside blockers. Do not call another agent.
 """

--- a/.codex/agents/rpm_workflow_manager.toml
+++ b/.codex/agents/rpm_workflow_manager.toml
@@ -34,8 +34,9 @@ Routing:
    - use the claimed issue's written intent, scope, and exclusions without adding new product intent;
    - execute at most one issue and never exceed the policy execution batch limit in one run.
 4. When the issue workflow returns a draft-PR checkpoint, return the checkpoint to the caller. After the caller supplies the PR URL, resume the same issue workflow and relay its result.
-5. Never request, wait for, or post `@codex review`. Repository-configured external review runs independently from this workflow.
-6. Return BLOCKED with exact evidence when an authorization, user decision, worktree, or manager result is missing. Do not substitute another workflow.
+5. After the caller publishes the validated PR and marks it review-ready, require the linked issue transition from claimed to review-pending. Repository-configured Codex Automatic reviews run independently.
+6. Never request, wait for, or post `@codex review`. Never merge.
+7. Return BLOCKED with exact evidence when an authorization, user decision, worktree, or manager result is missing. Do not substitute another workflow.
 
 No-work protocol:
 - A scheduled run with no eligible issue is healthy.

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,7 @@
+version = 1
+name = "RPM"
+
+[setup]
+script = """
+cargo fetch --locked
+"""

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "SubagentStart": [
       {
-        "matcher": "^rpm_",
+        "matcher": "^(rpm_|pr-review-resolver$)",
         "hooks": [
           {
             "type": "command",
@@ -29,7 +29,7 @@
     ],
     "SubagentStop": [
       {
-        "matcher": "^rpm_",
+        "matcher": "^(rpm_|pr-review-resolver$)",
         "hooks": [
           {
             "type": "command",

--- a/.codex/hooks/agent_tool_policy.py
+++ b/.codex/hooks/agent_tool_policy.py
@@ -18,11 +18,13 @@ MANAGERS = {
     "rpm_issue_manager",
 }
 LOCAL_WRITE_ROLES = {
+    "pr-review-resolver",
     "rpm_spec_updater",
     "rpm_test_author",
     "rpm_implementer",
 }
 MCP_READ_ROLES = {
+    "pr-review-resolver",
     "rpm_backlog_scout",
     "rpm_idea_issue_creator",
     "rpm_issue_fetcher",
@@ -54,6 +56,8 @@ STATE_LABELS = {
     "agent:research",
     "agent:ready",
     "agent:claimed",
+    "agent:review-pending",
+    "agent:awaiting-merge",
     "agent:blocked",
 }
 SHELL_TOOL_PARTS = {
@@ -189,6 +193,8 @@ def path_allowed(role: str, path: PurePosixPath) -> bool:
             or text.startswith(".codex/")
             or text.startswith(".agents/")
         )
+    if role == "pr-review-resolver":
+        return not (text.startswith(".codex/") or text.startswith(".agents/"))
     return False
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ This file is a navigation and judgment guide, not the enforcement layer. Determi
 
 - Contract behavior belongs in the owning `SPEC.md` under `docs/specs/`.
 - Durable architectural decisions belong in `docs/adrs/`.
-- GitHub Project #7 is the public roadmap/backlog, especially for M4-M10 execution planning.
+- GitHub Project #7 is the local roadmap and backlog-preparation inventory, especially for M4-M10 execution planning.
+- Open issue lifecycle labels are the Cloud scheduled execution queue.
 - Draft issues can explain implementation intent, ordering, dependencies, and acceptance context, but they do not override SPECs or ADRs.
 - If code, SPEC, ADR, and issue text disagree, classify the mismatch before editing behavior.
 
@@ -32,14 +33,22 @@ For GitHub Project, milestone, roadmap, backlog, or issue-group requests:
 5. Verify against the intended target set, not only the first subset edited.
 
 The agent-backed backlog policy lives in
-`.agents/workflows/backlog-policy.json`. Raw ideas enter Project #7 with the
-research state. Only ready items are eligible for scheduled ticket execution,
-and every scheduled execution must claim one item before starting work. Respect
-the policy batch limits and allowed state transitions.
+`.agents/workflows/backlog-policy.json`. Raw ideas enter Project #7 locally with
+the research state. Only open issues carrying the ready lifecycle label are
+eligible for Cloud scheduled ticket execution, and every scheduled execution
+must claim one item before starting work. Project membership is not an
+execution eligibility condition. Respect the policy batch limits and allowed
+state transitions.
 
 Repository agents consume review feedback after it appears on a pull request.
 Codex review creation is configured outside this repository workflow; agents
 must not post an `@codex review` request.
+
+Merging is owned exclusively by the scheduled merge gatekeeper defined in
+`.agents/skills/merge-gatekeeper/`. It merges at most one awaiting-merge pull
+request per run and only when the deterministic policy `merge_gate` passes:
+required checks concluded, the PR is mergeable, and no unresolved P0/P1
+finding remains. Subagents never merge; the tool policy hook enforces this.
 
 ## Change Discipline
 
@@ -64,6 +73,12 @@ just validate
 ```
 
 Report exactly which checks ran and which did not. Do not claim completion without real evidence.
+
+## Code Review Rules
+
+- **Public contract integrity:** Flag changes to CLI, resolver, manifest, lockfile, registry, cache, install, linker, or script behavior that conflict with the owning SPEC or lack an explicit contract decision and regression coverage. The safe path identifies the owning SPEC, classifies the change, updates the narrowest contract when authorized, and adds focused regression evidence.
+- **User-controlled filesystem safety:** Flag package metadata, tarball entries, symlinks, dependency names, or lifecycle scripts that can escape workspace, cache, store, or `node_modules` boundaries, overwrite user files, or leave a partial transaction. The safe path validates and normalizes inputs before mutation, confines writes to approved roots, rejects traversal and unsafe links, and verifies rollback or atomic completion.
+- **Deterministic package state:** Flag resolution, lockfile, registry, or fixture results that depend on iteration order, network timing, ambient machine state, or an uncontrolled clock. The safe path defines stable ordering, uses explicit deterministic inputs and clocks, isolates network evidence, and proves repeatability with deterministic fixtures.
 
 ## Where Rules Belong
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,17 @@ Issue text explains intent, but it does not override an owning SPEC.
 
 ### Agent-backed backlog
 
-Unrefined product ideas use the Idea issue template and enter GitHub Project #7.
-The state labels and allowed transitions are defined in
+Unrefined product ideas use the Idea issue template and enter GitHub Project #7
+through the local backlog-preparation workflow. Cloud scheduled execution uses
+open issue lifecycle labels as its queue. The state labels and allowed
+transitions are defined in
 `.agents/workflows/backlog-policy.json`.
 
 - `agent:research`: evidence, contract impact, scope, or done criteria still need work
 - `agent:ready`: the readiness gate passed and scheduled execution may select the issue
 - `agent:claimed`: one scheduled execution owns the issue
+- `agent:review-pending`: the implementation PR is review-ready and awaits review reconciliation
+- `agent:awaiting-merge`: review reconciliation is complete and a human may decide whether to merge
 - `agent:blocked`: a user, product, permission, or dependency decision is required
 
 Scheduled research and ticket execution process at most the configured batch

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -1,0 +1,41 @@
+# Codex Cloud environment
+
+RPM can run in the Codex universal container with a repository-specific setup
+script.
+
+## Configure the environment
+
+1. Open [Codex environment settings](https://chatgpt.com/codex/settings/environments).
+2. Create or edit the environment for `nerdchanii/rpm`.
+3. Use the following setup script:
+
+   ```bash
+   ./scripts/codex-cloud-setup.sh
+   ```
+
+4. Keep agent internet access disabled for repository validation. Enable only
+   the domains required by a task that must access a live registry or GitHub.
+5. Save the environment and reset its cache after changing toolchain settings.
+
+The setup installs the Rust formatting and lint components, installs `just`
+when the universal image does not provide it, verifies the auxiliary tools used
+by repository checks, fetches locked Cargo dependencies, and checks all Rust
+targets.
+
+## Validate a cloud task
+
+Use the repository recipes documented in `AGENTS.md`:
+
+```bash
+just check
+just test
+just validate
+```
+
+`just validate` is the full repository gate. Package operations that contact a
+live registry require agent internet access; deterministic fixture tests run
+offline.
+
+The checked-in `.codex/environments/environment.toml` configures Codex desktop
+worktrees. Codex Cloud environment setup is stored in Codex environment
+settings.

--- a/scripts/backlog-gen
+++ b/scripts/backlog-gen
@@ -3,13 +3,14 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-usage: backlog-gen [--state research|ready|claimed|blocked|untracked|all] [--format json|jsonl]
+usage: backlog-gen [--state research|ready|claimed|review-pending|awaiting-merge|blocked|untracked|all] [--format json|jsonl]
 
-Read open RPM issues from the GitHub Project configured in
-.agents/workflows/backlog-policy.json. Queue states come only from the
-configured agent:* labels. Research and execution selections are capped by
-the configured batch limit. Output order is deterministic by issue number.
-The command never mutates GitHub state.
+Read open RPM issues from the local-roadmap GitHub Project configured in
+.agents/workflows/backlog-policy.json. This command supports local capture and
+research workflows; Cloud execution uses the GitHub connector and issue labels
+directly. Queue states come only from configured agent:* labels. Research
+selection is capped by its batch limit. Output order is deterministic by issue
+number. The command never mutates GitHub state.
 USAGE
 }
 
@@ -54,7 +55,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 case "${state}" in
-  research|ready|claimed|blocked|untracked|all) ;;
+  research|ready|claimed|review-pending|awaiting-merge|blocked|untracked|all) ;;
   *)
     printf 'backlog_gen.error=invalid-state:%s\n' "${state}" >&2
     exit 2
@@ -88,14 +89,18 @@ policy="${root}/.agents/workflows/backlog-policy.json"
 }
 
 if ! jq -e '
-  (.version == 1)
+  (.version == 3)
   and (.repository | type == "string" and length > 0)
   and (.project.number == 7)
   and (.project.owner | type == "string" and length > 0)
+  and (.project.role == "local-roadmap")
+  and (.project.required_for_execution == false)
   and (.labels == {
     research:"agent:research",
     ready:"agent:ready",
     claimed:"agent:claimed",
+    "review-pending":"agent:review-pending",
+    "awaiting-merge":"agent:awaiting-merge",
     blocked:"agent:blocked"
   })
   and (.batch_limits.research == 1)
@@ -111,13 +116,15 @@ project_number="$(jq -r '.project.number' "${policy}")"
 research_label="$(jq -r '.labels.research' "${policy}")"
 ready_label="$(jq -r '.labels.ready' "${policy}")"
 claimed_label="$(jq -r '.labels.claimed' "${policy}")"
+review_pending_label="$(jq -r '.labels["review-pending"]' "${policy}")"
+awaiting_merge_label="$(jq -r '.labels["awaiting-merge"]' "${policy}")"
 blocked_label="$(jq -r '.labels.blocked' "${policy}")"
 
 case "${state}" in
   research)
     batch_limit="$(jq -r '.batch_limits.research' "${policy}")"
     ;;
-  ready|claimed)
+  ready|claimed|review-pending)
     batch_limit="$(jq -r '.batch_limits.execution' "${policy}")"
     ;;
   *)
@@ -151,6 +158,8 @@ jq -n \
   --arg research_label "${research_label}" \
   --arg ready_label "${ready_label}" \
   --arg claimed_label "${claimed_label}" \
+  --arg review_pending_label "${review_pending_label}" \
+  --arg awaiting_merge_label "${awaiting_merge_label}" \
   --arg blocked_label "${blocked_label}" \
   --argjson project_number "${project_number}" \
   --arg project_owner "${project_owner}" \
@@ -164,6 +173,8 @@ jq -n \
       {state:"research", label:$research_label},
       {state:"ready", label:$ready_label},
       {state:"claimed", label:$claimed_label},
+      {state:"review-pending", label:$review_pending_label},
+      {state:"awaiting-merge", label:$awaiting_merge_label},
       {state:"blocked", label:$blocked_label}
       | select(.label as $label | $labels | index($label))
     ];

--- a/scripts/check-agent-backlog-access.sh
+++ b/scripts/check-agent-backlog-access.sh
@@ -5,9 +5,10 @@ usage() {
   cat <<'USAGE'
 usage: check-agent-backlog-access.sh [--format jsonl|text]
 
-Read-only preflight for scheduled RPM backlog work. It validates repository
-identity, the four agent queue labels, and read access to the configured
-GitHub Project and its items. It never creates or edits GitHub resources.
+Read-only preflight for local RPM backlog preparation. It validates repository
+identity, the six lifecycle labels, and read access to the configured
+local-roadmap GitHub Project and its items. Cloud ticket execution does not run
+this command. It never creates or edits GitHub resources.
 USAGE
 }
 
@@ -65,14 +66,18 @@ policy="${root}/.agents/workflows/backlog-policy.json"
 }
 
 if ! jq -e '
-  (.version == 1)
+  (.version == 2)
   and (.repository | type == "string" and length > 0)
   and (.project.number == 7)
   and (.project.owner | type == "string" and length > 0)
+  and (.project.role == "local-roadmap")
+  and (.project.required_for_execution == false)
   and (.labels == {
     research:"agent:research",
     ready:"agent:ready",
     claimed:"agent:claimed",
+    "review-pending":"agent:review-pending",
+    "awaiting-merge":"agent:awaiting-merge",
     blocked:"agent:blocked"
   })
 ' "${policy}" >/dev/null; then

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -85,13 +85,17 @@ EXPECTED_TRANSITIONS = {
     "untracked": ["research"],
     "research": ["research", "ready", "blocked"],
     "ready": ["claimed", "blocked"],
-    "claimed": ["ready", "blocked"],
+    "claimed": ["ready", "review-pending", "blocked"],
+    "review-pending": ["review-pending", "awaiting-merge", "blocked"],
+    "awaiting-merge": ["blocked"],
     "blocked": ["research", "ready"],
 }
 EXPECTED_LABELS = {
     "research": "agent:research",
     "ready": "agent:ready",
     "claimed": "agent:claimed",
+    "review-pending": "agent:review-pending",
+    "awaiting-merge": "agent:awaiting-merge",
     "blocked": "agent:blocked",
 }
 
@@ -138,15 +142,26 @@ def check_policy(errors: list[str]) -> None:
     if not isinstance(policy, dict):
         fail(errors, f"{POLICY_PATH.relative_to(ROOT)}: policy must be an object")
         return
-    if policy.get("version") != 1:
-        fail(errors, f"{POLICY_PATH.relative_to(ROOT)}: version must be 1")
+    if policy.get("version") != 3:
+        fail(errors, f"{POLICY_PATH.relative_to(ROOT)}: version must be 3")
     if policy.get("repository") != "nerdchanii/rpm":
         fail(errors, f"{POLICY_PATH.relative_to(ROOT)}: repository must be nerdchanii/rpm")
+    queue = policy.get("execution_queue")
+    if queue != {
+        "source": "issue-labels",
+        "open_issues_only": True,
+        "order": "issue-number-ascending",
+        "active_states": ["claimed", "review-pending"],
+    }:
+        fail(errors, f"{POLICY_PATH.relative_to(ROOT)}: invalid execution queue contract")
     project = policy.get("project")
-    if not isinstance(project, dict) or project.get("number") != 7 or project.get(
-        "required"
-    ) is not True:
-        fail(errors, f"{POLICY_PATH.relative_to(ROOT)}: Project #7 must be required")
+    if not isinstance(project, dict) or project != {
+        "owner": "@me",
+        "number": 7,
+        "role": "local-roadmap",
+        "required_for_execution": False,
+    }:
+        fail(errors, f"{POLICY_PATH.relative_to(ROOT)}: invalid local-roadmap Project contract")
     if policy.get("labels") != EXPECTED_LABELS:
         fail(errors, f"{POLICY_PATH.relative_to(ROOT)}: lifecycle labels changed")
     if policy.get("batch_limits") != {"research": 1, "execution": 1}:
@@ -164,8 +179,20 @@ def check_policy(errors: list[str]) -> None:
     ):
         fail(
             errors,
-            f"{POLICY_PATH.relative_to(ROOT)}: automatic follow-ups, merge, and Codex review must stay disabled",
+            f"{POLICY_PATH.relative_to(ROOT)}: automatic follow-ups, subagent merge, and Codex review must stay disabled",
         )
+    if policy.get("merge_gate") != {
+        "enabled": True,
+        "source_state": "awaiting-merge",
+        "order": "issue-number-ascending",
+        "batch_limit": 1,
+        "required_checks": ["metadata", "verify"],
+        "required_mergeable": True,
+        "forbid_unresolved_p0_p1": True,
+        "method": "squash",
+        "delete_branch": True,
+    }:
+        fail(errors, f"{POLICY_PATH.relative_to(ROOT)}: invalid merge-gate contract")
 
 
 def check_role_contracts(
@@ -302,6 +329,30 @@ def check_entries_and_assets(errors: list[str]) -> None:
                 if required not in text:
                     fail(errors, f"{path.relative_to(ROOT)}: missing research contract {required!r}")
 
+    gatekeeper = ROOT / ".agents" / "skills" / "merge-gatekeeper" / "SKILL.md"
+    values = parse_frontmatter(gatekeeper, errors)
+    if values.get("disable-model-invocation") != "true":
+        fail(errors, f"{gatekeeper.relative_to(ROOT)}: entry must be hidden from model invocation")
+    try:
+        text = gatekeeper.read_text()
+    except OSError:
+        text = ""
+    if text:
+        for required in (
+            "no-work",
+            "check-merge-gate.py",
+            "At most one merge per run",
+            "merge_gate",
+        ):
+            if required not in text:
+                fail(errors, f"{gatekeeper.relative_to(ROOT)}: missing merge-gate contract {required!r}")
+        leaked = sorted(role for role in EXPECTED_SANDBOX if role in text)
+        if leaked:
+            fail(
+                errors,
+                f"{gatekeeper.relative_to(ROOT)}: gatekeeper must not delegate to roles: {', '.join(leaked)}",
+            )
+
     for relative in FORBIDDEN_ASSETS:
         path = ROOT / relative
         if path.is_file() or (path.is_dir() and any(item.is_file() for item in path.rglob("*"))):
@@ -332,6 +383,8 @@ def check_deterministic_assets(errors: list[str]) -> None:
     required_files = (
         "scripts/backlog-gen",
         "scripts/check-agent-backlog-access.sh",
+        "scripts/check-cloud-queue-contract.py",
+        "scripts/check-merge-gate.py",
         "scripts/check-agent-issue-readiness.py",
         ".codex/hooks/agent_tool_policy.py",
         ".codex/hooks/issue_manager_stop_gate.py",
@@ -464,6 +517,13 @@ def check_tool_policy_runtime(errors: list[str]) -> None:
             "rpm_backlog_manager",
             "exec_command",
             {"cmd": "gh issue create --title x --body y"},
+            2,
+        ),
+        (
+            "review-resolver-merge",
+            "pr-review-resolver",
+            "exec_command",
+            {"cmd": "gh pr merge 1 --squash"},
             2,
         ),
     )

--- a/scripts/check-cloud-queue-contract.py
+++ b/scripts/check-cloud-queue-contract.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Validate deterministic connector-normalized Cloud queue decisions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: str) -> dict[str, object]:
+    value = json.loads(Path(path).read_text())
+    if not isinstance(value, dict):
+        raise ValueError("fixture must be a JSON object")
+    return value
+
+
+def lifecycle_labels(policy: dict[str, object]) -> dict[str, str]:
+    labels = policy.get("labels")
+    if not isinstance(labels, dict):
+        raise ValueError("policy labels must be an object")
+    return {str(state): str(label) for state, label in labels.items()}
+
+
+def issue_labels(issue: dict[str, object]) -> list[str]:
+    labels = issue.get("labels", [])
+    if not isinstance(labels, list):
+        raise ValueError("issue labels must be an array")
+    return sorted(str(label) for label in labels)
+
+
+def issue_state(issue: dict[str, object], lifecycle: dict[str, str]) -> tuple[str, list[str]]:
+    labels = issue_labels(issue)
+    states = sorted(state for state, label in lifecycle.items() if label in labels)
+    if len(states) == 0:
+        return "untracked", states
+    if len(states) == 1:
+        return states[0], states
+    return "invalid", states
+
+
+def is_open(issue: dict[str, object]) -> bool:
+    return str(issue.get("state", "")).casefold() == "open"
+
+
+def has_open_closing_pr(issue: dict[str, object]) -> bool:
+    prs = issue.get("closing_prs", [])
+    if not isinstance(prs, list):
+        raise ValueError("closing_prs must be an array")
+    return any(
+        isinstance(pr, dict) and str(pr.get("state", "")).casefold() == "open"
+        for pr in prs
+    )
+
+
+def normalized_issues(fixture: dict[str, object]) -> list[dict[str, object]]:
+    issues = fixture.get("issues")
+    if not isinstance(issues, list) or not all(isinstance(issue, dict) for issue in issues):
+        raise ValueError("fixture issues must be an array of objects")
+    return sorted(issues, key=lambda issue: (int(issue.get("number", 0)), str(issue.get("url", ""))))
+
+
+def select_execution(
+    fixture: dict[str, object], lifecycle: dict[str, str], batch_limit: int
+) -> dict[str, object]:
+    open_issues = [issue for issue in normalized_issues(fixture) if is_open(issue)]
+    invalid = []
+    states: list[tuple[dict[str, object], str]] = []
+    for issue in open_issues:
+        state, matched = issue_state(issue, lifecycle)
+        if state == "invalid":
+            invalid.append({"number": issue.get("number"), "states": matched})
+        states.append((issue, state))
+    if invalid:
+        return {"status": "blocked", "reason": "multiple-lifecycle-labels", "invalid": invalid, "issues": []}
+    active = [
+        int(issue.get("number", 0))
+        for issue, state in states
+        if state in {"claimed", "review-pending"}
+    ]
+    if active:
+        return {"status": "no-work", "reason": "active-work", "active": active, "issues": []}
+    selected = [
+        issue
+        for issue, state in states
+        if state == "ready" and not has_open_closing_pr(issue)
+    ][:batch_limit]
+    return {
+        "status": "selected" if selected else "no-work",
+        "reason": "ready" if selected else "no-ready-issue",
+        "issues": [int(issue.get("number", 0)) for issue in selected],
+    }
+
+
+def select_review(fixture: dict[str, object], lifecycle: dict[str, str]) -> dict[str, object]:
+    candidates = []
+    for issue in normalized_issues(fixture):
+        state, matched = issue_state(issue, lifecycle)
+        if len(matched) > 1:
+            return {
+                "status": "blocked",
+                "reason": "multiple-lifecycle-labels",
+                "invalid": [{"number": issue.get("number"), "states": matched}],
+                "issues": [],
+            }
+        if is_open(issue) and state == "review-pending" and has_open_closing_pr(issue):
+            candidates.append(issue)
+    if not candidates:
+        return {"status": "no-work", "reason": "no-review-pending-pr", "issues": []}
+    selected = candidates[0]
+    if selected.get("codex_review_present") is not True:
+        return {
+            "status": "no-work",
+            "reason": "review-not-arrived",
+            "issues": [int(selected.get("number", 0))],
+        }
+    return {
+        "status": "selected",
+        "reason": "review-present",
+        "issues": [int(selected.get("number", 0))],
+    }
+
+
+def transition(
+    fixture: dict[str, object],
+    lifecycle: dict[str, str],
+    issue_number: int,
+    before: str,
+    after: str,
+) -> dict[str, object]:
+    issue = next(
+        (item for item in normalized_issues(fixture) if int(item.get("number", 0)) == issue_number),
+        None,
+    )
+    if issue is None:
+        return {"status": "blocked", "reason": "issue-not-found"}
+    current, matched = issue_state(issue, lifecycle)
+    if not is_open(issue) or current != before or len(matched) != 1:
+        return {"status": "no-work", "reason": "compare-and-set-mismatch", "current": current}
+    labels = issue_labels(issue)
+    ordinary = sorted(label for label in labels if label not in lifecycle.values())
+    result_labels = sorted([*ordinary, lifecycle[after]])
+    return {
+        "status": "transition",
+        "issue": issue_number,
+        "before": before,
+        "after": after,
+        "preserved_labels": ordinary,
+        "labels": result_labels,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--policy", default=".agents/workflows/backlog-policy.json")
+    parser.add_argument("--issues-file", required=True)
+    parser.add_argument(
+        "--operation",
+        required=True,
+        choices=("select-execution", "select-review", "transition"),
+    )
+    parser.add_argument("--issue", type=int)
+    parser.add_argument("--from-state")
+    parser.add_argument("--to-state")
+    args = parser.parse_args()
+
+    policy = load_json(args.policy)
+    fixture = load_json(args.issues_file)
+    lifecycle = lifecycle_labels(policy)
+    if args.operation == "select-execution":
+        limit = int(dict(policy["batch_limits"])["execution"])
+        result = select_execution(fixture, lifecycle, limit)
+    elif args.operation == "select-review":
+        result = select_review(fixture, lifecycle)
+    else:
+        if args.issue is None or args.from_state is None or args.to_state is None:
+            parser.error("transition requires --issue, --from-state, and --to-state")
+        result = transition(
+            fixture,
+            lifecycle,
+            args.issue,
+            args.from_state,
+            args.to_state,
+        )
+    print(json.dumps({"type": "cloud_queue_contract", "data": result}, sort_keys=True))
+    return 1 if result.get("status") == "blocked" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-merge-gate.py
+++ b/scripts/check-merge-gate.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Validate deterministic connector-normalized merge-gate decisions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: str) -> dict[str, object]:
+    value = json.loads(Path(path).read_text())
+    if not isinstance(value, dict):
+        raise ValueError("fixture must be a JSON object")
+    return value
+
+
+def lifecycle_labels(policy: dict[str, object]) -> dict[str, str]:
+    labels = policy.get("labels")
+    if not isinstance(labels, dict):
+        raise ValueError("policy labels must be an object")
+    return {str(state): str(label) for state, label in labels.items()}
+
+
+def merge_gate(policy: dict[str, object]) -> dict[str, object]:
+    gate = policy.get("merge_gate")
+    if not isinstance(gate, dict):
+        raise ValueError("policy merge_gate must be an object")
+    return gate
+
+
+def issue_labels(issue: dict[str, object]) -> list[str]:
+    labels = issue.get("labels", [])
+    if not isinstance(labels, list):
+        raise ValueError("issue labels must be an array")
+    return sorted(str(label) for label in labels)
+
+
+def issue_state(issue: dict[str, object], lifecycle: dict[str, str]) -> tuple[str, list[str]]:
+    labels = issue_labels(issue)
+    states = sorted(state for state, label in lifecycle.items() if label in labels)
+    if len(states) == 0:
+        return "untracked", states
+    if len(states) == 1:
+        return states[0], states
+    return "invalid", states
+
+
+def is_open(value: dict[str, object]) -> bool:
+    return str(value.get("state", "")).casefold() == "open"
+
+
+def open_closing_prs(issue: dict[str, object]) -> list[dict[str, object]]:
+    prs = issue.get("closing_prs", [])
+    if not isinstance(prs, list):
+        raise ValueError("closing_prs must be an array")
+    return [pr for pr in prs if isinstance(pr, dict) and is_open(pr)]
+
+
+def normalized_issues(fixture: dict[str, object]) -> list[dict[str, object]]:
+    issues = fixture.get("issues")
+    if not isinstance(issues, list) or not all(isinstance(issue, dict) for issue in issues):
+        raise ValueError("fixture issues must be an array of objects")
+    return sorted(issues, key=lambda issue: (int(issue.get("number", 0)), str(issue.get("url", ""))))
+
+
+def evaluate_gate(
+    gate: dict[str, object], issue: dict[str, object], pr: dict[str, object]
+) -> dict[str, object]:
+    issue_number = int(issue.get("number", 0))
+    pr_number = int(pr.get("number", 0))
+    checks = pr.get("checks", {})
+    if not isinstance(checks, dict):
+        raise ValueError("pr checks must be an object")
+    conclusions = {str(name): str(conclusion).casefold() for name, conclusion in checks.items()}
+    required = [str(name) for name in list(gate.get("required_checks", []))]
+    failed = sorted(
+        name
+        for name in required
+        if conclusions.get(name) in {"failure", "cancelled", "timed_out", "action_required"}
+    )
+    if failed:
+        return {
+            "status": "blocked",
+            "reason": "checks-failed",
+            "issue": issue_number,
+            "pr": pr_number,
+            "checks": failed,
+        }
+    pending = sorted(name for name in required if conclusions.get(name) != "success")
+    if pending:
+        return {
+            "status": "no-work",
+            "reason": "checks-pending",
+            "issue": issue_number,
+            "pr": pr_number,
+            "checks": pending,
+        }
+    if gate.get("required_mergeable") is True and pr.get("mergeable") is not True:
+        reason = "not-mergeable" if pr.get("mergeable") is False else "mergeability-unknown"
+        status = "blocked" if pr.get("mergeable") is False else "no-work"
+        return {"status": status, "reason": reason, "issue": issue_number, "pr": pr_number}
+    if gate.get("forbid_unresolved_p0_p1") is True and pr.get("unresolved_p0_p1") is not False:
+        return {
+            "status": "blocked",
+            "reason": "review-findings-remain",
+            "issue": issue_number,
+            "pr": pr_number,
+        }
+    return {
+        "status": "merge",
+        "reason": "gate-passed",
+        "issue": issue_number,
+        "pr": pr_number,
+        "method": str(gate.get("method", "")),
+        "delete_branch": gate.get("delete_branch") is True,
+    }
+
+
+def select_merge(
+    fixture: dict[str, object], lifecycle: dict[str, str], gate: dict[str, object]
+) -> dict[str, object]:
+    if gate.get("enabled") is not True:
+        return {"status": "no-work", "reason": "merge-gate-disabled"}
+    source_state = str(gate.get("source_state", "awaiting-merge"))
+    candidates = []
+    for issue in normalized_issues(fixture):
+        state, matched = issue_state(issue, lifecycle)
+        if len(matched) > 1:
+            return {
+                "status": "blocked",
+                "reason": "multiple-lifecycle-labels",
+                "invalid": [{"number": issue.get("number"), "states": matched}],
+            }
+        if is_open(issue) and state == source_state:
+            candidates.append(issue)
+    if not candidates:
+        return {"status": "no-work", "reason": "no-awaiting-merge-candidate"}
+    selected = candidates[0]
+    prs = open_closing_prs(selected)
+    if len(prs) == 0:
+        return {
+            "status": "blocked",
+            "reason": "no-open-closing-pr",
+            "issue": int(selected.get("number", 0)),
+        }
+    if len(prs) > 1:
+        return {
+            "status": "blocked",
+            "reason": "multiple-open-closing-prs",
+            "issue": int(selected.get("number", 0)),
+        }
+    return evaluate_gate(gate, selected, prs[0])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--policy", default=".agents/workflows/backlog-policy.json")
+    parser.add_argument("--issues-file", required=True)
+    parser.add_argument("--operation", required=True, choices=("select-merge",))
+    args = parser.parse_args()
+
+    policy = load_json(args.policy)
+    fixture = load_json(args.issues_file)
+    result = select_merge(fixture, lifecycle_labels(policy), merge_gate(policy))
+    print(json.dumps({"type": "merge_gate_contract", "data": result}, sort_keys=True))
+    return 1 if result.get("status") == "blocked" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-workflow-intake.sh
+++ b/scripts/check-workflow-intake.sh
@@ -15,13 +15,6 @@ else
   printf 'workflow_intake.worktree=clean\n'
 fi
 
-if gh auth status >/dev/null 2>&1; then
-  printf 'workflow_intake.gh_auth=ok\n'
-else
-  status="fail"
-  printf 'workflow_intake.gh_auth=fail\n'
-fi
-
 if git remote get-url origin >/dev/null 2>&1; then
   printf 'workflow_intake.origin=ok\n'
 else

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v cargo >/dev/null 2>&1; then
+  printf 'codex-cloud-setup: cargo is required\n' >&2
+  exit 1
+fi
+
+if command -v rustup >/dev/null 2>&1; then
+  rust_components=()
+  command -v rustfmt >/dev/null 2>&1 || rust_components+=(rustfmt)
+  command -v cargo-clippy >/dev/null 2>&1 || rust_components+=(clippy)
+  if [ "${#rust_components[@]}" -gt 0 ]; then
+    rustup component add "${rust_components[@]}"
+  fi
+fi
+
+if ! command -v just >/dev/null 2>&1; then
+  cargo install just --locked
+fi
+
+for command_name in jq node python3; do
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    printf 'codex-cloud-setup: %s is required\n' "${command_name}" >&2
+    exit 1
+  fi
+done
+
+cargo fetch --locked
+cargo check --locked --all-targets

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -493,7 +493,7 @@ check_backlog_inventory_order() {
 for skill in .agents/skills/*; do
   [ -d "${skill}" ] || continue
   name="$(basename "${skill}")"
-  if [ "${name}" = "take-ticket" ] || [ "${name}" = "prepare-backlog" ]; then
+  if [ "${name}" = "take-ticket" ] || [ "${name}" = "prepare-backlog" ] || [ "${name}" = "merge-gatekeeper" ]; then
     emit_check \
       "skill_${name}" \
       "ok" \
@@ -518,14 +518,23 @@ if [ -d .codex/agents ]; then
 fi
 
 check "backlog_policy_schema" jq -e '
-  .version == 1
+  .version == 3
   and .repository == "nerdchanii/rpm"
+  and .execution_queue == {
+    source:"issue-labels",
+    open_issues_only:true,
+    order:"issue-number-ascending",
+    active_states:["claimed","review-pending"]
+  }
   and .project.number == 7
-  and .project.required == true
+  and .project.role == "local-roadmap"
+  and .project.required_for_execution == false
   and .labels == {
     research:"agent:research",
     ready:"agent:ready",
     claimed:"agent:claimed",
+    "review-pending":"agent:review-pending",
+    "awaiting-merge":"agent:awaiting-merge",
     blocked:"agent:blocked"
   }
   and .batch_limits == {research:1,execution:1}
@@ -533,8 +542,26 @@ check "backlog_policy_schema" jq -e '
     untracked:["research"],
     research:["research","ready","blocked"],
     ready:["claimed","blocked"],
-    claimed:["ready","blocked"],
+    claimed:["ready","review-pending","blocked"],
+    "review-pending":["review-pending","awaiting-merge","blocked"],
+    "awaiting-merge":["blocked"],
     blocked:["research","ready"]
+  }
+  and .automation == {
+    create_followup_issues_by_default:false,
+    merge_pull_requests:false,
+    request_codex_review:false
+  }
+  and .merge_gate == {
+    enabled:true,
+    source_state:"awaiting-merge",
+    order:"issue-number-ascending",
+    batch_limit:1,
+    required_checks:["metadata","verify"],
+    required_mergeable:true,
+    forbid_unresolved_p0_p1:true,
+    method:"squash",
+    delete_branch:true
   }
 ' .agents/workflows/backlog-policy.json
 
@@ -564,6 +591,10 @@ check "script_check_agent_issue_readiness_syntax" \
   python3 -c 'import ast,pathlib; ast.parse(pathlib.Path("scripts/check-agent-issue-readiness.py").read_text())'
 check "script_check_agent_organization_syntax" \
   python3 -c 'import ast,pathlib; ast.parse(pathlib.Path("scripts/check-agent-organization.py").read_text())'
+check "script_check_cloud_queue_contract_syntax" \
+  python3 -c 'import ast,pathlib; ast.parse(pathlib.Path("scripts/check-cloud-queue-contract.py").read_text())'
+check "script_check_merge_gate_syntax" \
+  python3 -c 'import ast,pathlib; ast.parse(pathlib.Path("scripts/check-merge-gate.py").read_text())'
 check "script_check_claude_security_syntax" \
   bash -n scripts/check-claude-security.sh
 check "script_validate_agent_workflow_assets_syntax" \
@@ -578,6 +609,145 @@ check "readiness_live_issue_fixture" check_readiness_live_issue
 check "backlog_research_batch" check_backlog_research_batch
 check "backlog_no_work" check_backlog_no_work
 check "backlog_inventory_order" check_backlog_inventory_order
+
+check "cloud_label_only_selection" sh -c '
+  output="$(python3 scripts/check-cloud-queue-contract.py \
+    --issues-file .agents/fixtures/backlog/cloud-issues.json \
+    --operation select-execution)"
+  printf "%s\n" "$output" | jq -e "
+    .data.status == \"selected\"
+    and .data.issues == [3]
+  " >/dev/null
+'
+check "cloud_multiple_lifecycle_blocked" sh -c '
+  set +e
+  output="$(python3 scripts/check-cloud-queue-contract.py \
+    --issues-file .agents/fixtures/backlog/cloud-invalid.json \
+    --operation select-execution)"
+  code=$?
+  set -e
+  [ "$code" -eq 1 ]
+  printf "%s\n" "$output" | jq -e "
+    .data.status == \"blocked\"
+    and .data.reason == \"multiple-lifecycle-labels\"
+  " >/dev/null
+'
+check "cloud_active_work_no_work" sh -c '
+  output="$(python3 scripts/check-cloud-queue-contract.py \
+    --issues-file .agents/fixtures/backlog/cloud-active.json \
+    --operation select-execution)"
+  printf "%s\n" "$output" | jq -e "
+    .data.status == \"no-work\"
+    and .data.reason == \"active-work\"
+  " >/dev/null
+'
+check "cloud_ready_to_claimed" sh -c '
+  output="$(python3 scripts/check-cloud-queue-contract.py \
+    --issues-file .agents/fixtures/backlog/cloud-issues.json \
+    --operation transition --issue 3 --from-state ready --to-state claimed)"
+  printf "%s\n" "$output" | jq -e "
+    .data.status == \"transition\"
+    and .data.preserved_labels == [\"priority:high\"]
+    and .data.labels == [\"agent:claimed\",\"priority:high\"]
+  " >/dev/null
+'
+check "cloud_claimed_to_review_pending" sh -c '
+  output="$(python3 scripts/check-cloud-queue-contract.py \
+    --issues-file .agents/fixtures/backlog/cloud-active.json \
+    --operation transition --issue 4 --from-state claimed --to-state review-pending)"
+  printf "%s\n" "$output" | jq -e "
+    .data.status == \"transition\"
+    and .data.labels == [\"agent:review-pending\",\"kind:bug\"]
+  " >/dev/null
+'
+check "cloud_review_not_arrived_no_work" sh -c '
+  output="$(python3 scripts/check-cloud-queue-contract.py \
+    --issues-file .agents/fixtures/backlog/cloud-review.json \
+    --operation select-review)"
+  printf "%s\n" "$output" | jq -e "
+    .data.status == \"no-work\"
+    and .data.reason == \"review-not-arrived\"
+    and .data.issues == [12]
+  " >/dev/null
+'
+check "cloud_review_pending_to_awaiting_merge" sh -c '
+  selected="$(python3 scripts/check-cloud-queue-contract.py \
+    --issues-file .agents/fixtures/backlog/cloud-review-ready.json \
+    --operation select-review)"
+  transitioned="$(python3 scripts/check-cloud-queue-contract.py \
+    --issues-file .agents/fixtures/backlog/cloud-review-ready.json \
+    --operation transition --issue 12 --from-state review-pending --to-state awaiting-merge)"
+  printf "%s\n" "$selected" | jq -e ".data.status == \"selected\"" >/dev/null
+  printf "%s\n" "$transitioned" | jq -e "
+    .data.status == \"transition\"
+    and .data.preserved_labels == [\"kind:feature\"]
+    and .data.labels == [\"agent:awaiting-merge\",\"kind:feature\"]
+  " >/dev/null
+'
+check "cloud_queue_has_no_gh_or_project_dependency" sh -c '
+  ! rg -n "(^|[^[:alnum:]_])(gh|GH_TOKEN|Project)([^[:alnum:]_]|$)" \
+    scripts/check-cloud-queue-contract.py
+'
+check "merge_gate_pass" sh -c '
+  output="$(python3 scripts/check-merge-gate.py \
+    --issues-file .agents/fixtures/backlog/merge-ready.json \
+    --operation select-merge)"
+  printf "%s\n" "$output" | jq -e "
+    .data.status == \"merge\"
+    and .data.issue == 12
+    and .data.pr == 44
+    and .data.method == \"squash\"
+    and .data.delete_branch == true
+  " >/dev/null
+'
+check "merge_gate_checks_pending_no_work" sh -c '
+  output="$(python3 scripts/check-merge-gate.py \
+    --issues-file .agents/fixtures/backlog/merge-checks-pending.json \
+    --operation select-merge)"
+  printf "%s\n" "$output" | jq -e "
+    .data.status == \"no-work\"
+    and .data.reason == \"checks-pending\"
+    and .data.checks == [\"verify\"]
+  " >/dev/null
+'
+check "merge_gate_checks_failed_blocked" sh -c '
+  set +e
+  output="$(python3 scripts/check-merge-gate.py \
+    --issues-file .agents/fixtures/backlog/merge-checks-failed.json \
+    --operation select-merge)"
+  code=$?
+  set -e
+  [ "$code" -eq 1 ]
+  printf "%s\n" "$output" | jq -e "
+    .data.status == \"blocked\"
+    and .data.reason == \"checks-failed\"
+  " >/dev/null
+'
+check "merge_gate_no_candidate_no_work" sh -c '
+  output="$(python3 scripts/check-merge-gate.py \
+    --issues-file .agents/fixtures/backlog/cloud-issues.json \
+    --operation select-merge)"
+  printf "%s\n" "$output" | jq -e "
+    .data.status == \"no-work\"
+    and .data.reason == \"no-awaiting-merge-candidate\"
+  " >/dev/null
+'
+check "merge_gate_has_no_gh_or_project_dependency" sh -c '
+  ! rg -n "(^|[^[:alnum:]_])(gh|GH_TOKEN|Project)([^[:alnum:]_]|$)" \
+    scripts/check-merge-gate.py
+'
+check "local_prepare_keeps_project_registration" sh -c '
+  rg -q "register the new issue in the policy-defined Project" \
+    .codex/agents/rpm_idea_issue_creator.toml
+  rg -q "local Project preflight" .agents/skills/prepare-backlog/SKILL.md
+'
+check "workflow_forbids_merge_and_codex_request" sh -c '
+  ! rg -n -i \
+    "(gh pr merge|merge_pull_request|@codex review)" \
+    .agents/skills .codex/agents .agents/docs \
+    | rg -v \
+      "(Never|never|금지|Do not|does not|do not|without|request_codex_review|configured code review|does not post|no @codex review|or request @codex review|request, or wait for)"
+'
 
 if [ "${format}" = "jsonl" ]; then
   jq -nc --arg status "${status}" '{type:"agent_assets_result",data:{status:$status}}'


### PR DESCRIPTION
## Summary

- Split local backlog preparation (Project #7) from the Cloud issue-label execution queue (policy v3).
- Add `review-pending` / `awaiting-merge` lifecycle states with deterministic queue contract checks and fixtures.
- Add the `merge_gate` policy, `scripts/check-merge-gate.py`, merge fixtures, and the `merge-gatekeeper` skill as the single authorized merge path of the autonomous loop. Subagents remain merge-forbidden via the tool policy hook.
- Extend agent organization and workflow asset validation gates to enforce the new contracts.
- Document Codex/Claude cloud setup and the scheduled workflow prompts.

## Validation

- `just agent-assets` — ok (includes 5 new merge-gate fixture checks)
- `just audit-fixtures`, `just fixture-smoke` — ok
- No Rust source changes; `just check/lint/test` not run locally (CI covers).