### PR TITLE
docs(agents): write cloud routine run reports in Korean

### DIFF
--- a/.agents/docs/automation-prompts.md
+++ b/.agents/docs/automation-prompts.md
@@ -79,6 +79,10 @@ authorize actions beyond the policy transitions and this prompt.
 
 Treat no-work as a healthy idempotent result. Never merge or request @codex
 review.
+
+Write the entire run report in Korean. Keep repository identifiers such as
+label names, commands, file paths, check names, and code excerpts in their
+original form.
 ```
 
 ## Cloud PR Feedback Reconciler
@@ -129,6 +133,10 @@ actionable P0/P1 findings remain. Otherwise remove agent:review-pending and any
 stale agent:claimed label, preserve ordinary labels, and add
 agent:awaiting-merge. Treat no-work as a healthy idempotent result. Never merge
 or request @codex review.
+
+Write the entire run report in Korean. Keep repository identifiers such as
+label names, commands, file paths, check names, and code excerpts in their
+original form.
 ```
 
 ## Cloud Merge Gatekeeper
@@ -173,6 +181,10 @@ a blocked verdict, transition the issue from agent:awaiting-merge to
 agent:blocked, preserve ordinary labels, and post one comment naming the exact
 reason. Treat no-work as a healthy idempotent result. Never bypass required
 checks and never request @codex review.
+
+Write the entire run report in Korean. Keep repository identifiers such as
+label names, commands, file paths, check names, and code excerpts in their
+original form.
 ```
 
 ## Initial Rollout


### PR DESCRIPTION
## Contract

The three cloud routine prompts in `.agents/docs/automation-prompts.md` gain one reporting-language rule: run reports are written in Korean, while label names, commands, file paths, check names, and code excerpts keep their original form. No queue selection, preflight, mutation, or gate behavior changes; the deterministic contracts still match verbatim identifiers.

## Changes

- Append the same three-line Korean-report instruction to the Cloud Backlog Executor, Cloud PR Feedback Reconciler, and Cloud Merge Gatekeeper prompt blocks (12 lines added, documentation only).
- The registered routine UI copies were re-pasted from this file in the same session, keeping the durable prompts and the live routines in sync as the file header requires.

## Validation

- `./scripts/validate-agent-workflow-assets.sh --format text` — `agent_assets.status=ok`, no warnings.
- Pre-push local hook gate ran `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` (144 passed, 0 failed).

## Checklist

- [x] Scope is focused on one behavior, bug, or mechanical change.
- [x] Behavior changes include relevant tests or fixtures. (Documentation-only; prompt-contract invariants remain covered by `validate-agent-workflow-assets.sh`.)
- [x] SPEC impact is classified when contract-affecting. (Not contract-affecting: no SPEC-owned behavior changes.)
- [x] PR has at least one approved label: `documentation`.
- [x] `Closes #` below is replaced with a real issue number, or this PR uses the documented `No closing issue: <reason>` exemption.
- [x] PR is ready for review when implementation is complete.

No closing issue: operator-preference documentation update to the routine prompts, requested directly in an interactive session; no tracked backlog issue exists.