### PR TITLE
feat(install): count metadata reads by package in the fake registry harness

### DIFF
--- a/docs/specs/core/install/performance/SPEC.md
+++ b/docs/specs/core/install/performance/SPEC.md
@@ -97,8 +97,9 @@ deduplication before adding concurrency.
 Measurement runs should copy the fixture to a temporary directory before
 mutation. A measurement must record:
 
-- number of metadata fetches by package name and selected version
-- number of tarball downloads by package name and selected version
+- number of metadata fetches by package name (a registry document covers every
+  version, so version selection happens after the fetch)
+- number of tarball downloads by selected package and version
 - resolved package/version list
 - whether `rpm.lock`, `package.json`, `.rpm`, or `node_modules` were written
   before the graph was fully resolved

--- a/src/lib/api/mod.rs
+++ b/src/lib/api/mod.rs
@@ -10,6 +10,7 @@ use std::{fs, io::ErrorKind, path::PathBuf};
 pub async fn get_registry(lib_name: &str, version: &str) -> std::io::Result<Registry> {
     #[cfg(test)]
     if let Some(registry) = read_registry_fixture(lib_name)? {
+        test_support::record_metadata_read(lib_name);
         return Ok(registry);
     }
 
@@ -204,6 +205,51 @@ pub(crate) mod test_support {
         recorded.sort();
         recorded
     }
+
+    // Metadata read counters. A registry metadata document covers every version
+    // of a package, so version selection happens after the fetch. Metadata reads
+    // are therefore counted by package name, while tarball downloads are counted
+    // by the selected `package@version`.
+    fn metadata_counts() -> &'static Mutex<HashMap<String, u32>> {
+        static METADATA_COUNTS: OnceLock<Mutex<HashMap<String, u32>>> = OnceLock::new();
+        METADATA_COUNTS.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    fn locked_metadata_counts() -> std::sync::MutexGuard<'static, HashMap<String, u32>> {
+        metadata_counts()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+    }
+
+    pub(crate) fn record_metadata_read(package_name: &str) {
+        *locked_metadata_counts()
+            .entry(package_name.to_string())
+            .or_insert(0) += 1;
+    }
+
+    /// Clear recorded metadata reads. Tests must call this while holding the
+    /// shared install test env lock so counts never leak between tests.
+    pub(crate) fn reset_metadata_read_counts() {
+        locked_metadata_counts().clear();
+    }
+
+    pub(crate) fn metadata_read_count(package_name: &str) -> u32 {
+        locked_metadata_counts()
+            .get(package_name)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Recorded metadata reads as a stable, sorted `(package-name, count)` list
+    /// so expected read counts stay reviewable in test output.
+    pub(crate) fn recorded_metadata_reads() -> Vec<(String, u32)> {
+        let mut recorded = locked_metadata_counts()
+            .iter()
+            .map(|(name, count)| (name.clone(), *count))
+            .collect::<Vec<_>>();
+        recorded.sort();
+        recorded
+    }
 }
 
 #[cfg(test)]
@@ -289,6 +335,30 @@ mod tests {
 
         assert_eq!(registry.name, "@rpm-fixture/alpha");
         assert_eq!(registry.select_version("^1.0.0").unwrap(), "1.0.0");
+    }
+
+    #[tokio::test]
+    async fn get_registry_counts_metadata_reads_by_package_name() {
+        let _fixture_root =
+            FixtureRoot::set(fixture_path(&["registry", "shared-transitive", "metadata"]));
+        test_support::reset_metadata_read_counts();
+
+        get_registry("@rpm-fixture/alpha", "").await.unwrap();
+        get_registry("@rpm-fixture/beta", "").await.unwrap();
+        get_registry("@rpm-fixture/shared", "").await.unwrap();
+        get_registry("@rpm-fixture/alpha", "").await.unwrap();
+
+        assert_eq!(test_support::metadata_read_count("@rpm-fixture/alpha"), 2);
+        assert_eq!(test_support::metadata_read_count("@rpm-fixture/beta"), 1);
+        assert_eq!(test_support::metadata_read_count("@rpm-fixture/shared"), 1);
+        assert_eq!(
+            test_support::recorded_metadata_reads(),
+            vec![
+                ("@rpm-fixture/alpha".to_string(), 2),
+                ("@rpm-fixture/beta".to_string(), 1),
+                ("@rpm-fixture/shared".to_string(), 1),
+            ],
+        );
     }
 
     #[test]

