### PR TITLE
feat(agents): review/merge skills, Claude bridge, skill evaluator

### DIFF
--- a/.agents/skills/open-pr-review-batch/SKILL.md
+++ b/.agents/skills/open-pr-review-batch/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: open-pr-review-batch
+description: Post a non-blocking code review on every open PR in parallel. One reviewer agent per PR; multi-lens (correctness, contract, filesystem safety, determinism), confidence-scored, false-positive-filtered, posted as a COMMENT review.
+---
+
+# Open PR Review Batch
+
+요구 도구: Agent·Bash·gh·GitHub plugin.
+
+## Role
+
+Review every open PR (or an explicit subset) by spawning one reviewer agent per
+PR in parallel. Each review is non-blocking (COMMENT), confidence-scored, and
+false-positive-filtered. This complements the existing Codex Automatic review
+flow and the `pr-review-resolution` skill; it does not replace either.
+
+## Workflow
+
+1. Inventory open PRs: `gh pr list --state open --json number,title,...`.
+   Skip drafts and PRs with nothing to review. Narrow to an explicit subset when
+   the user named specific PRs.
+2. Spawn ONE background agent per PR in a single message (parallel). Do NOT use
+   worktree isolation: reviewers are read-only and share the working tree; the
+   only writes are the per-PR review post and distinct temp files.
+3. Each agent follows [references/worker-prompt.md](references/worker-prompt.md)
+   and the method in [references/review-method.md](references/review-method.md):
+   fetch diff + sibling-PR context, review through the AGENTS.md lenses, score
+   findings 0–100, keep only ≥80, drop false positives, post exactly one COMMENT
+   review, and report `PR: <url>`.
+4. Render a status table; update it as completion notifications arrive.
+
+## Boundaries
+
+- Review only. Never edit code, push, merge, or touch labels.
+- Post exactly one COMMENT review per PR (never APPROVE / REQUEST_CHANGES).
+- Never post or request `@codex review`. Never resolve threads.
+- Use the AGENTS.md "Code Review Rules" as the review lens.
+
+## When to read references
+
+- `references/worker-prompt.md` — the exact per-PR reviewer prompt template.
+- `references/review-method.md` — lenses, scoring rubric, false-positive list,
+  and the COMMENT review body format.

--- a/.agents/skills/open-pr-review-batch/agents/openai.yaml
+++ b/.agents/skills/open-pr-review-batch/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Open PR Review Batch"
+  short_description: "Post a non-blocking, confidence-scored code review on every open PR."
+  default_prompt: "Use $open-pr-review-batch to review every open PR in parallel and post one COMMENT review each."

--- a/.agents/skills/open-pr-review-batch/references/review-method.md
+++ b/.agents/skills/open-pr-review-batch/references/review-method.md
@@ -1,0 +1,70 @@
+# Open PR Review Batch — Method
+
+## Lenses (flag only REAL, IMPORTANT issues)
+
+Apply the AGENTS.md "Code Review Rules" plus:
+
+- Correctness/bugs: scan the diff for genuine bugs. Large bugs only; ignore
+  style, formatting, imports, and anything a linter/typechecker/compiler catches.
+- Contract integrity: conflict with the owning SPEC, or a contract-affecting
+  change without SPEC classification. For docs, internal consistency vs the
+  owning SPEC/ADR and the doc's own statements.
+- Filesystem safety: path traversal, symlink escape, partial writes, cache/store
+  boundary leaks (install/registry/linker/cache).
+- Determinism: dependence on iteration order, HashMap randomization, network
+  timing, ambient machine state, or an uncontrolled clock (resolver/lockfile/
+  registry/fixtures).
+- Change discipline: focused scope; behavior changes carry tests/fixtures.
+- Historical context: `git log`/blame on modified code; prior PRs touching these
+  files for applicable comments.
+
+## Cross-PR dependency awareness
+
+`collect-pr-review-context.sh` may emit `pr_sibling_pr` events. When a finding
+says something "does not exist" or "is missing", check whether a sibling PR
+introduces it before flagging — it may be landing in another open PR. Prefer a
+note over a defect in that case.
+
+## Confidence scoring (keep only ≥ 80)
+
+- 0: false positive / pre-existing.
+- 25: maybe real, unverifiable.
+- 50: real but minor/rare.
+- 75: verified, important, hits in practice.
+- 100: certain, frequent.
+
+Drop < 80. Drop false positives: pre-existing issues, linter/compiler-caught,
+intentional behavior, pedantic nitpicks, lines the PR did not modify, and
+generic "add more tests/docs" unless a SPEC requires it.
+
+## COMMENT review body format
+
+When no findings survive:
+
+```
+### Code review
+
+No issues found. Checked for correctness, contract integrity, filesystem
+safety, and determinism.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+```
+
+When findings survive:
+
+```
+### Code review
+
+Found N issues:
+
+1. <brief description> (AGENTS.md / <SPEC path> says "<…>")
+<full-SHA permalink, ±1 line context>
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+```
+
+Permalink rules: use the full HEAD SHA (never `HEAD`/`main`/branch), repo must
+match `nameWithOwner`, `#L<start>-L<end>` after the path. Keep it brief; keep
+finding text emoji-free (the trailer line is the only emoji). Post with
+`gh pr review <n> --comment -F <file>`, then verify with
+`gh pr view <n> --json reviews`.

