### PR TITLE
test(install): prove shared transitive tarball downloads once for deduped graph

### DIFF
--- a/src/lib/api/mod.rs
+++ b/src/lib/api/mod.rs
@@ -160,9 +160,10 @@ fn package_key_from_tarball_url(tarball_url: &str) -> String {
 /// reach them.
 #[cfg(test)]
 pub(crate) mod test_support {
-    // A documented `std::sync::Mutex` guards the counter map because installer
-    // tests may run on a multi-threaded Tokio runtime, where a `thread_local`
-    // or `RefCell` counter would silently miscount downloads.
+    // A documented `std::sync::Mutex` guards the counter map because libtest
+    // runs test functions on parallel OS threads, so a `thread_local` or
+    // `RefCell` counter would be per-thread state that silently miscounts
+    // downloads across concurrently running tests.
     #![allow(clippy::disallowed_types)]
 
     use std::{

--- a/src/lib/api/mod.rs
+++ b/src/lib/api/mod.rs
@@ -30,6 +30,7 @@ pub async fn get_registry(lib_name: &str, version: &str) -> std::io::Result<Regi
 pub async fn get_tarball(tarball_url: &str) -> std::io::Result<Vec<u8>> {
     #[cfg(test)]
     if std::env::var_os("RPM_REGISTRY_FIXTURE_ROOT").is_some() {
+        test_support::record_tarball_download(&package_key_from_tarball_url(tarball_url));
         return fixture_tarball(tarball_url);
     }
 
@@ -121,6 +122,86 @@ fn package_name_from_tarball_url(tarball_url: &str) -> std::io::Result<String> {
             ErrorKind::InvalidInput,
             format!("invalid fixture tarball URL path: {tarball_url}"),
         )),
+    }
+}
+
+/// Derive the selected `package-name@version` a fixture tarball URL stands for.
+///
+/// Install deduplication is keyed by the selected package and version, not by
+/// the requested range, so download measurement records the same unit. URLs
+/// that do not follow the fixture layout fall back to the raw URL, which keeps
+/// distinct downloads distinct instead of silently merging counters.
+#[cfg(test)]
+fn package_key_from_tarball_url(tarball_url: &str) -> String {
+    let Ok(package_name) = package_name_from_tarball_url(tarball_url) else {
+        return tarball_url.to_string();
+    };
+    let unscoped = package_name
+        .rsplit('/')
+        .next()
+        .unwrap_or(package_name.as_str());
+    let version = tarball_url
+        .rsplit('/')
+        .next()
+        .and_then(|file_name| file_name.strip_suffix(".tgz"))
+        .and_then(|stem| stem.strip_prefix(&format!("{unscoped}-")))
+        .filter(|version| !version.is_empty());
+    match version {
+        Some(version) => format!("{package_name}@{version}"),
+        None => tarball_url.to_string(),
+    }
+}
+
+/// Tarball download counters for the fixture registry API.
+///
+/// ADR 0005 places installer measurement on the fake registry API that serves
+/// deterministic fixture responses, recording calls by package name and
+/// selected version. These counters are test-only; production downloads never
+/// reach them.
+#[cfg(test)]
+pub(crate) mod test_support {
+    // A documented `std::sync::Mutex` guards the counter map because installer
+    // tests may run on a multi-threaded Tokio runtime, where a `thread_local`
+    // or `RefCell` counter would silently miscount downloads.
+    #![allow(clippy::disallowed_types)]
+
+    use std::{
+        collections::HashMap,
+        sync::{Mutex, OnceLock},
+    };
+
+    fn counts() -> &'static Mutex<HashMap<String, u32>> {
+        static COUNTS: OnceLock<Mutex<HashMap<String, u32>>> = OnceLock::new();
+        COUNTS.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    fn locked_counts() -> std::sync::MutexGuard<'static, HashMap<String, u32>> {
+        counts().lock().unwrap_or_else(|error| error.into_inner())
+    }
+
+    pub(crate) fn record_tarball_download(package_key: &str) {
+        *locked_counts().entry(package_key.to_string()).or_insert(0) += 1;
+    }
+
+    /// Clear recorded downloads. Tests must call this while holding the shared
+    /// install test env lock so counts never leak between tests.
+    pub(crate) fn reset_tarball_download_counts() {
+        locked_counts().clear();
+    }
+
+    pub(crate) fn tarball_download_count(package_key: &str) -> u32 {
+        locked_counts().get(package_key).copied().unwrap_or(0)
+    }
+
+    /// Recorded downloads as a stable, sorted `(package@version, count)` list
+    /// so expected download counts stay reviewable in test output.
+    pub(crate) fn recorded_tarball_downloads() -> Vec<(String, u32)> {
+        let mut recorded = locked_counts()
+            .iter()
+            .map(|(key, count)| (key.clone(), *count))
+            .collect::<Vec<_>>();
+        recorded.sort();
+        recorded
     }
 }
 
