### PR TITLE
docs(conventions): define install fixture expected-output convention

### DIFF
--- a/docs/conventions/install_fixture_outputs.md
+++ b/docs/conventions/install_fixture_outputs.md
@@ -39,7 +39,9 @@ One line per resolved lockfile entry to assert:
 
 Compared (sorted) against a derivation of `LockFile::get_packages()`. Use it to
 assert the resolved graph shape, including that a shared transitive package is
-represented once (see the resolver SPEC node-uniqueness invariant). Omit entries
+represented once (see the installer performance SPEC, whose first success
+criterion is that shared transitive packages are represented once in the
+resolved graph and downloaded once). Omit entries
 whose `requested` range is not deterministic across runs (for example a transitive
 package reached through several parents records only one parent's range) and guard
 their input shape against the `registry/` fixture instead.
@@ -47,9 +49,10 @@ their input shape against the `registry/` fixture instead.
 ### `error-substrings.txt` — install error snapshot
 
 One substring per line; each must appear in the install error string. Use it for
-phase-labeled failures (fetch, integrity, extract, link, write). Older fixtures
-use `errors.txt` (a full-line match variant); prefer `error-substrings.txt` for
-new fixtures.
+phase-labeled failures (fetch, integrity, extract, link, write). This is the
+only error-expectation file the harness reads (`assert_expected_error` in
+`src/lib/command/working_process/install.rs`). A legacy `errors.txt` exists in
+some older fixtures but is read by no code; do not use it for new fixtures.
 
 ## Measurement counts (asserted in-test)
 
@@ -57,13 +60,15 @@ Download and metadata-read counts are not checked into `expected/`; they are
 asserted in the test through the fake-registry harness in `api::test_support`:
 
 - tarball downloads per selected `package@version` — `recorded_tarball_downloads()`
-- metadata reads per package name — `recorded_metadata_reads()`
+- metadata reads per package name — `recorded_metadata_reads()` (not yet
+  implemented; tracked by #93, landing in #106)
 
 Express expected counts as sorted `[(key, count)]` assertions with a failure
 message that prints the full recorded snapshot, so a count drift names the
-offending package/version. See
-`apply_resolved_graph_downloads_shared_transitive_package_once` and
-`install_counts_metadata_reads_once_per_package`.
+offending package/version. For the tarball-download pattern, see
+`apply_resolved_graph_downloads_shared_transitive_package_once`; the
+metadata-read analogue (`install_counts_metadata_reads_once_per_package`) is
+planned in #106.
 
 ## Optional snapshots (when a scenario needs them)
 

--- a/docs/conventions/install_fixture_outputs.md
+++ b/docs/conventions/install_fixture_outputs.md
@@ -1,0 +1,83 @@
+# Install Fixture Expected-Output Convention
+
+Install fixtures under `tests/fixtures/install-projects/<kebab-name>/` exercise the
+installer against deterministic, offline registry data. This convention defines
+the expected-output files a fixture uses so reviewers can distinguish real
+behavior changes from fixture churn. It is a support artifact; the owning SPECs
+remain the contract source of truth (see `docs/specs/core/install/**`,
+`docs/specs/core/resolver/SPEC.md`, and `docs/specs/core/lockfile/SPEC.md`).
+
+Fixture layout and required files are enforced by `scripts/audit-fixtures.sh`; new
+fixtures are scaffolded by `scripts/new-install-fixture.sh` (or `just fixture <name>`).
+
+## Invariants
+
+- **Offline and deterministic.** Fixtures never access the network. Registry
+  metadata lives in `registry/<@scope__name>.json`; tarballs are synthesized by the
+  fake registry when `RPM_REGISTRY_FIXTURE_ROOT` is set. Expected output is never
+  derived from a live registry response.
+- **Copied before mutation.** Every mutating install fixture is copied to a
+  temporary directory before the installer runs (`TempProject` + `FixtureInstallEnv`),
+  so repository-root install state is never mutated by a test.
+- **One fixture, one scenario.** A fixture represents one graph or error scenario.
+  Split unrelated package or script behavior into separate fixtures.
+- **Comments are allowed.** In line-list files, blank lines and lines starting with
+  `#` are ignored by `read_expected_lines`, so a fixture can annotate why an entry
+  is or is not present without changing what is asserted.
+
+## Expected-output files
+
+All checked-in expected outputs live under `<fixture>/expected/`.
+
+### `resolved-packages.txt` — resolved graph snapshot
+
+One line per resolved lockfile entry to assert:
+
+```text
+<package-name>@<selected-version> requested <range>
+```
+
+Compared (sorted) against a derivation of `LockFile::get_packages()`. Use it to
+assert the resolved graph shape, including that a shared transitive package is
+represented once (see the resolver SPEC node-uniqueness invariant). Omit entries
+whose `requested` range is not deterministic across runs (for example a transitive
+package reached through several parents records only one parent's range) and guard
+their input shape against the `registry/` fixture instead.
+
+### `error-substrings.txt` — install error snapshot
+
+One substring per line; each must appear in the install error string. Use it for
+phase-labeled failures (fetch, integrity, extract, link, write). Older fixtures
+use `errors.txt` (a full-line match variant); prefer `error-substrings.txt` for
+new fixtures.
+
+## Measurement counts (asserted in-test)
+
+Download and metadata-read counts are not checked into `expected/`; they are
+asserted in the test through the fake-registry harness in `api::test_support`:
+
+- tarball downloads per selected `package@version` — `recorded_tarball_downloads()`
+- metadata reads per package name — `recorded_metadata_reads()`
+
+Express expected counts as sorted `[(key, count)]` assertions with a failure
+message that prints the full recorded snapshot, so a count drift names the
+offending package/version. See
+`apply_resolved_graph_downloads_shared_transitive_package_once` and
+`install_counts_metadata_reads_once_per_package`.
+
+## Optional snapshots (when a scenario needs them)
+
+- **Lockfile snapshot.** A checked-in `*.lock` variant (for example
+  `lockfile-reproducible` ships `rpm-without-tarballs.lock`) compared against the
+  post-install lockfile to prove reproducibility.
+- **Filesystem tree.** When a test must assert a `node_modules` layout, snapshot
+  the expected tree as a separate reviewed artifact. Do not derive it from a real
+  install run on the repository root.
+
+## Canonical example
+
+`tests/fixtures/install-projects/shared-transitive-divergent-ranges/` follows this
+convention end to end: an offline `registry/` of metadata, a `package.json` input,
+an `expected/resolved-packages.txt` graph snapshot (with comments explaining the
+deliberately-absent shared entry), and in-test download and metadata count
+assertions.

--- a/docs/specs/core/install/performance/SPEC.md
+++ b/docs/specs/core/install/performance/SPEC.md
@@ -92,7 +92,9 @@ version for every package record, matching `docs/specs/core/resolver/SPEC.md`.
 Use `tests/fixtures/install-projects/performance-small/` as the first
 measurement fixture. It intentionally includes two direct dependencies that
 share one transitive dependency so later implementation can prove graph
-deduplication before adding concurrency.
+deduplication before adding concurrency. The expected-output files and in-test
+count assertions that install fixtures use are documented in
+`docs/conventions/install_fixture_outputs.md`.
 
 Measurement runs should copy the fixture to a temporary directory before
 mutation. A measurement must record:

--- a/tests/fixtures/install-projects/shared-transitive-divergent-ranges/expected/resolved-packages.txt
+++ b/tests/fixtures/install-projects/shared-transitive-divergent-ranges/expected/resolved-packages.txt
@@ -1,3 +1,4 @@
+# Expected-output convention: docs/conventions/install_fixture_outputs.md.
 # Direct dependency entries the install must record in `rpm.lock`.
 #
 # `@rpm-fixture/shared@1.0.0` is intentionally absent. It is reached through two


### PR DESCRIPTION
Closes #97. Defines the expected-output convention for install fixtures so review can distinguish behavior changes from fixture churn.

## Changes

- `docs/conventions/install_fixture_outputs.md` (new): documents the expected-output files install fixtures use — `expected/resolved-packages.txt` (resolved graph snapshot), `expected/error-substrings.txt` (error snapshot; `errors.txt` as the older full-line variant), in-test measurement counts via `api::test_support` (tarball downloads by `package@version`, metadata reads by package name), and optional lockfile/filesystem-tree snapshots. Records the invariants fixtures already follow.
- `docs/specs/core/install/performance/SPEC.md`: cross-reference the convention from the Test Fixtures section.
- `tests/fixtures/install-projects/shared-transitive-divergent-ranges/expected/resolved-packages.txt`: comment pointing to the convention doc (canonical example).

## Done criteria (#97)

- [x] Convention documented in fixture/test documentation (`docs/conventions/`)
- [x] At least one existing install fixture follows it — `shared-transitive-divergent-ranges`, now explicitly referenced
- [x] Preserves copy-to-temp-before-mutation — documented invariant, enforced by `TempProject` + `FixtureInstallEnv`
- [x] Avoids network-derived expected output — documented invariant, `RPM_REGISTRY_FIXTURE_ROOT`-gated fake registry
- Covers resolved package lists, download counts, filesystem trees, lockfile snapshots, and error snapshots

## Validation

`just validate` green (format-check, audit-fixtures, fixture-smoke, agent-assets, check, lint, test, docs). The added fixture comment is stripped by `read_expected_lines`, so install test assertions are unchanged.

## Checklist

- [x] Convention doc added under `docs/conventions/`
- [x] Performance SPEC + canonical fixture linked to the convention
- [x] Invariants (offline, temp-copy, one-scenario, comments) documented
- [x] `just validate` green