--- a/.agents/skills/open-pr-review-batch/references/worker-prompt.md
+++ b/.agents/skills/open-pr-review-batch/references/worker-prompt.md
@@ -1,0 +1,39 @@
+# Open PR Review Batch — Worker Prompt Template
+
+Spawn one agent per PR with this prompt, substituting `<PR>`, `<TITLE>`, and a
+one-line theme. Run all reviewers in one message (parallel, background).
+
+---
+
+You are one of several PARALLEL code-review agents. Review ONE open PR in the
+`rpm` repo and post a single COMMENT review. REVIEW ONLY — do not modify code.
+
+REPO: `rpm`, a Rust package-manager prototype. Working dir is the repo root.
+Sources of truth: `AGENTS.md` (code-review rules, change discipline),
+`docs/specs/**/SPEC.md`, `docs/adrs/`. An automated Codex review flow already
+exists; do not disrupt it.
+
+YOUR PR: #<PR> — "<TITLE>". Theme: <one-line>.
+
+HARD CONSTRAINTS
+- Review only. Do NOT edit/commit/push/merge. Do NOT touch labels.
+- Post EXACTLY ONE review, state COMMENT:
+  `gh pr review <PR> --comment -F /tmp/review-<PR>.md`
+- Write the body in English (conventional-commit repo). Be rigorous, avoid
+  nitpicks. Do NOT run build/lint/typecheck — CI handles those.
+
+METHOD
+1. Fetch: `gh pr diff <PR>`, `gh pr view <PR> --json headRefOid,files,body`,
+   `gh repo view --json nameWithOwner`, and
+   `bash scripts/collect-pr-review-context.sh <PR> --format jsonl` (this now
+   includes `pr_sibling_pr` events for cross-PR dependency awareness).
+2. Read the owning SPEC/ADR and the changed files in full.
+3. Review through the lenses in `review-method.md`. Score findings 0–100; keep
+   only ≥80; drop false positives (including dependency-driven "missing" items a
+   sibling PR introduces).
+4. Write the body to `/tmp/review-<PR>.md` in the format from `review-method.md`
+   (full-SHA permalinks only).
+5. Post: `gh pr review <PR> --comment -F /tmp/review-<PR>.md`, then verify with
+   `gh pr view <PR> --json reviews`.
+
+Report back one line: `PR: <url>` (or `PR: #<PR> — <reason>` if posting failed).

--- a/.agents/skills/pr-review-resolution/references/resolution-workflow.md
+++ b/.agents/skills/pr-review-resolution/references/resolution-workflow.md
@@ -24,4 +24,12 @@
 
 Only `accept-now` may change code in the current PR.
 
+Cross-PR dependency awareness: the collected context may include
+`pr_sibling_pr` events describing other open PRs (number, title, branch,
+changed files, body). When a finding asserts something is "missing" or
+"not yet implemented", check whether a sibling PR introduces it. If so,
+prefer a forward-looking `accept-now` reword that stays accurate both before
+and after that sibling lands (e.g. "tracked by #N, landing in #<sibling>");
+otherwise defer. This avoids classifying a real dependency as a defect.
+
 If validation fails after an accepted change, stop and return a blocked result with the failing command and log summary.

--- a/.agents/skills/safe-direct-merge/SKILL.md
+++ b/.agents/skills/safe-direct-merge/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: safe-direct-merge
+description: Gate-checked squash merge for PRs the scheduled merge-gatekeeper cannot reach (no closing issue, or issues outside the agent lifecycle). Verifies the same gate conditions, clears blocking worktrees, merges, and cleans branches.
+---
+
+# Safe Direct Merge
+
+요구 도구: Bash·gh·git.
+
+## Role
+
+Manual merge path for PRs the scheduled merge-gatekeeper queue cannot select:
+the PR has no closing issue (e.g. it lands work scoped by an open
+milestone-contract issue), or its linked issue is not in `agent:awaiting-merge`.
+This skill mirrors the gate's deterministic conditions, then squash-merges and
+cleans up branches. It does not replace the gatekeeper for normal lifecycle PRs.
+
+## When to use
+
+- The PR has no closing issue (milestone-contract exemption).
+- The linked issue is outside the agent lifecycle and the 5-step label
+  transition (`untracked→…→awaiting-merge`) is not justified.
+- The user has explicitly authorized a direct merge.
+
+Prefer the scheduled `merge-gatekeeper` for PRs already in `agent:awaiting-merge`.
+
+## Workflow
+
+1. Dry-run first to confirm every PR passes the gate:
+   `bash scripts/safe-direct-merge.sh --dry-run <pr>...`
+2. Pass PRs in dependency-friendly order (land a referenced PR before one that
+   references it).
+3. Merge: `bash scripts/safe-direct-merge.sh [--allow-findings] <pr>...`
+4. Per PR the script verifies: OPEN / non-draft, `mergeable` true,
+   `mergeState` CLEAN, required checks (`metadata`, `verify`) pass, and no
+   unresolved review threads (unless `--allow-findings`). It then clears any
+   worktree still holding the PR branch, squash-merges, and deletes the merged
+   remote branch (ref-deletion push, which the local pre-push gate skips) and
+   local branch.
+
+## Boundaries
+
+- Never force-push. Never merge a PR that fails the gate. Never touch labels.
+- Never request `@codex review`; never make merge depend on a fresh Automatic review.
+- This is a deliberate manual bypass; the scheduled `merge-gatekeeper` remains
+  the default and sole merge path for lifecycle PRs.