@@ -260,6 +341,27 @@ mod tests {
             .expect("package.json should exist in generated archive");
 
         assert_eq!(package_json, r#"{"name":"@rpm-fixture/alpha"}"#);
+    }
+
+    #[test]
+    fn package_key_from_tarball_url_records_selected_package_and_version() {
+        assert_eq!(
+            package_key_from_tarball_url(
+                "https://registry.example.invalid/@rpm-fixture/shared/-/shared-1.0.0.tgz"
+            ),
+            "@rpm-fixture/shared@1.0.0"
+        );
+        assert_eq!(
+            package_key_from_tarball_url(
+                "https://registry.example.invalid/alpha/-/alpha-2.1.0.tgz"
+            ),
+            "alpha@2.1.0"
+        );
+        assert_eq!(package_key_from_tarball_url("not-a-url"), "not-a-url");
+        assert_eq!(
+            package_key_from_tarball_url("https://registry.example.invalid/alpha/-/alpha.tgz"),
+            "https://registry.example.invalid/alpha/-/alpha.tgz"
+        );
     }
 
     #[test]

--- a/src/lib/command/working_process/add.rs
+++ b/src/lib/command/working_process/add.rs
@@ -452,6 +452,7 @@ mod tests {
         resolution_error_to_io, InstallMetadata,
     };
     use crate::{
+        api,
         core::resolver::{
             resolve_dependency_graph, DependencyRequest, DependencyRequestKind, ResolutionError,
             ResolvedPackage, ResolvedRequest,
@@ -576,6 +577,67 @@ mod tests {
         assert_eq!(fetches.borrow().get("@rpm-fixture/alpha"), Some(&1));
         assert_eq!(fetches.borrow().get("@rpm-fixture/beta"), Some(&1));
         assert_eq!(fetches.borrow().get("@rpm-fixture/shared"), Some(&1));
+    }
+
+    #[tokio::test]
+    async fn apply_resolved_graph_downloads_shared_transitive_package_once() {
+        let _guard = TestEnvLock::acquire().unwrap();
+        let fixture_root = fixture_path(&["install-projects", "performance-small"]);
+        let project = TempProject::new("add-download-dedupe").unwrap();
+        let package_path = project
+            .copy_fixture(fixture_root.join("package.json"), "package.json")
+            .unwrap();
+        let project_root = package_path.parent().unwrap();
+        let mut package_manifest = PackageManifest::read_from_path(&package_path).unwrap();
+        let mut lockfile = LockFile::load_from_path(project_root.join("rpm.lock")).unwrap();
+        let libs = package_manifest
+            .get_dependencies()
+            .into_iter()
+            .map(|(library_name, version)| format!("{library_name}@{version}"))
+            .collect::<Vec<_>>();
+        let cache_dir = project_root.join(".rpm").join(".cache");
+
+        let _env = FixtureInstallEnv::new(&fixture_root.join("registry"));
+        api::test_support::reset_tarball_download_counts();
+        add_with_cache_dir(
+            &mut package_manifest,
+            &mut lockfile,
+            libs,
+            false,
+            false,
+            &cache_dir,
+        )
+        .await
+        .expect("performance-small fixture should install offline");
+
+        // `@rpm-fixture/shared@1.0.0` is reached through two different requested
+        // ranges (via alpha and via beta) but is one selected version, so the
+        // deduped graph must download it exactly once.
+        for package_key in [
+            "@rpm-fixture/alpha@1.0.0",
+            "@rpm-fixture/beta@1.0.0",
+            "@rpm-fixture/shared@1.0.0",
+        ] {
+            let downloads = api::test_support::tarball_download_count(package_key);
+            assert_eq!(
+                downloads,
+                1,
+                "expected exactly one tarball download for selected package/version \
+                 {package_key}, got {downloads}; recorded downloads: {:?}",
+                api::test_support::recorded_tarball_downloads()
+            );
+        }
+
+        assert_eq!(
+            api::test_support::recorded_tarball_downloads(),
+            vec![
+                ("@rpm-fixture/alpha@1.0.0".to_string(), 1),
+                ("@rpm-fixture/beta@1.0.0".to_string(), 1),
+                ("@rpm-fixture/shared@1.0.0".to_string(), 1),
+            ],
+            "install of the performance-small fixture should download each selected \
+             package/version exactly once and nothing else"
+        );
     }
 
     #[tokio::test]

--- a/src/lib/command/working_process/add.rs
+++ b/src/lib/command/working_process/add.rs
@@ -642,30 +642,94 @@ mod tests {
              package/version exactly once and nothing else"
         );
 
-        // Guard the fixture itself: alpha requests `@rpm-fixture/shared` as
-        // `~1.0.0` while beta requests it as `^1.0.0`, so the two requested
-        // range strings stay textually different while selecting version
-        // `1.0.0`. If the fixture ever collapsed to one shared range, the
-        // download assertions above would stop distinguishing version-keyed
-        // dedupe from range-keyed dedupe.
-        let mut resolved_from_lock = lockfile
+        // Guard the fixture's *input* shape: alpha must declare
+        // `@rpm-fixture/shared` as `~1.0.0` while beta declares it as `^1.0.0`,
+        // so the two requested range strings stay textually different while
+        // selecting version `1.0.0`. If the fixture ever collapsed to one
+        // shared range, the download assertions above would stop
+        // distinguishing version-keyed dedupe from range-keyed dedupe.
+        //
+        // This is deliberately asserted against the registry fixtures rather
+        // than the resolved lockfile. A package reached through several parents
+        // records only one parent's range in `requested`
+        // (`requested_for_lockfile` takes `requests.first()`), and which parent
+        // lands first follows the direct dependency order that
+        // `PackageManifest::get_dependencies` reads out of a `HashMap`, so it
+        // is not stable across processes. The lockfile also cannot detect a
+        // collapse to a single range, because it only ever records one winner.
+        assert_eq!(
+            fixture_declared_range(
+                &fixture_root,
+                "@rpm-fixture__alpha.json",
+                "@rpm-fixture/shared"
+            ),
+            "~1.0.0",
+            "fixture must keep alpha requesting `@rpm-fixture/shared` on `~1.0.0`"
+        );
+        assert_eq!(
+            fixture_declared_range(
+                &fixture_root,
+                "@rpm-fixture__beta.json",
+                "@rpm-fixture/shared"
+            ),
+            "^1.0.0",
+            "fixture must keep beta requesting `@rpm-fixture/shared` on `^1.0.0`"
+        );
+
+        // The direct dependency entries are keyed by their own package names and
+        // are unaffected by shared-transitive resolution order, so they stay
+        // exact. `@rpm-fixture/shared@1.0.0` is checked for presence only, for
+        // the ordering reason described above.
+        let mut direct_from_lock = lockfile
             .get_packages()
             .into_iter()
+            .filter(|(key, _)| key.as_str() != "@rpm-fixture/shared@1.0.0")
             .map(|(key, dependency)| format!("{key} requested {}", dependency.get_requested()))
             .collect::<Vec<_>>();
-        resolved_from_lock.sort();
-        let mut expected_resolved =
-            fs::read_to_string(fixture_root.join("expected/resolved-packages.txt"))
-                .unwrap()
-                .lines()
-                .map(str::to_owned)
-                .collect::<Vec<_>>();
-        expected_resolved.sort();
+        direct_from_lock.sort();
+        let mut expected_direct =
+            read_expected_lines(&fixture_root.join("expected").join("resolved-packages.txt"));
+        expected_direct.sort();
         assert_eq!(
-            resolved_from_lock, expected_resolved,
-            "fixture must keep alpha on `~1.0.0` and beta on `^1.0.0` for \
-             `@rpm-fixture/shared@1.0.0`"
+            direct_from_lock, expected_direct,
+            "install must record the fixture's direct dependency entries in the lockfile"
         );
+        assert!(
+            lockfile
+                .get_packages()
+                .into_iter()
+                .any(|(key, _)| key.as_str() == "@rpm-fixture/shared@1.0.0"),
+            "install must record the deduped shared transitive package in the lockfile"
+        );
+    }
+
+    /// Reads the declared range for `dependency` from a registry fixture
+    /// document, so a test can guard the fixture's input shape directly.
+    fn fixture_declared_range(
+        fixture_root: &Path,
+        registry_file: &str,
+        dependency: &str,
+    ) -> String {
+        let path = fixture_root.join("registry").join(registry_file);
+        let contents = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("{} should be readable: {error}", path.display()));
+        let document = serde_json::from_str::<serde_json::Value>(&contents)
+            .unwrap_or_else(|error| panic!("{} should be valid JSON: {error}", path.display()));
+        document["versions"]["1.0.0"]["dependencies"][dependency]
+            .as_str()
+            .unwrap_or_else(|| panic!("{} should declare a range for {dependency}", path.display()))
+            .to_owned()
+    }
+
+    /// Reads an expectation fixture, skipping blank lines and `#` comments.
+    fn read_expected_lines(path: &Path) -> Vec<String> {
+        fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("{} should be readable: {error}", path.display()))
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .map(str::to_owned)
+            .collect()
     }
 
     #[tokio::test]