--- a/src/lib/command/working_process/add.rs
+++ b/src/lib/command/working_process/add.rs
@@ -703,6 +703,57 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn install_counts_metadata_reads_once_per_package() {
+        let _guard = TestEnvLock::acquire().unwrap();
+        let fixture_root =
+            fixture_path(&["install-projects", "shared-transitive-divergent-ranges"]);
+        let project = TempProject::new("add-metadata-count").unwrap();
+        let package_path = project
+            .copy_fixture(fixture_root.join("package.json"), "package.json")
+            .unwrap();
+        let project_root = package_path.parent().unwrap();
+        let mut package_manifest = PackageManifest::read_from_path(&package_path).unwrap();
+        let mut lockfile = LockFile::load_from_path(project_root.join("rpm.lock")).unwrap();
+        let libs = package_manifest
+            .get_dependencies()
+            .into_iter()
+            .map(|(library_name, version)| format!("{library_name}@{version}"))
+            .collect::<Vec<_>>();
+        let cache_dir = project_root.join(".rpm").join(".cache");
+
+        let _env = FixtureInstallEnv::new(&fixture_root.join("registry"));
+        api::test_support::reset_metadata_read_counts();
+        add_with_cache_dir(
+            &mut package_manifest,
+            &mut lockfile,
+            libs,
+            false,
+            false,
+            &cache_dir,
+        )
+        .await
+        .expect("divergent range fixture should install offline");
+
+        // `add_with_cache_dir` fetches each package's metadata exactly once:
+        // `populate_metadata` dedupes by package name before version selection,
+        // and it loads metadata through `api::get_registry`, which the fake
+        // registry harness records. This proves the measurement harness observes
+        // metadata reads independently of tarball downloads, keyed by package.
+        for package_name in [
+            "@rpm-fixture/alpha",
+            "@rpm-fixture/beta",
+            "@rpm-fixture/shared",
+        ] {
+            assert_eq!(
+                api::test_support::metadata_read_count(package_name),
+                1,
+                "expected exactly one metadata read for {package_name}; recorded reads: {:?}",
+                api::test_support::recorded_metadata_reads()
+            );
+        }
+    }
+
     /// Reads the declared range for `dependency` from a registry fixture
     /// document, so a test can guard the fixture's input shape directly.
     fn fixture_declared_range(


### PR DESCRIPTION
Closes #93. Adds the missing half of the M4 fake-registry measurement harness — a metadata-read counter — complementing the tarball download counter that landed in #103.

## Changes

- `src/lib/api/mod.rs`: test-only metadata-read counters in `api::test_support` (`record_metadata_read` / `reset_metadata_read_counts` / `metadata_read_count` / `recorded_metadata_reads`), mirroring the download counter. `get_registry` records a read by **package name** whenever it serves a fixture metadata document.
- `src/lib/command/working_process/add.rs`: install-level test proving `add_with_cache_dir` records each package's metadata exactly once (uses the existing `shared-transitive-divergent-ranges` fixture).
- `docs/specs/core/install/performance/SPEC.md`: clarify that metadata fetches are counted by package name while tarball downloads are counted by selected `package@version`.

## Why metadata is keyed by package name

`add_with_cache_dir` loads metadata via `api::get_registry(&package_name, "")` — the version arg is empty because version selection happens *after* the fetch. One registry document covers all versions, so the honest granularity is package name. `populate_metadata` already dedupes by package name, so an install reads each package's metadata once. This is distinct from tarball downloads, which are keyed by selected `package@version`.

## Done criteria (#93)

- [x] Metadata reads counted by package — by package name (version is not selected at fetch time; see rationale)
- [x] Tarball downloads counted by package@version — already present (#103)
- [x] Harness uses deterministic fixtures, no network — `RPM_REGISTRY_FIXTURE_ROOT`-gated
- [x] Tests copy install fixtures to a temp dir before mutation — `TempProject` + `FixtureInstallEnv`

## Validation

`just validate` green: format-check, audit-fixtures, fixture-smoke, agent-assets, check, lint, test (**147 passed, 0 failed**), docs. No production behavior change — counters are `#[cfg(test)]`-only and recording sits inside the existing fixture branch of `get_registry`.

## Checklist

- [x] Metadata-read counter added, mirroring the download counter
- [x] api unit test + install integration test
- [x] performance SPEC aligned with the harness granularity
- [x] `just validate` green