--- a/.agents/skills/safe-direct-merge/agents/openai.yaml
+++ b/.agents/skills/safe-direct-merge/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Safe Direct Merge"
+  short_description: "Gate-checked squash merge for PRs outside the merge-gatekeeper queue."
+  default_prompt: "Use $safe-direct-merge to gate-check and squash-merge PRs the scheduled merge-gatekeeper cannot reach, then clean up branches."

--- a/.claude/skills/fixture-governance
+++ b/.claude/skills/fixture-governance
@@ -1,1 +1,1 @@
-/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/fixture-governance
+../../.agents/skills/fixture-governance

--- a/.claude/skills/fixture-governance
+++ b/.claude/skills/fixture-governance
@@ -1,0 +1,1 @@
+/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/fixture-governance

--- a/.claude/skills/merge-gatekeeper
+++ b/.claude/skills/merge-gatekeeper
@@ -1,1 +1,1 @@
-/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/merge-gatekeeper
+../../.agents/skills/merge-gatekeeper

--- a/.claude/skills/merge-gatekeeper
+++ b/.claude/skills/merge-gatekeeper
@@ -1,0 +1,1 @@
+/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/merge-gatekeeper

--- a/.claude/skills/open-pr-review-batch
+++ b/.claude/skills/open-pr-review-batch
@@ -1,1 +1,1 @@
-/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/open-pr-review-batch
+../../.agents/skills/open-pr-review-batch

--- a/.claude/skills/open-pr-review-batch
+++ b/.claude/skills/open-pr-review-batch
@@ -1,0 +1,1 @@
+/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/open-pr-review-batch

--- a/.claude/skills/pr-review-resolution
+++ b/.claude/skills/pr-review-resolution
@@ -1,1 +1,1 @@
-/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/pr-review-resolution
+../../.agents/skills/pr-review-resolution

--- a/.claude/skills/pr-review-resolution
+++ b/.claude/skills/pr-review-resolution
@@ -1,0 +1,1 @@
+/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/pr-review-resolution

--- a/.claude/skills/prepare-backlog
+++ b/.claude/skills/prepare-backlog
@@ -1,1 +1,1 @@
-/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/prepare-backlog
+../../.agents/skills/prepare-backlog

--- a/.claude/skills/prepare-backlog
+++ b/.claude/skills/prepare-backlog
@@ -1,0 +1,1 @@
+/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/prepare-backlog

--- a/.claude/skills/rust-analyzer
+++ b/.claude/skills/rust-analyzer
@@ -1,0 +1,1 @@
+/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/rust-analyzer

--- a/.claude/skills/rust-analyzer
+++ b/.claude/skills/rust-analyzer
@@ -1,1 +1,1 @@
-/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/rust-analyzer
+../../.agents/skills/rust-analyzer

--- a/.claude/skills/safe-direct-merge
+++ b/.claude/skills/safe-direct-merge
@@ -1,1 +1,1 @@
-/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/safe-direct-merge
+../../.agents/skills/safe-direct-merge

--- a/.claude/skills/safe-direct-merge
+++ b/.claude/skills/safe-direct-merge
@@ -1,0 +1,1 @@
+/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/safe-direct-merge

--- a/.claude/skills/spec-governance
+++ b/.claude/skills/spec-governance
@@ -1,1 +1,1 @@
-/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/spec-governance
+../../.agents/skills/spec-governance

--- a/.claude/skills/spec-governance
+++ b/.claude/skills/spec-governance
@@ -1,0 +1,1 @@
+/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/spec-governance

--- a/.claude/skills/take-ticket
+++ b/.claude/skills/take-ticket
@@ -1,1 +1,1 @@
-/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/take-ticket
+../../.agents/skills/take-ticket

--- a/.claude/skills/take-ticket
+++ b/.claude/skills/take-ticket
@@ -1,0 +1,1 @@
+/Users/gim-yechan/project/nerdchanii/rpm/.agents/skills/take-ticket

--- a/scripts/collect-pr-review-context.sh
+++ b/scripts/collect-pr-review-context.sh
@@ -256,6 +256,17 @@ jq -n \
   }
 ' > "${tmp_dir}/review-context.json"
 
+# Sibling open PRs (cross-PR dependency context). Excludes this PR itself.
+# Lets a resolver/reviewer see what other still-open PRs introduce or cite,
+# e.g. a counter that "does not exist yet" because it lands in another PR.
+gh pr list --state open --json number,title,headRefName,baseRefName,files,body 2>/dev/null \
+  | jq --argjson self "${pr_number}" \
+       '[.[] | select(.number != $self)
+              | {number,title,headRefName,baseRefName,
+                 files:[.files[].path],
+                 body:((.body // "")[:600])}]' \
+  > "${tmp_dir}/sibling-prs.json" 2>/dev/null || printf '[]' > "${tmp_dir}/sibling-prs.json"
+
 if [ "${format}" = "json" ]; then
   cat "${tmp_dir}/review-context.json"
   exit 0
@@ -280,6 +291,7 @@ if [ "${format}" = "jsonl" ]; then
     }}),
     (.reviewThreads[]? as $thread | $thread.comments.nodes[]? | {type:"pr_review_thread_comment", thread_id:$thread.id, data:.})
   ' "${tmp_dir}/review-context.json"