--- a/src/lib/command/working_process/add.rs
+++ b/src/lib/command/working_process/add.rs
@@ -582,7 +582,8 @@ mod tests {
     #[tokio::test]
     async fn apply_resolved_graph_downloads_shared_transitive_package_once() {
         let _guard = TestEnvLock::acquire().unwrap();
-        let fixture_root = fixture_path(&["install-projects", "performance-small"]);
+        let fixture_root =
+            fixture_path(&["install-projects", "shared-transitive-divergent-ranges"]);
         let project = TempProject::new("add-download-dedupe").unwrap();
         let package_path = project
             .copy_fixture(fixture_root.join("package.json"), "package.json")
@@ -608,11 +609,13 @@ mod tests {
             &cache_dir,
         )
         .await
-        .expect("performance-small fixture should install offline");
+        .expect("divergent range fixture should install offline");
 
-        // `@rpm-fixture/shared@1.0.0` is reached through two different requested
-        // ranges (via alpha and via beta) but is one selected version, so the
-        // deduped graph must download it exactly once.
+        // `@rpm-fixture/shared@1.0.0` is reached through two textually different
+        // requested ranges (`~1.0.0` via alpha, `^1.0.0` via beta) that converge
+        // on one selected version, so the deduped graph must download it exactly
+        // once. Keying dedupe on the requested range instead of the selected
+        // package/version would download it twice here.
         for package_key in [
             "@rpm-fixture/alpha@1.0.0",
             "@rpm-fixture/beta@1.0.0",
@@ -635,8 +638,33 @@ mod tests {
                 ("@rpm-fixture/beta@1.0.0".to_string(), 1),
                 ("@rpm-fixture/shared@1.0.0".to_string(), 1),
             ],
-            "install of the performance-small fixture should download each selected \
+            "install of the divergent range fixture should download each selected \
              package/version exactly once and nothing else"
+        );
+
+        // Guard the fixture itself: alpha requests `@rpm-fixture/shared` as
+        // `~1.0.0` while beta requests it as `^1.0.0`, so the two requested
+        // range strings stay textually different while selecting version
+        // `1.0.0`. If the fixture ever collapsed to one shared range, the
+        // download assertions above would stop distinguishing version-keyed
+        // dedupe from range-keyed dedupe.
+        let mut resolved_from_lock = lockfile
+            .get_packages()
+            .into_iter()
+            .map(|(key, dependency)| format!("{key} requested {}", dependency.get_requested()))
+            .collect::<Vec<_>>();
+        resolved_from_lock.sort();
+        let mut expected_resolved =
+            fs::read_to_string(fixture_root.join("expected/resolved-packages.txt"))
+                .unwrap()
+                .lines()
+                .map(str::to_owned)
+                .collect::<Vec<_>>();
+        expected_resolved.sort();
+        assert_eq!(
+            resolved_from_lock, expected_resolved,
+            "fixture must keep alpha on `~1.0.0` and beta on `^1.0.0` for \
+             `@rpm-fixture/shared@1.0.0`"
         );
     }
 

--- a/tests/fixtures/install-projects/shared-transitive-divergent-ranges/expected/resolved-packages.txt
+++ b/tests/fixtures/install-projects/shared-transitive-divergent-ranges/expected/resolved-packages.txt
@@ -1,3 +1,9 @@
+# Direct dependency entries the install must record in `rpm.lock`.
+#
+# `@rpm-fixture/shared@1.0.0` is intentionally absent. It is reached through two
+# parents (`~1.0.0` via alpha, `^1.0.0` via beta) and the lockfile records only
+# whichever parent's edge resolved first, which is not a deterministic property.
+# The divergence of those two ranges is guarded against the registry fixtures
+# in `../registry/` instead.
 @rpm-fixture/alpha@1.0.0 requested ^1.0.0
 @rpm-fixture/beta@1.0.0 requested ^1.0.0
-@rpm-fixture/shared@1.0.0 requested ~1.0.0

--- a/tests/fixtures/install-projects/shared-transitive-divergent-ranges/expected/resolved-packages.txt
+++ b/tests/fixtures/install-projects/shared-transitive-divergent-ranges/expected/resolved-packages.txt
@@ -1,0 +1,3 @@
+@rpm-fixture/alpha@1.0.0 requested ^1.0.0
+@rpm-fixture/beta@1.0.0 requested ^1.0.0
+@rpm-fixture/shared@1.0.0 requested ~1.0.0

--- a/tests/fixtures/install-projects/shared-transitive-divergent-ranges/package.json
+++ b/tests/fixtures/install-projects/shared-transitive-divergent-ranges/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shared-transitive-divergent-ranges",
+  "version": "0.0.0",
+  "dependencies": {
+    "@rpm-fixture/alpha": "^1.0.0",
+    "@rpm-fixture/beta": "^1.0.0"
+  }
+}

