### PR TITLE
docs(specs): M4 ownership/gap audit + resolver node-uniqueness invariant

### DIFF
--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -42,7 +42,8 @@ Findings:
 - Graph node uniqueness was implied by the resolver merge step but was not
   stated as an invariant in the owning resolver SPEC. This audit adds the
   invariant there; the dedup behavior was already proven by the resolver test
-  added in #103 and referenced by #94.
+  tracked by #94 (landed via #74). The download-dedup proof is a separate
+  install-layer test landed in #103.
 - The performance SPEC states the measurement-harness contract (metadata fetch
   and tarball download counts via a fake registry). The tarball download
   counter exists (#103); the metadata-read counter is the remaining

--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -16,3 +16,38 @@ Current core contracts:
 - `install/recovery/SPEC.md`
 - `install/performance/SPEC.md`
 - `linker/SPEC.md`
+
+## M4 Ownership and Gap Audit
+
+The 2026-08-07 M4 audit maps each M4 behavior area to its owning SPEC/ADR and
+records whether the contract is explicitly stated. M4 is a measurement and
+deduplication milestone: it must observe duplicate graph nodes and duplicate
+downloads deterministically before expanding npm compatibility or adding
+concurrency.
+
+| M4 behavior area | Owning SPEC / ADR | Contract status | Follow-up |
+| --- | --- | --- | --- |
+| install pipeline shape | `install/performance/SPEC.md` | states the current recursive bottleneck and the future staged pipeline (resolve → dedupe → fetch → download → verify → extract → link → write) | none |
+| resolver graph deduplication | `resolver/SPEC.md`, ADR 0006 | resolved graph preserves requested range and selected version; node uniqueness by `<name>@<version>` is stated in the resolver contract | closed by this audit |
+| tarball download deduplication | `install/performance/SPEC.md`, `install/cache/SPEC.md` | performance SPEC states a selected version downloads once; cache SPEC's version-keyed filename `<name>@<version>.tgz` yields one cache file per selected version | none |
+| cache behavior | `install/cache/SPEC.md` | staged write plus same-directory rename publication; metadata reads are side-effect free | none |
+| lockfile preservation | `lockfile/SPEC.md` | `<name>@<version>` key; requested range and selected version recorded as separate fields | none |
+| manifest reads | `manifest/SPEC.md` | `package.json` read and save contract | none |
+| recovery behavior | `install/recovery/SPEC.md` | staged `node_modules` replacement, phase labels (`resolve|fetch|extract|link|write`), M3 side-effect audit table | #96 adds the M4 side-effect audit |
+| measurement harness | `install/performance/SPEC.md`, ADR 0005 | harness records metadata fetch and tarball download counts through a fake registry API owned by the install domain | #93 adds the metadata-read counter; the tarball download counter landed in #103 |
+
+Findings:
+
+- Ownership exists for every M4 behavior area; no area is unowned.
+- Graph node uniqueness was implied by the resolver merge step but was not
+  stated as an invariant in the owning resolver SPEC. This audit adds the
+  invariant there; the dedup behavior was already proven by the resolver test
+  added in #103 and referenced by #94.
+- The performance SPEC states the measurement-harness contract (metadata fetch
+  and tarball download counts via a fake registry). The tarball download
+  counter exists (#103); the metadata-read counter is the remaining
+  implementation gap, tracked by #93.
+- The M4 delivery order is already decomposed into phase-isolated tickets:
+  #93 (measurement harness), #94 (graph dedup proof, completed), #103 (download
+  dedup proof, completed), #96 (phase side-effect audit), and #97 (fixture
+  output convention).

--- a/docs/specs/core/resolver/SPEC.md
+++ b/docs/specs/core/resolver/SPEC.md
@@ -48,6 +48,14 @@ preserves both the requested range and the selected version. The graph is the
 input to later installer phases that download tarballs, verify integrity,
 extract packages, link `node_modules`, and write lockfile or manifest state.
 
+The resolved graph contains at most one record per `<name>@<version>`. A
+package reached through several parents is merged into a single node, so a
+shared transitive package/version is represented once even when it is reached
+through different requested ranges. This node-uniqueness invariant is the basis
+for the deduplication proofs in
+`docs/specs/core/install/performance/SPEC.md`, and it is the reason later
+installer phases may download and cache a selected version at most once.
+
 Version and range satisfaction rules are owned by
 `docs/specs/core/semver/SPEC.md`. Resolver strategies call the version
 selection abstraction and record its selected version; they must not duplicate


### PR DESCRIPTION
## Summary

Lands the M4 ownership/gap audit that **#92** scopes, and closes the one real SPEC gap the audit found. Docs-only; no production or test code touched.

- Adds an **M4 Ownership and Gap Audit** section to `docs/specs/core/README.md`, mapping each M4 behavior area (install pipeline, resolver graph dedup, tarball download dedup, cache, lockfile, manifest, recovery, measurement harness) to its owning SPEC/ADR with contract status and follow-up.
- States the **resolved-graph node-uniqueness invariant** (at most one record per `<name>@<version>`) in `docs/specs/core/resolver/SPEC.md`. The resolver merge step already dedupes by selected version (proven by the resolver test in #103 / #94), but the owning SPEC was silent on the invariant.

## Findings

- Ownership exists for every M4 area; no area is unowned.
- The M4 delivery order is already decomposed into phase-isolated tickets: #93 (measurement harness), #94 (graph dedup proof, completed), #103 (download dedup proof, completed), #96 (phase side-effect audit), #97 (fixture output convention).
- Remaining implementation gap: the metadata-read counter tracked by #93 (the tarball download counter landed in #103).

## Validation

`just validate` green locally — format-check, audit-fixtures, fixture-smoke, agent-assets, check, lint, test (145 passed, 0 failed), docs.

## Closing issue

No closing issue: **#92 is the M4 milestone-contract issue and must stay open until M4 completes** (CONTRIBUTING.md "Milestones"). This PR lands the gap audit the contract issue scopes, and updates the contract's owning-SPEC map.

## Checklist

- [x] M4 ownership/gap audit added to the core SPEC index
- [x] Resolver node-uniqueness invariant stated in the owning SPEC
- [x] `just validate` green
- [x] No behavior change (docs only)