+  jq -c '.[] | {type:"pr_sibling_pr", data:.}' "${tmp_dir}/sibling-prs.json" 2>/dev/null || true
   exit 0
 fi
 
@@ -357,3 +369,13 @@ jq -r '
     end
   )
 ' "${tmp_dir}/review-context.json"
+
+echo ""
+echo "## Sibling Open PRs (cross-PR dependency context)"
+if [ -s "${tmp_dir}/sibling-prs.json" ] \
+  && [ "$(jq 'length' "${tmp_dir}/sibling-prs.json" 2>/dev/null || echo 0)" -gt 0 ]; then
+  jq -r '.[] | "### #\(.number) \(.title)\nbranch=\(.headRefName) base=\(.baseRefName)\nfiles: \(.files | join(", "))\nbody: \(.body)\n"' \
+    "${tmp_dir}/sibling-prs.json"
+else
+  echo "none"
+fi

--- a/scripts/evaluate-skills.sh
+++ b/scripts/evaluate-skills.sh
@@ -76,7 +76,9 @@ sync_links() {
   while IFS= read -r s; do
     [ -d "$s" ] || continue
     name="$(basename "$s")"
-    ln -sfn "$SKILLS_DIR/$name" "$CLAUDE_LINKS_DIR/$name"
+    # Relative target so the links survive across clones/CI (a machine-absolute
+    # target like /Users/.../ would dangle everywhere else).
+    ln -sfn "../../.agents/skills/$name" "$CLAUDE_LINKS_DIR/$name"
   done < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d)
   local l target
   for l in "$CLAUDE_LINKS_DIR"/*; do

--- a/scripts/evaluate-skills.sh
+++ b/scripts/evaluate-skills.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# evaluate-skills.sh — score RPM skills under .agents/skills/ for structure,
+# content completeness, reference/script validity, Claude Code compatibility,
+# and Claude Code discoverability (the .claude/skills symlink bridge).
+#
+# This complements scripts/validate-agent-workflow-assets.sh (which checks the
+# Codex/Cloud workflow contract). evaluate-skills.sh is about skill *quality*
+# and *Claude usability*, not the queue/gate lifecycle.
+#
+# Override the checkout root to evaluate another checkout, e.g.:
+#   RPM_REPO_ROOT=/path/rpm bash scripts/evaluate-skills.sh
+
+SKILLS_DIR="${SKILLS_DIR:-.agents/skills}"
+CLAUDE_LINKS_DIR="${CLAUDE_LINKS_DIR:-.claude/skills}"
+
+usage() {
+  cat <<'USAGE'
+usage: evaluate-skills.sh [--sync-links] [<skill-name> ...]
+
+Score each skill in .agents/skills/ (or a named subset) on:
+  - structure:        SKILL.md, frontmatter name+description
+  - content:          description quality, structure sections, length
+  - references:       links to references/* resolve
+  - scripts:          scripts/* mentioned in SKILL.md exist
+  - metadata:         agents/openai.yaml present with default_prompt
+  - claude bridge:    .claude/skills/<name> symlink exists (Claude discovery)
+  - claude frontmatter: name+description present (Codex/Claude shared keys)
+
+Options:
+  --sync-links    reconcile .claude/skills/ symlinks with .agents/skills/ first
+                  (add links for new skills, prune dead links), then evaluate
+  --json          emit one compact JSON object per skill on stdout
+  -h, --help      show this help
+
+Exit code is 1 if any skill has a failing (critical) check, else 0.
+USAGE
+}
+
+want_json=false
+sync_first=false
+targets=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --sync-links) sync_first=true; shift ;;
+    --json) want_json=true; shift ;;
+    --*) printf 'unknown option: %s\n' "$1" >&2; exit 2 ;;
+    *) targets+=("$1"); shift ;;
+  esac
+done
+
+# Override the checkout root (for evaluating another checkout's skills/scripts).
+repo_root="${RPM_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+resolve_dir() {
+  local d="$1"
+  case "$d" in
+    /*) printf '%s' "$d" ;;
+    *)  printf '%s/%s' "$repo_root" "$d" ;;
+  esac
+}
+SKILLS_DIR="$(resolve_dir "$SKILLS_DIR")"
+CLAUDE_LINKS_DIR="$(resolve_dir "$CLAUDE_LINKS_DIR")"
+
+if [ ! -d "$SKILLS_DIR" ]; then
+  printf 'evaluate.error=missing-skills-dir:%s\n' "$SKILLS_DIR" >&2
+  exit 2
+fi
+
+sync_links() {
+  mkdir -p "$CLAUDE_LINKS_DIR"
+  local s name
+  while IFS= read -r s; do
+    [ -d "$s" ] || continue
+    name="$(basename "$s")"
+    ln -sfn "$SKILLS_DIR/$name" "$CLAUDE_LINKS_DIR/$name"
+  done < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d)
+  local l target
+  for l in "$CLAUDE_LINKS_DIR"/*; do
+    [ -L "$l" ] || continue
+    if [ ! -e "$l" ]; then
+      rm -f "$l"
+    else
+      target="$(basename "$l")"
+      [ -d "$SKILLS_DIR/$target" ] || rm -f "$l"
+    fi
+  done
+}
+
+[ "$sync_first" = "true" ] && sync_links
+
+all_skills=()
+while IFS= read -r d; do
+  all_skills+=("$(basename "$d")")
+done < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d | sort)
+
+if [ "${#targets[@]}" -gt 0 ]; then
+  for t in "${targets[@]}"; do
+    if [ ! -d "${SKILLS_DIR}/${t}" ]; then
+      printf 'evaluate.error=unknown-skill:%s\n' "$t" >&2
+      exit 2
+    fi
+  done
+  selected=("${targets[@]}")
+else
+  selected=("${all_skills[@]}")
+fi
+
+grade() {
+  if   [ "$1" -ge 90 ]; then printf 'A'
+  elif [ "$1" -ge 75 ]; then printf 'B'
+  elif [ "$1" -ge 60 ]; then printf 'C'
+  else printf 'D'
+  fi
+}
+
+EVAL_FAILS=0
+EVAL_TOTAL=0
+EVAL_GRADES=""
+
+evaluate_one() {
+  local name="$1"
+  local dir="${SKILLS_DIR}/${name}"
+  local sk="${dir}/SKILL.md"
+  local score=0 max=0 fails=0 warns=0
+  local -a lines=()
+
+  bump() { max=$((max + $1)); }
+  ok()   { score=$((score + $1)); lines+=("  PASS  [$1/$1] $2"); }
+  bad()  { lines+=("  FAIL  [0/$1] $2"); fails=$((fails + 1)); }
+  soft() { score=$((score + $1)); lines+=("  PASS  [$1/$1] $2"); }
+  nit()  { lines+=("  WARN  [0/$1] $2"); warns=$((warns + 1)); }
+
+  bump 10
+  if [ -f "$sk" ]; then ok 10 "SKILL.md exists"; else bad 10 "SKILL.md missing"; fi
+
+  local fm=""
+  if [ -f "$sk" ]; then
+    fm="$(awk 'NR==1 && /^---$/{f=1;next} f&&/^---$/{exit} f' "$sk")"
+  fi
+  local name_val desc_val
+  name_val="$(printf '%s\n' "$fm" | awk '/^name:/{sub(/^name:[[:space:]]*/,""); gsub(/"/,""); print; exit}')"
+  desc_val="$(printf '%s\n' "$fm" | awk '/^description:/{sub(/^description:[[:space:]]*/,""); gsub(/^"|"$/,""); print; exit}')"
+
+  bump 10
+  if [ -n "$name_val" ] && [ "$name_val" = "$name" ]; then
+    ok 10 "frontmatter name"
+  elif [ -n "$name_val" ]; then
+    bad 10 "frontmatter name '${name_val}' != dir '${name}'"
+  else
+    bad 10 "frontmatter name missing"
+  fi
+
+  bump 10
+  if [ -n "$desc_val" ]; then ok 10 "frontmatter description"; else bad 10 "frontmatter description missing"; fi
+
+  bump 5
+  if [ "${#desc_val}" -ge 30 ]; then soft 5 "description length >= 30"; else nit 5 "description short (${#desc_val} < 30)"; fi
+
+  bump 10
+  if [ -f "$sk" ]; then
+    local headers
+    headers="$(grep -cE '^#{2,3} +[A-Za-z]' "$sk")"
+    if [ "${headers:-0}" -ge 2 ]; then soft 10 "has ${headers} structure sections"; else nit 10 "few structure sections (${headers:-0})"; fi
+  else
+    nit 10 "cannot read body (no SKILL.md)"
+  fi
+
+  bump 10
+  if [ -f "$sk" ]; then
+    local -a refs=()
+    mapfile -t refs < <(grep -oE 'references/[A-Za-z0-9_./-]+' "$sk" | sort -u || true)
+    if [ "${#refs[@]}" -eq 0 ]; then
+      soft 10 "no references/ cited"
+    else
+      local broken=()
+      for r in "${refs[@]}"; do [ -e "${dir}/${r}" ] || broken+=("$r"); done
+      if [ "${#broken[@]}" -eq 0 ]; then soft 10 "all ${#refs[@]} reference(s) resolve"
+      else bad 10 "broken references: ${broken[*]}"; fi
+    fi
+  else
+    bad 10 "cannot check references (no SKILL.md)"
+  fi
+
+  bump 5
+  if [ -f "$sk" ]; then
+    local -a scrs=()
+    mapfile -t scrs < <(grep -oE 'scripts/[A-Za-z0-9_./-]+\.(sh|py)' "$sk" | sort -u || true)
+    if [ "${#scrs[@]}" -eq 0 ]; then
+      soft 5 "no scripts/ cited"
+    else
+      local missing=()
+      for s in "${scrs[@]}"; do [ -e "${repo_root}/${s}" ] || missing+=("$s"); done
+      if [ "${#missing[@]}" -eq 0 ]; then soft 5 "all ${#scrs[@]} script(s) exist"
+      else nit 5 "missing scripts: ${missing[*]}"; fi
+    fi
+  else
+    nit 5 "cannot check scripts (no SKILL.md)"
+  fi
+
+  bump 5
+  local yaml="${dir}/agents/openai.yaml"
+  if [ -f "$yaml" ] && grep -q 'default_prompt' "$yaml"; then
+    soft 5 "agents/openai.yaml has default_prompt"
+  else
+    nit 5 "agents/openai.yaml missing or no default_prompt"
+  fi
+
+  bump 5
+  if [ -f "$sk" ]; then
+    local n
+    n="$(wc -l < "$sk" | tr -d ' ')"
+    if [ "$n" -le 120 ]; then soft 5 "SKILL.md concise (${n} lines)"; else nit 5 "SKILL.md long (${n} > 120 lines)"; fi
+  else
+    nit 5 "cannot measure length (no SKILL.md)"
+  fi
+
+  bump 10
+  if [ -L "${CLAUDE_LINKS_DIR}/${name}" ] && [ -e "${CLAUDE_LINKS_DIR}/${name}" ]; then
+    ok 10 ".claude/skills/${name} bridge symlink"
+  else
+    bad 10 ".claude/skills/${name} symlink missing (run with --sync-links)"
+  fi
+
+  bump 10
+  if [ -n "$name_val" ] && [ -n "$desc_val" ]; then
+    soft 10 "Claude frontmatter OK (name+description)"
+  else
+    nit 10 "Claude frontmatter incomplete"
+  fi
+
+  local pct=0
+  [ "$max" -gt 0 ] && pct=$(( score * 100 / max ))
+  local g; g="$(grade "$pct")"
+
+  if [ "$want_json" = "true" ]; then
+    printf '{"skill":"%s","score":%d,"max":%d,"pct":%d,"grade":"%s","fails":%d,"warns":%d}\n' \
+      "$name" "$score" "$max" "$pct" "$g" "$fails" "$warns"
+  else
+    printf '=== %s ===\n' "$name"
+    printf '%s\n' "${lines[@]}"
+    printf -- '--------------------------------------------------\n'
+    printf 'Score: %d/%d  Grade: %s  (%d warn, %d fail)\n\n' "$score" "$max" "$g" "$warns" "$fails"
+  fi
+
+  EVAL_FAILS=$((EVAL_FAILS + fails))
+  EVAL_TOTAL=$((EVAL_TOTAL + 1))
+  EVAL_GRADES="$EVAL_GRADES $g"
+}
+
+for name in "${selected[@]}"; do
+  evaluate_one "$name"
+done
+
+if [ "$want_json" = "false" ]; then
+  printf '=== Summary (%d skill(s)) ===\n' "$EVAL_TOTAL"
+  for g in A B C D; do
+    n=$(printf '%s\n' "$EVAL_GRADES" | tr ' ' '\n' | grep -cx "$g" || true)
+    printf '%s=%d ' "$g" "$n"
+  done
+  printf '\n'
+  [ "$EVAL_FAILS" -gt 0 ] && printf '%d failing check(s) — see FAIL lines above.\n' "$EVAL_FAILS"
+fi
+
+[ "$EVAL_FAILS" -gt 0 ] && exit 1
+exit 0

