### PR TITLE
feat(agents): fire cloud routines from GitHub events and add claude cloud setup

### DIFF
--- a/.github/workflows/agent-loop-triggers.yml
+++ b/.github/workflows/agent-loop-triggers.yml
@@ -1,0 +1,91 @@
+name: Agent Loop Triggers
+
+# Fires the Claude Code cloud routines that drive the autonomous loop as soon
+# as the matching GitHub event happens, instead of waiting for the next cron
+# tick. Every routine is idempotent (no-work is a healthy result), so a
+# duplicate or unnecessary fire is harmless. Fires are skipped entirely until
+# the CLAUDE_ROUTINE_*_TOKEN repository secrets are configured.
+
+on:
+  issues:
+    types: [labeled]
+  pull_request_review:
+    types: [submitted]
+  check_suite:
+    types: [completed]
+
+permissions:
+  issues: read
+
+concurrency:
+  group: agent-loop-triggers-${{ github.event_name }}
+  cancel-in-progress: false
+
+jobs:
+  fire:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Route event to a routine
+        id: route
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          LABEL: ${{ github.event.label.name }}
+          CONCLUSION: ${{ github.event.check_suite.conclusion }}
+          REPO: ${{ github.repository }}
+        run: |
+          routine=""
+          case "${EVENT}" in
+            issues)
+              case "${LABEL}" in
+                agent:ready) routine="executor" ;;
+                agent:awaiting-merge) routine="gatekeeper" ;;
+              esac
+              ;;
+            pull_request_review)
+              count="$(gh api "repos/${REPO}/issues?labels=agent:review-pending&state=open" --jq 'length')"
+              [ "${count}" -gt 0 ] && routine="reconciler"
+              ;;
+            check_suite)
+              if [ "${CONCLUSION}" = "success" ]; then
+                count="$(gh api "repos/${REPO}/issues?labels=agent:awaiting-merge&state=open" --jq 'length')"
+                [ "${count}" -gt 0 ] && routine="gatekeeper"
+              fi
+              ;;
+          esac
+          echo "routine=${routine}" >> "${GITHUB_OUTPUT}"
+
+      - name: Fire routine
+        if: steps.route.outputs.routine != ''
+        env:
+          ROUTINE: ${{ steps.route.outputs.routine }}
+          EVENT: ${{ github.event_name }}
+          EXECUTOR_TOKEN: ${{ secrets.CLAUDE_ROUTINE_EXECUTOR_TOKEN }}
+          RECONCILER_TOKEN: ${{ secrets.CLAUDE_ROUTINE_RECONCILER_TOKEN }}
+          GATEKEEPER_TOKEN: ${{ secrets.CLAUDE_ROUTINE_GATEKEEPER_TOKEN }}
+        run: |
+          case "${ROUTINE}" in
+            executor)
+              trigger="trig_01RKkcSx9hnY7WbWkab41m8s"
+              token="${EXECUTOR_TOKEN}"
+              ;;
+            reconciler)
+              trigger="trig_018PKXDKq4uW3GnZyTRTjxB5"
+              token="${RECONCILER_TOKEN}"
+              ;;
+            gatekeeper)
+              trigger="trig_01DMqm1WAayrwfUdtcZVLCah"
+              token="${GATEKEEPER_TOKEN}"
+              ;;
+          esac
+          if [ -z "${token}" ]; then
+            echo "secret for ${ROUTINE} routine is not configured; skipping fire"
+            exit 0
+          fi
+          curl -sS -f -X POST \
+            "https://api.anthropic.com/v1/claude_code/routines/${trigger}/fire" \
+            -H "Authorization: Bearer ${token}" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+            -H "Content-Type: application/json" \
+            -d "{\"text\": \"GitHub ${EVENT} event on nerdchanii/rpm fired this run.\"}"