--- a/tests/fixtures/install-projects/shared-transitive-divergent-ranges/registry/@rpm-fixture__alpha.json
+++ b/tests/fixtures/install-projects/shared-transitive-divergent-ranges/registry/@rpm-fixture__alpha.json
@@ -1,0 +1,23 @@
+{
+  "_id": "@rpm-fixture/alpha",
+  "name": "@rpm-fixture/alpha",
+  "description": "Fixture package alpha requesting the shared package with a tilde range",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/alpha",
+      "version": "1.0.0",
+      "description": "Fixture package alpha requesting the shared package with a tilde range",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/alpha/-/alpha-1.0.0.tgz",
+        "shasum": "fixture-alpha-1.0.0"
+      },
+      "dependencies": {
+        "@rpm-fixture/shared": "~1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/install-projects/shared-transitive-divergent-ranges/registry/@rpm-fixture__beta.json
+++ b/tests/fixtures/install-projects/shared-transitive-divergent-ranges/registry/@rpm-fixture__beta.json
@@ -1,0 +1,23 @@
+{
+  "_id": "@rpm-fixture/beta",
+  "name": "@rpm-fixture/beta",
+  "description": "Fixture package beta requesting the shared package with a caret range",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/beta",
+      "version": "1.0.0",
+      "description": "Fixture package beta requesting the shared package with a caret range",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/beta/-/beta-1.0.0.tgz",
+        "shasum": "fixture-beta-1.0.0"
+      },
+      "dependencies": {
+        "@rpm-fixture/shared": "^1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/install-projects/shared-transitive-divergent-ranges/registry/@rpm-fixture__shared.json
+++ b/tests/fixtures/install-projects/shared-transitive-divergent-ranges/registry/@rpm-fixture__shared.json
@@ -1,0 +1,21 @@
+{
+  "_id": "@rpm-fixture/shared",
+  "name": "@rpm-fixture/shared",
+  "description": "Fixture package shared by alpha and beta through divergent ranges",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/shared",
+      "version": "1.0.0",
+      "description": "Fixture package shared by alpha and beta through divergent ranges",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/shared/-/shared-1.0.0.tgz",
+        "shasum": "fixture-shared-1.0.0"
+      },
+      "dependencies": {}
+    }
+  }
+}