--- a/scripts/run-local-git-hook-gate.sh
+++ b/scripts/run-local-git-hook-gate.sh
@@ -19,11 +19,29 @@ run_gate() {
   "$@"
 }
 
+# A ref-deletion-only push (`git push --delete ...`) carries all-zero local
+# SHAs on stdin. Such a push changes no committed content, so clippy/test are
+# not meaningful and are skipped. Any real (content-bearing) ref falls through
+# to the full gate.
+is_deletion_only_push() {
+  local local_ref local_sha remote_ref remote_sha
+  local saw_input=false
+  while read -r local_ref local_sha remote_ref remote_sha; do
+    saw_input=true
+    [[ "$local_sha" =~ ^0{40}$ ]] || return 1
+  done
+  [[ "$saw_input" == "true" ]]
+}
+
 case "$hook_name" in
   pre-commit)
     run_gate "cargo fmt --check" cargo fmt --check
     ;;
   pre-push)
+    if is_deletion_only_push; then
+      echo "[local-hook] pre-push: ref-deletion-only push, skipping clippy/test gate"
+      exit 0
+    fi
     run_gate "cargo clippy --all-targets --all-features -- -D warnings" \
       cargo clippy --all-targets --all-features -- -D warnings
     run_gate "cargo test" cargo test