--- a/docs/claude-cloud.md
+++ b/docs/claude-cloud.md
@@ -1,0 +1,63 @@
+# Claude Code cloud routines
+
+The autonomous loop runs on three Claude Code cloud routines. Their durable
+prompts live in `.agents/docs/automation-prompts.md`; the deterministic
+contracts they follow live in `.agents/workflows/backlog-policy.json` and
+`scripts/`.
+
+| Routine | Purpose | Cron fallback (UTC) |
+|---|---|---|
+| rpm-backlog-executor | Claim one ready issue, implement, publish PR | `12 */2 * * *` |
+| rpm-review-reconciler | Apply accepted review findings | `25 * * * *` |
+| rpm-merge-gatekeeper | Gated squash merge of awaiting-merge PRs | `45 * * * *` |
+
+Manage them at <https://claude.ai/code/routines>.
+
+## Environment setup
+
+The routines use the gh CLI for issue, label, and PR mutations. Configure the
+cloud environment once:
+
+1. Create a fine-grained GitHub PAT scoped to `nerdchanii/rpm` with
+   read/write on contents, issues, and pull requests.
+2. In the routine's cloud environment settings, add an environment variable
+   `GH_TOKEN` with that PAT. The gh CLI picks it up automatically.
+3. Set `./scripts/claude-cloud-setup.sh` as the environment setup script. It
+   installs gh when missing and reuses `scripts/codex-cloud-setup.sh` for the
+   Rust toolchain. The result is cached across runs.
+4. Keep the default Trusted network access. If gh calls fail with
+   `x-deny-reason: host_not_allowed`, add `api.github.com` to the
+   environment's allowed domains.
+
+Every routine prompt begins with `gh auth status` and reports BLOCKED without
+mutating anything when authentication is missing, so a misconfigured
+environment fails safely.
+
+## Event-driven fires
+
+Cron keeps the loop alive, but `.github/workflows/agent-loop-triggers.yml`
+fires the matching routine immediately when the loop advances:
+
+| GitHub event | Guard | Fired routine |
+|---|---|---|
+| Issue labeled `agent:ready` | — | executor |
+| Issue labeled `agent:awaiting-merge` | — | gatekeeper |
+| PR review submitted | an open `agent:review-pending` issue exists | reconciler |
+| Check suite completed (success) | an open `agent:awaiting-merge` issue exists | gatekeeper |
+
+Routines treat no-work as a healthy result, so duplicate fires are harmless;
+the fire endpoint has no idempotency key, and each fire consumes one routine
+run from the account's daily allowance.
+
+To enable the fires, add an API trigger to each routine in the web UI
+(Edit routine → Add another trigger → API → Generate token) and store the
+three tokens as repository secrets:
+
+- `CLAUDE_ROUTINE_EXECUTOR_TOKEN`
+- `CLAUDE_ROUTINE_RECONCILER_TOKEN`
+- `CLAUDE_ROUTINE_GATEKEEPER_TOKEN`
+
+Until the secrets exist, the workflow routes events but skips the fire step,
+and the cron schedules carry the loop alone. Native GitHub triggers on the
+routines are not used: they only cover pull-request and release events, which
+cannot express the issue-label and check-suite conditions above.

--- a/scripts/check-claude-security.sh
+++ b/scripts/check-claude-security.sh
@@ -31,6 +31,7 @@ check_allowlist() {
   while IFS= read -r rule; do
     case "${rule}" in
       "Bash(gh auth status --active --hostname github.com)") ;;
+      "WebSearch") ;;
       *) fail "${settings#${repo_root}/} contains an unreviewed allow rule: ${rule}" ;;
     esac
   done < <(jq -r '.permissions.allow[]? // empty' "${settings}")

--- a/scripts/claude-cloud-setup.sh
+++ b/scripts/claude-cloud-setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Claude Code cloud environment setup for RPM.
+# Configure this script as the cloud environment's setup script and set a
+# GH_TOKEN environment variable on the same environment (fine-grained PAT for
+# nerdchanii/rpm with contents, issues, and pull-requests read/write). The gh
+# CLI reads GH_TOKEN automatically, so scheduled routines need no extra login.
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    ${SUDO} apt-get update -y
+    ${SUDO} apt-get install -y gh
+  fi
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  printf 'claude-cloud-setup: gh is required and could not be installed\n' >&2
+  exit 1
+fi
+
+if [ -f Cargo.toml ] && [ -x scripts/codex-cloud-setup.sh ]; then
+  ./scripts/codex-cloud-setup.sh
+fi


### PR DESCRIPTION
## Summary

- `scripts/claude-cloud-setup.sh`: cloud environment setup script that installs the gh CLI (apt-get) and reuses `codex-cloud-setup.sh` for the Rust toolchain. Pair with a `GH_TOKEN` environment variable on the routine's cloud environment.
- `.github/workflows/agent-loop-triggers.yml`: fires the executor / reconciler / gatekeeper routines via the routines `/fire` API on issue-label, PR-review, and check-suite events. Guarded on lifecycle-label state; skips cleanly until `CLAUDE_ROUTINE_*_TOKEN` secrets exist.
- `docs/claude-cloud.md`: routine inventory, environment setup, and the event-to-routine mapping.
- `scripts/check-claude-security.sh`: review the user-approved `WebSearch` allow rule into the whitelist.

## Validation

- `just agent-assets` — ok
- `bash -n` on the setup script, YAML parse on the workflow — ok
- No Rust source changes.