### PR DESCRIPTION
## Contract

No public contract change. This is a test-only proof that install graph deduplication downloads a shared transitive package/version exactly once, per `docs/specs/core/install/performance/SPEC.md`. Adds `#[cfg(test)]`-only download-count instrumentation to the fixture registry API (ADR 0005 places this measurement on the fake registry API); no production function signature or behavior is touched.

## Changes

- `src/lib/api/mod.rs`: `#[cfg(test)]`-only `package_key_from_tarball_url` helper and a `test_support` module (`OnceLock<Mutex<HashMap<String, u32>>>`) recording tarball downloads by selected `package@version`, wired into the existing `RPM_REGISTRY_FIXTURE_ROOT` fixture branch of `get_tarball`.
- `src/lib/command/working_process/add.rs`: new `apply_resolved_graph_downloads_shared_transitive_package_once` test using a new dedicated fixture (below), asserting each selected package/version — especially the shared transitive one, reached via two textually different requested ranges — downloads exactly once, with failure messages naming the offending package/version and the full recorded snapshot.
- `tests/fixtures/install-projects/shared-transitive-divergent-ranges/`: new fixture (two direct deps requesting the shared transitive dependency via different-but-compatible ranges, `~1.0.0` and `^1.0.0`, both selecting `1.0.0`) so the test actually distinguishes version-keyed dedupe from range-keyed dedupe. The pre-existing `performance-small` fixture was left untouched since it's shared by other tests and its two parents happen to request identical ranges.