--- a/scripts/safe-direct-merge.sh
+++ b/scripts/safe-direct-merge.sh
@@ -89,17 +89,24 @@ merge_one() {
     echo "skip: mergeState=$merge_state (resolve conflicts/blocking reviews first)"; return 1
   fi
 
-  # Required checks must be green.
-  local checks_json bucket failed=()
-  checks_json="$(gh pr checks "$pr" --json name,bucket 2>/dev/null || printf '[]')"
+  # Required checks must be green. gh exits 8 while checks are pending, so
+  # capture JSON regardless of exit code and classify each required check.
+  local checks_json bucket failed=() pending=()
+  checks_json="$(gh pr checks "$pr" --json name,bucket 2>/dev/null || true)"
+  printf '%s' "$checks_json" | jq -e . >/dev/null 2>&1 || checks_json='[]'
   for c in "${required_checks[@]}"; do
-    bucket="$(printf '%s' "$checks_json" | jq -r --arg n "$c" '.[] | select(.name==$n) | .bucket // ""' | head -1)"
-    if [ "$bucket" != "pass" ]; then
-      failed+=("$c=${bucket:-missing}")
-    fi
+    bucket="$(printf '%s' "$checks_json" | jq -r --arg n "$c" '.[]? | select(.name==$n) | .bucket // ""' | head -1)"
+    case "$bucket" in
+      pass) : ;;
+      fail|failure|cancelled|timed_out|action_required) failed+=("$c=$bucket") ;;
+      *) pending+=("$c=${bucket:-pending}") ;;
+    esac
   done
   if [ "${#failed[@]}" -gt 0 ]; then
