### PR TITLE
docs(specs): refresh M4 gap-audit table after #93/#96/#97 landed

### DIFF
--- a/docs/conventions/install_fixture_outputs.md
+++ b/docs/conventions/install_fixture_outputs.md
@@ -60,15 +60,14 @@ Download and metadata-read counts are not checked into `expected/`; they are
 asserted in the test through the fake-registry harness in `api::test_support`:
 
 - tarball downloads per selected `package@version` — `recorded_tarball_downloads()`
-- metadata reads per package name — `recorded_metadata_reads()` (not yet
-  implemented; tracked by #93, landing in #106)
+- metadata reads per package name — `recorded_metadata_reads()` (#93, landed
+  via #106)
 
 Express expected counts as sorted `[(key, count)]` assertions with a failure
 message that prints the full recorded snapshot, so a count drift names the
 offending package/version. For the tarball-download pattern, see
 `apply_resolved_graph_downloads_shared_transitive_package_once`; the
-metadata-read analogue (`install_counts_metadata_reads_once_per_package`) is
-planned in #106.
+metadata-read analogue is `install_counts_metadata_reads_once_per_package`.
 
 ## Optional snapshots (when a scenario needs them)
 

--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -23,7 +23,8 @@ The 2026-08-07 M4 audit maps each M4 behavior area to its owning SPEC/ADR and
 records whether the contract is explicitly stated. M4 is a measurement and
 deduplication milestone: it must observe duplicate graph nodes and duplicate
 downloads deterministically before expanding npm compatibility or adding
-concurrency.
+concurrency. All follow-up tickets below landed and merged to `main`; M4 is
+complete.
 
 | M4 behavior area | Owning SPEC / ADR | Contract status | Follow-up |
 | --- | --- | --- | --- |
@@ -33,8 +34,8 @@ concurrency.
 | cache behavior | `install/cache/SPEC.md` | staged write plus same-directory rename publication; metadata reads are side-effect free | none |
 | lockfile preservation | `lockfile/SPEC.md` | `<name>@<version>` key; requested range and selected version recorded as separate fields | none |
 | manifest reads | `manifest/SPEC.md` | `package.json` read and save contract | none |
-| recovery behavior | `install/recovery/SPEC.md` | staged `node_modules` replacement, phase labels (`resolve|fetch|extract|link|write`), M3 side-effect audit table | #96 adds the M4 side-effect audit |
-| measurement harness | `install/performance/SPEC.md`, ADR 0005 | harness records metadata fetch and tarball download counts through a fake registry API owned by the install domain | #93 adds the metadata-read counter; the tarball download counter landed in #103 |
+| recovery behavior | `install/recovery/SPEC.md` | staged `node_modules` replacement, phase labels (`resolve|fetch|extract|link|write`), M3 and M4 side-effect audit tables | #96 added the M4 side-effect audit (completed, landed via #107) |
+| measurement harness | `install/performance/SPEC.md`, ADR 0005 | harness records metadata fetch and tarball download counts through a fake registry API owned by the install domain | #93 added the metadata-read counter (completed, landed via #106); the tarball download counter landed in #103 |
 
 Findings:
 
@@ -45,10 +46,10 @@ Findings:
   tracked by #94 (landed via #74). The download-dedup proof is a separate
   install-layer test landed in #103.
 - The performance SPEC states the measurement-harness contract (metadata fetch
-  and tarball download counts via a fake registry). The tarball download
-  counter exists (#103); the metadata-read counter is the remaining
-  implementation gap, tracked by #93.
-- The M4 delivery order is already decomposed into phase-isolated tickets:
-  #93 (measurement harness), #94 (graph dedup proof, completed), #103 (download
-  dedup proof, completed), #96 (phase side-effect audit), and #97 (fixture
-  output convention).
+  and tarball download counts via a fake registry). Both counters are now
+  implemented: the tarball download counter (#103) and the metadata-read
+  counter (#93, landed via #106).
+- The M4 delivery order was decomposed into phase-isolated tickets, all
+  completed: #93 (measurement harness, landed via #106), #94 (graph dedup
+  proof), #103 (download dedup proof), #96 (phase side-effect audit, landed
+  via #107), and #97 (fixture output convention, landed via #108).

--- a/docs/specs/core/install/recovery/SPEC.md
+++ b/docs/specs/core/install/recovery/SPEC.md
@@ -74,8 +74,8 @@ and performance SPECs.
 
 The 2026-08-07 M4 audit re-checks installer phase side effects after the M4
 measurement and deduplication work (#92 contract and gap audit, #94 graph dedup
-proof, #103 tarball download counter; #93 adds a metadata-read counter, landing
-in #106). M4 adds no
+proof, #103 tarball download counter, #93 metadata-read counter landed via
+#106). M4 adds no
 production install behavior: all measurement instrumentation is `#[cfg(test)]`-only
 recording inside the fake registry API, and the deduplication proofs exercise
 behavior the resolver already had. The audit confirms M3 recovery guarantees are
@@ -85,7 +85,7 @@ not weakened and classifies each phase against its owning SPEC.
 | --- | --- | --- | --- | --- | --- |
 | read manifest | manifest | none | `package.json` read only | manifest parser tests and install fixture copy tests | conforms |
 | resolve graph | resolver, lockfile | none (dedup proven, not added) | in-memory graph; no output writes before resolution | resolver tests; #94 graph proof (`graph.packages().len() == 3`); #103 download proof | conforms |
-| fetch/cache | cache, performance | measurement only (`#[cfg(test)]` counters) | `.rpm/.cache` staged write plus rename; metadata reads side-effect free | registry cache tests; #103 tarball download counter (the #93 metadata-read counter is not yet implemented; landing in #106) | conforms |
+| fetch/cache | cache, performance | measurement only (`#[cfg(test)]` counters) | `.rpm/.cache` staged write plus rename; metadata reads side-effect free | registry cache tests; #103 tarball download counter; #93 metadata-read counter (landed via #106) | conforms |
 | verify (integrity) | performance | none | lockfile metadata and cached tarball bytes; failure blocks extraction | lockfile, registry metadata, and integrity failure fixture tests | conforms |
 | extract | recovery, linker | none | temporary sibling staging directory | linker extract-failure recovery tests | conforms |
 | link | recovery, linker | none | temporary sibling staging directory | linker missing-target recovery tests | conforms |
@@ -98,7 +98,7 @@ Findings:
 - M4 introduces no production side effects. The tarball download counter (#103) is
   `#[cfg(test)]`-only and records inside the `RPM_REGISTRY_FIXTURE_ROOT`-gated
   branch of `get_tarball`; production downloads never reach it. The metadata-read
-  counter (#93), landing in #106, will record inside the corresponding branch of
+  counter (#93, landed via #106) records inside the corresponding branch of
   `get_registry` and is likewise test-only.
 - Failed graph resolution stays side-effect free: `populate_metadata` writes only
   to in-memory `InstallMetadata`, and `resolve_dependency_graph` runs before


### PR DESCRIPTION
## Contract

Docs-only. No production or test code touched, no contract behavior changes.

## Changes

The "M4 Ownership and Gap Audit" table in `docs/specs/core/README.md` (added by #105) still described the metadata-read counter (#93) and the phase side-effect audit (#96) as remaining/pending gaps. Both tickets — plus the fixture output convention (#97) — have since landed on `main`:

- #93 → metadata-read counter, landed via #106
- #96 → M4 phase side-effect audit, landed via #107
- #97 → fixture output convention, landed via #108

This PR updates the audit table and findings to reflect that all M4 follow-up tickets are complete, and notes that M4 itself is done.

## Validation

Docs-only Markdown edit; no code paths touched. `just format-check`, `just check`, `just lint`, `just test` are unaffected by this change (not re-run since no Rust source changed).

## Checklist

- [x] Scope is focused on one behavior, bug, or mechanical change (doc freshness only).
- [ ] Behavior changes include relevant tests or fixtures. — N/A, docs only.
- [x] SPEC impact is classified when contract-affecting. — Not contract-affecting; audit table only.
- [ ] PR has at least one approved label: `bug`, `documentation`, `enhancement`, `refactor`, `planning`, `milestone-contract`, or `process:metadata-cleanup`.
- [x] `Closes #` below is replaced with a real issue number, or this PR uses the documented `No closing issue: <reason>` exemption.
- [ ] PR is ready for review when implementation is complete.

No closing issue: this PR only refreshes the M4 gap-audit table now that #93/#96/#97 have landed. Issue #92 (the M4 milestone-contract issue) is being closed directly, per repo convention for milestone-contract issues (see #105's precedent), not by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNqvRL1GaAuMb29BzHmepZ)_