## Validation

- `cargo test --locked --lib --bins --tests` (full suite) → 145 lib + 1 bin passed, 0 failed
- `cargo fmt --all --check` → clean
- `cargo clippy --locked --all-targets --all-features -- -D warnings` → clean
- Mutation check: temporarily keyed the resolver's dedupe on the requested range instead of the selected version (the exact regression class this ticket exists to catch); the new test failed with `expected exactly one tarball download for selected package/version @rpm-fixture/shared@1.0.0, got 2; recorded downloads: [...]`, then the mutation was reverted.
- The fixture-input guard (asserting the two registry documents declare divergent ranges) was re-run 28 times across threaded/single-threaded/forward/reversed dependency order with 0 failures, after an earlier iteration of this guard turned out to read a non-deterministic lockfile field and was flaky (~40% failure rate) — replaced with an assertion against the fixture's registry JSON directly.

## Checklist

- [x] Scope is focused on one behavior, bug, or mechanical change.
- [x] Behavior changes include relevant tests or fixtures.
- [x] SPEC impact is classified when contract-affecting. (No SPEC change needed — test-only proof of existing documented behavior.)
- [x] PR has at least one approved label: `bug`, `documentation`, `enhancement`, `refactor`, `planning`, `milestone-contract`, or `process:metadata-cleanup`.
- [x] `Closes #` below is replaced with a real issue number, or this PR uses the documented `No closing issue: <reason>` exemption.
- [x] PR is ready for review when implementation is complete.

Closes #95