-    echo "skip: required checks not green: ${failed[*]}"; return 1
+    echo "skip: required checks failed: ${failed[*]}"; return 1
+  fi
+  if [ "${#pending[@]}" -gt 0 ]; then
+    echo "skip: required checks pending: ${pending[*]} (retry shortly)"; return 1
   fi
 
   # Best-effort unresolved-thread check (P0/P1 proxy). gh --json reviewThreads

--- a/scripts/safe-direct-merge.sh
+++ b/scripts/safe-direct-merge.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# safe-direct-merge.sh — gate-checked squash merge for PRs the scheduled
+# merge-gatekeeper cannot reach (e.g. a PR with no closing issue, or issues
+# outside the agent lifecycle). Verifies the SAME conditions the gate checks
+# in .agents/workflows/backlog-policy.json `merge_gate`, clears worktrees that
+# would block local branch deletion, squash-merges, and cleans up branches
+# without paying the full pre-push test gate on ref deletions.
+
+usage() {
+  cat <<'USAGE'
+usage: safe-direct-merge.sh [--dry-run] [--allow-findings] <pr> [<pr> ...]
+
+Gate-checked squash merge for one or more PRs, for the manual path the
+scheduled merge-gatekeeper cannot reach (a PR with no closing issue, or issues
+outside the agent lifecycle). Pass PRs in dependency-friendly order: land a
+referenced PR before one that references it.
+
+For each PR, verifies (mirroring merge_gate in backlog-policy.json):
+  - state OPEN, not draft
+  - mergeable true, mergeState CLEAN
+  - required checks (metadata, verify) concluded pass
+  - no unresolved review threads (--allow-findings overrides)
+
+Then, per PR:
+  - removes any git worktree still holding the PR branch
+  - squash-merges via `gh pr merge --squash`
+  - deletes the merged remote branch (`git push --delete`, which the local
+    pre-push gate skips for ref-deletion-only pushes)
+  - deletes the local branch if present
+
+Options:
+  --dry-run          verify and report only; merge nothing
+  --allow-findings   merge even when unresolved review threads remain
+
+Does NOT touch issue/PR labels, never force-pushes, never requests @codex,
+and never blocks on a fresh Automatic review.
+USAGE
+}
+
+dry_run=false
+allow_findings=false
+prs=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --dry-run) dry_run=true; shift ;;
+    --allow-findings) allow_findings=true; shift ;;
+    --*) printf 'unknown option: %s\n' "$1" >&2; exit 2 ;;
+    *) prs+=("$1"); shift ;;
+  esac
+done
+
+if [ "${#prs[@]}" -eq 0 ]; then
+  usage >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "safe-direct-merge.error=missing-gh" >&2
+  exit 127
+fi
+
+required_checks=(metadata verify)
+
+merge_one() {
+  local pr="$1"
+  echo "=== PR #$pr ==="
+
+  local state draft mergeable merge_state branch
+  state="$(gh pr view "$pr" --json state -q .state)"
+  draft="$(gh pr view "$pr" --json isDraft -q .isDraft)"
+  mergeable="$(gh pr view "$pr" --json mergeable -q .mergeable)"
+  merge_state="$(gh pr view "$pr" --json mergeStateStatus -q .mergeStateStatus)"
+  branch="$(gh pr view "$pr" --json headRefName -q .headRefName)"
+
+  if [ "$state" != "OPEN" ]; then
+    echo "skip: state=$state (not OPEN)"; return 1
+  fi
+  if [ "$draft" = "true" ]; then
+    echo "skip: draft PR"; return 1
+  fi
+  if [ "$mergeable" != "MERGEABLE" ]; then
+    echo "skip: mergeable=$mergeable"; return 1
+  fi
+  if [ "$merge_state" != "CLEAN" ]; then
+    echo "skip: mergeState=$merge_state (resolve conflicts/blocking reviews first)"; return 1
+  fi
+
+  # Required checks must be green.
+  local checks_json bucket failed=()
+  checks_json="$(gh pr checks "$pr" --json name,bucket 2>/dev/null || printf '[]')"
+  for c in "${required_checks[@]}"; do
+    bucket="$(printf '%s' "$checks_json" | jq -r --arg n "$c" '.[] | select(.name==$n) | .bucket // ""' | head -1)"
+    if [ "$bucket" != "pass" ]; then
+      failed+=("$c=${bucket:-missing}")
+    fi
+  done
+  if [ "${#failed[@]}" -gt 0 ]; then
+    echo "skip: required checks not green: ${failed[*]}"; return 1
+  fi
+
+  # Best-effort unresolved-thread check (P0/P1 proxy). gh --json reviewThreads
+  # support varies by version; degrade gracefully when unavailable.
+  if [ "$allow_findings" = "false" ]; then
+    local unresolved
+    unresolved="$(gh pr view "$pr" --json reviewThreads \
+      -q '[.reviewThreads[]? | select(.isResolved != true)] | length' 2>/dev/null || printf '0')"
+    if [ "${unresolved:-0}" -gt 0 ]; then
+      echo "skip: $unresolved unresolved review thread(s); pass --allow-findings to override"
+      return 1
+    fi
+  fi
+
+  echo "OK: branch=$branch mergeable=$mergeable mergeState=$merge_state checks=green"
+
+  if [ "$dry_run" = "true" ]; then
+    echo "(dry-run) would squash-merge and delete branch $branch"
+    return 0
+  fi
+
+  # Clear worktrees still holding this branch (prevents local-delete failure).
+  local wt wt_branch
+  while IFS= read -r wt; do
+    [ -n "$wt" ] || continue
+    wt_branch="$(git -C "$wt" branch --show-current 2>/dev/null || true)"
+    if [ "$wt_branch" = "$branch" ]; then
+      echo "removing worktree $wt holding $branch"
+      git worktree remove --force "$wt" 2>/dev/null || true
+    fi
+  done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+
+  # Squash merge (non-interactive). No --delete-branch: we clean via ref-delete
+  # push so the pre-push test gate is skipped.
+  if ! gh pr merge "$pr" --squash < /dev/null; then
+    echo "FAIL: gh pr merge returned non-zero"; return 1
+  fi
+
+  # Delete the merged remote branch (ref-deletion push skips the local gate).
+  if git push origin --delete "$branch" 2>/dev/null; then
+    echo "deleted remote branch $branch"
+  else
+    local repo
+    repo="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
+    if [ -n "$repo" ] \
+      && gh api -X DELETE "repos/$repo/git/refs/heads/$branch" >/dev/null 2>&1; then
+      echo "deleted remote branch $branch via API"
+    else
+      echo "note: remote branch $branch already gone or delete failed (non-fatal)"
+    fi
+  fi
+
+  # Local branch cleanup.
+  git branch -D "$branch" 2>/dev/null || true
+
+  echo "merged #$pr"
+}
+
+rc=0
+for pr in "${prs[@]}"; do
+  merge_one "$pr" || rc=1
+done
+
+exit "$rc"


### PR DESCRIPTION
## Contract

Agent/tooling layer only — no production code or SPEC behavior changes. Adds two skills, hardens review/merge automation, exposes all skills to Claude Code, and adds a skill evaluator.

## Changes

- **open-pr-review-batch** skill (`.agents/skills/open-pr-review-batch/`): parallel non-blocking code review per open PR (multi-lens, confidence-scored ≥80, false-positive-filtered, COMMENT review).
- **safe-direct-merge** skill + `scripts/safe-direct-merge.sh`: gate-checked squash merge for PRs the scheduled merge-gatekeeper cannot reach (no closing issue, lifecycle outside the queue). Verifies mergeability/checks, clears blocking worktrees, squash-merges, and cleans branches via ref-delete.
- `scripts/collect-pr-review-context.sh`: emit `pr_sibling_pr` events so resolvers see other open PRs (cross-PR dependency context); degrades to `[]` without gh.
- `scripts/run-local-git-hook-gate.sh`: skip clippy/test for ref-deletion-only pushes (local sha all zeros).
- `.agents/skills/pr-review-resolution/references/resolution-workflow.md`: cross-PR dependency awareness note.
- `.claude/skills/`: symlink bridge so Claude Code discovers `.agents/skills/*` (single source of truth; `--sync-links` reconciles).
- `scripts/evaluate-skills.sh`: score each skill on structure, content, reference/script validity, Claude bridge symlink, and frontmatter compatibility.

## Validation

- `just agent-assets`: new/modified skills pass (remaining `claude_security` fail is the gitignored `.claude/settings.local.json` only — not committed).
- `scripts/evaluate-skills.sh`: 9/9 skills grade A.
- `bash -n` on all scripts; `safe-direct-merge.sh --dry-run` skip path; pre-push ref-deletion skip; collect sibling `[]` fallback all verified.
- pre-push gate: clippy clean, 145 tests pass.

## Checklist

- [x] Scope focused on one area (agent automation/tooling).
- [x] Behavior changes (scripts) covered by the `agent-assets` gate + `evaluate-skills.sh`.
- [x] SPEC impact: none (tooling/agent layer).
- [x] Label: `enhancement`.

No closing issue: tooling/automation improvements (standalone tooling PR; no single tracking issue).
