### PR TITLE
docs(specs): define registry metadata fields consumed by RPM

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -149,6 +149,8 @@ docs/specs/
       SPEC.md
     resolver/
       SPEC.md
+    registry/
+      SPEC.md
     lockfile/
       SPEC.md
     install/
@@ -266,6 +268,8 @@ M1 should start from:
 - `docs/specs/core/manifest/SPEC.md`: `package.json` interpretation
 - `docs/specs/core/semver/SPEC.md`: npm-compatible semver selection baseline
 - `docs/specs/core/resolver/SPEC.md`: dependency graph resolution boundary
+- `docs/specs/core/registry/SPEC.md`: npm registry metadata fields consumed by
+  RPM
 - `docs/specs/core/lockfile/SPEC.md`: `rpm.lock` v1 contract
 - `docs/specs/core/install/cache/SPEC.md`: install tarball cache filename and
   registry tarball write boundary

--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -11,6 +11,7 @@ Current core contracts:
 - `manifest/SPEC.md`
 - `semver/SPEC.md`
 - `resolver/SPEC.md`
+- `registry/SPEC.md`
 - `lockfile/SPEC.md`
 - `install/cache/SPEC.md`
 - `install/recovery/SPEC.md`

--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -1,0 +1,211 @@
+---
+spec_id: registry_metadata
+title: Registry Metadata
+status: draft
+owner: core/registry
+last_reviewed: 2026-08-09
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_adrs:
+  - 0002-single-crate-cli-core-boundary
+related_issues:
+  - 50
+  - 110
+---
+
+# Spec: Registry Metadata
+
+Status: Draft
+Owner: core/registry
+Last reviewed: 2026-08-09
+
+## Purpose
+
+RPM consumes a narrow subset of npm registry package-document metadata to select
+versions, locate tarballs, verify integrity, and discover dependency edges. This
+contract defines which registry metadata fields RPM consumes, which it ignores,
+and which it rejects, and keeps registry metadata interpretation separate from
+semver range parsing and installer side effects.
+
+This is the M5 foundation for npm compatibility work. Semver range behavior is
+owned by `docs/specs/core/semver/SPEC.md`. Cache writes, extraction, and linking
+are owned by the install and linker SPECs. This document owns only the boundary
+between registry metadata and the consumers that read it.
+
+## Contract
+
+Registry metadata is the npm registry package document keyed by package name. The
+authoritative implementation lives in `src/lib/registry/mod.rs` through the
+`Registry`, `Version`, `Dist`, and `DistTags` types. RPM reads metadata without
+writing files: metadata reads must remain side-effect free even when the document
+carries tarball URLs.
+
+### Metadata sources
+
+RPM reads two shapes of registry document:
+
+1. A full packument with a `versions` map keyed by version string plus a
+   `dist-tags` map. This is the primary shape; the selected version's
+   `Version` record supplies dependencies, dist metadata, and other fields.
+2. A legacy single-version shape that has no `versions` map but carries a
+   top-level `version`, `dist`, and `dependencies`. When a `versions` map is
+   absent, RPM falls back to these top-level fields for version selection,
+   dist lookup, and dependency discovery.
+
+### Consumed metadata fields
+
+RPM consumes the following fields. Fields are grouped by where they are read.
+
+Root document (`Registry`):
+
+- `name`: package name, including scope. Used as the cache filename base and the
+  resolver package key.
+- `dist-tags`: map of tag name to version string. Tag resolution happens at the
+  registry boundary before semver range evaluation. `latest` and any other
+  published tag (for example `next`, `beta`) resolve to their target version.
+- `versions`: map of version string to per-version `Version` record. The keys
+  are the candidate version set for semver range selection.
+
+Legacy root fallbacks, used only when `versions` is absent:
+
+- `version`: the single published version.
+- `dist`: root-level dist metadata used when a per-version dist is unavailable.
+- `dependencies`: root-level dependency map used when a per-version dependency
+  list is unavailable.
+
+Per-version record (`Version`):
+
+- `version`: the version this record describes.
+- `dependencies`: map of package name to range. Consumed as transitive
+  dependency edges during graph resolution. This is the only dependency map RPM
+  enqueues as ordinary dependency requests.
+- `dist`: per-version distribution metadata (see below).
+
+Distribution record (`Dist`):
+
+- `tarball`: tarball download URL. Required for download; the fetch phase fails
+  before any network request if the selected version has no tarball URL.
+- `integrity`: Subresource Integrity value. Authoritative when present. The
+  supported algorithm is `sha512`. RPM may select any matching `sha512` token
+  when the value contains multiple whitespace-separated tokens.
+- `shasum`: legacy hex-encoded SHA-1 digest. The fallback when `integrity` is
+  absent or empty. Used for tarball verification when no supported SRI value
+  exists.
+
+### Ignored metadata fields
+
+The following fields are deserialized for document fidelity but are not consumed
+by any active install, resolver, lockfile, linker, or script behavior. They do
+not affect version selection, dependency edges, cache writes, or integrity
+verification:
+
+- `devDependencies`, `peerDependencies`, `optionalDependencies`, and
+  `bundledDependencies` on both the root document and per-version records. RPM
+  does not enqueue these as dependency requests in the current non-peer-aware
+  strategy. Peer dependencies are represented as peer requirement metadata on
+  resolved package records per `docs/specs/core/resolver/SPEC.md`; they must not
+  be silently enqueued as ordinary dependencies.
+- `engines`, `os`, and `cpu`. RPM does not perform engine, OS, or CPU filtering.
+  Platform incompatibility is not a resolver or install failure today.
+- `main`, `types`, `scripts`, `bin`/package bin metadata, `private`,
+  `repository`, `description`, `maintainers`, `author`, `homepage`, `keywords`,
+  `license`, `readme`, `readmeFilename`, `time`, `_id`, `_rev`, and `sequence`.
+  These do not influence resolution, download, verification, extraction,
+  linking, lockfile, or manifest output.
+
+Ignored means RPM may accept documents that carry these fields, but no active
+behavior depends on them. An ignored field that is invalid or missing must not
+fail resolution or install.
+
+### Unsupported metadata behavior
+
+RPM rejects the following as input errors rather than silently proceeding:
+
+- A version-dist record with no `tarball` URL. The download phase must return an
+  error instead of writing a placeholder cache file (owned with
+  `docs/specs/core/install/cache/SPEC.md`).
+- An `integrity` value whose supported `sha512` token digest does not match the
+  downloaded bytes, whose digest is not valid base64, or which carries no
+  supported algorithm. The integrity gate fails the fetch/verify phase before
+  extraction (owned with
+  `docs/specs/core/install/performance/SPEC.md`).
+- A `shasum` value that is not a 40-character hex string when used as the
+  fallback verification digest, or whose SHA-1 digest does not match the
+  downloaded bytes.
+
+When both `integrity` and `shasum` are absent or empty, RPM may proceed without
+verification but must not claim the tarball was verified.
+
+## Registry Boundary
+
+The registry boundary resolves dist-tags and supplies version metadata to the
+resolver through explicit abstractions. It must not duplicate semver range
+parsing policy (owned by `docs/specs/core/semver/SPEC.md`) or perform installer
+side effects.
+
+Version selection precedence at the registry boundary:
+
+1. An empty request or `latest` resolves to the `latest` dist-tag when present,
+   otherwise to the root `version` fallback when present.
+2. A request matching any `dist-tags` key resolves to that tag's target version.
+3. Any other request is evaluated as a semver range against the `versions` keys
+   by the semver facade.
+
+Only requests that are not registry dist-tags are evaluated as semver ranges.
+This keeps version selection centralized and keeps dist-tag interpretation out of
+semver code.
+
+## Error Cases
+
+Registry metadata interpretation must not panic on user- or registry-controlled
+content. Failures must be returned to callers as typed errors:
+
+- Missing package metadata is a resolver failure (owned by
+  `docs/specs/core/resolver/SPEC.md`).
+- A requested range that cannot be satisfied or is invalid is a resolver failure
+  (owned by `docs/specs/core/semver/SPEC.md`).
+- A selected version with no tarball URL is a fetch/download failure that must
+  occur before any network tarball request (owned with
+  `docs/specs/core/install/cache/SPEC.md`).
+- A supported integrity or shasum value that does not match downloaded bytes is
+  an integrity failure that blocks extraction, lockfile writes, and manifest
+  writes (owned with `docs/specs/core/install/performance/SPEC.md` and
+  `docs/specs/core/install/recovery/SPEC.md`).
+
+Every registry-metadata failure must be reported before installer side effects
+and must not be hidden behind a panic.
+
+## Test Fixtures
+
+Registry metadata fixtures are offline JSON documents shaped like npm registry
+packuments. They live under `tests/fixtures/registry/` and the per-scenario
+`registry/` directories under `tests/fixtures/install-projects/`.
+
+Fixture expectations are defined by the owning scenario and documented in
+`docs/conventions/install_fixture_outputs.md`; they are not duplicated here. The
+`src/lib/registry/mod.rs` unit tests verify the consumed-field contract:
+
+- cache filename derivation for unscoped and scoped names (name + version)
+- tarball URL lookup for the selected version and the root-level `dist` fallback
+- integrity-only dist metadata (no legacy shasum)
+- legacy single-version document shape (root `version`, `dist`, `dependencies`)
+- dist-tag resolution before semver range evaluation
+- missing dist rejected before fetch
+- integrity verification of supported, mismatched, invalid, and absent variants
+
+New fixtures should cover dist metadata, dist-tags, dependencies, optional
+dependencies, peer dependencies, engines, OS/CPU, aliases, scoped packages, and
+package bin metadata only as needed for narrow compatibility scenarios, and must
+not duplicate the contract text above.
+
+## Open Questions
+
+- When and how RPM begins consuming `peerDependencies`, `optionalDependencies`,
+  `engines`, `os`, `cpu`, and package `bin` metadata. These remain ignored until
+  a peer-aware resolution strategy, platform gating, or `.bin` generation SPEC
+  owns the active behavior. The linker SPEC already notes `.bin` generation is
+  out of scope.

--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -50,11 +50,11 @@ RPM reads two shapes of registry document:
 
 1. A full packument with a `versions` map keyed by version string plus a
    `dist-tags` map. This is the primary shape; the selected version's
-   `Version` record supplies dependencies, dist metadata, and other fields.
-2. A legacy single-version shape that has no `versions` map but carries a
-   top-level `version`, `dist`, and `dependencies`. When a `versions` map is
-   absent, RPM falls back to these top-level fields for version selection,
-   dist lookup, and dependency discovery.
+   `Version` record supplies dependencies and dist metadata.
+2. A legacy single-version shape that carries a top-level `version`, `dist`,
+   and `dependencies`. RPM consults these root fields as a fallback whenever a
+   per-version lookup misses (including when `versions` is absent). See
+   "Legacy root fallbacks" below for the exact fallback conditions.
 
 ### Consumed metadata fields
 
@@ -70,25 +70,43 @@ Root document (`Registry`):
 - `versions`: map of version string to per-version `Version` record. The keys
   are the candidate version set for semver range selection.
 
-Legacy root fallbacks, used only when `versions` is absent:
+Legacy root fallbacks. RPM consults these root fields whenever a per-version
+lookup misses — that is, when the selected version key is not present in the
+`versions` map (including the case where `versions` is entirely absent):
 
-- `version`: the single published version.
-- `dist`: root-level dist metadata used when a per-version dist is unavailable.
-- `dependencies`: root-level dependency map used when a per-version dependency
-  list is unavailable.
+- `version`: the single published version. Used by `latest`/empty selection
+  ahead of `dist-tags.latest` (see "Registry Boundary").
+- `dist`: root-level dist metadata used when `get_dist_for_version` misses the
+  `versions` map.
+- `dependencies`: root-level dependency map used when
+  `get_dependencies_for_version` misses the `versions` map.
+
+Note: because a dist-tag target is returned without checking the `versions` map
+(see "Registry Boundary"), a tag pointing at a version absent from the map also
+falls through to these root fields. Tightening this gating is tracked as a
+follow-up (see "Open Questions").
 
 Per-version record (`Version`):
 
-- `version`: the version this record describes.
 - `dependencies`: map of package name to range. Consumed as transitive
   dependency edges during graph resolution. This is the only dependency map RPM
   enqueues as ordinary dependency requests.
 - `dist`: per-version distribution metadata (see below).
 
+Deserialized for document fidelity but not consumed after parsing: the
+per-version `name` and `version` fields. RPM selects versions by the `versions`
+map key and carries that key through dependency lookup, cache naming, and
+lockfile creation; the embedded `Version.version` and `Version.name` are never
+read by an active code path and do not influence selection.
+
 Distribution record (`Dist`):
 
-- `tarball`: tarball download URL. Required for download; the fetch phase fails
-  before any network request if the selected version has no tarball URL.
+- `tarball`: tarball download URL. `Dist` (and therefore `Version.dist`) is a
+  non-optional Serde field, so any `versions` entry that omits `dist` or
+  `dist.tarball` fails packument parsing before version selection. The
+  post-selection "no tarball" path is therefore reached only when the selected
+  version key is absent from the `versions` map and no root `dist` fallback is
+  available; the fetch phase then fails before any network request.
 - `integrity`: Subresource Integrity value. Authoritative when present. The
   supported algorithm is `sha512`. RPM may select any matching `sha512` token
   when the value contains multiple whitespace-separated tokens.
@@ -118,16 +136,29 @@ verification:
   linking, lockfile, or manifest output.
 
 Ignored means RPM may accept documents that carry these fields, but no active
-behavior depends on them. An ignored field that is invalid or missing must not
-fail resolution or install.
+behavior depends on them. The intent is that an ignored field that is invalid or
+missing must not fail resolution or install.
+
+Known gap (current behavior): several fields classified as ignored above are
+still modeled as non-optional in `src/lib/registry/mod.rs` and therefore can
+fail packument parsing if they are absent or malformed. Today this affects at
+least root `description`, root `maintainers`, and the per-version `name`,
+`version`, and `description` fields. Making the ignored-field classification
+tolerant during deserialization is tracked as a follow-up (see "Open
+Questions"). Until then, "ignored" describes the absence of downstream
+behavior, not a guarantee that a malformed ignored field cannot fail parsing.
 
 ### Unsupported metadata behavior
 
 RPM rejects the following as input errors rather than silently proceeding:
 
-- A version-dist record with no `tarball` URL. The download phase must return an
-  error instead of writing a placeholder cache file (owned with
-  `docs/specs/core/install/cache/SPEC.md`).
+- A selected version with no `tarball` URL reachable after version selection
+  (i.e. the version key is absent from the `versions` map and no root `dist`
+  fallback exists). The download phase must return an error instead of writing a
+  placeholder cache file (owned with
+  `docs/specs/core/install/cache/SPEC.md`). Note that an entry inside the
+  `versions` map with a missing `dist` or `dist.tarball` is rejected earlier,
+  during Serde parsing of the packument.
 - An `integrity` value whose supported `sha512` token digest does not match the
   downloaded bytes, whose digest is not valid base64, or which carries no
   supported algorithm. The integrity gate fails the fetch/verify phase before
@@ -149,11 +180,20 @@ side effects.
 
 Version selection precedence at the registry boundary:
 
-1. An empty request or `latest` resolves to the `latest` dist-tag when present,
-   otherwise to the root `version` fallback when present.
-2. A request matching any `dist-tags` key resolves to that tag's target version.
+1. An empty request or `latest` resolves to the root `version` fallback when
+   present; otherwise to the `latest` dist-tag when present. (The current
+   implementation checks root `version` before `dist-tags.latest`.)
+2. A request matching any `dist-tags` key resolves to that tag's target version
+   string, returned without checking that the target exists in the `versions`
+   map. Downstream lookups then fall through to root fields when the target is
+   absent from the map (see "Legacy root fallbacks").
 3. Any other request is evaluated as a semver range against the `versions` keys
-   by the semver facade.
+   by the semver facade. `max_satisfying` iterates the `versions` map in
+   `HashMap` order and keeps the first candidate on equal precedence; because
+   `Version::cmp` ignores build metadata, ranges that match keys differing only
+   in build metadata (for example `1.0.0+one` and `1.0.0+two`) can select a
+   different raw key across runs. A deterministic tie-break is tracked as a
+   follow-up (see "Open Questions").
 
 Only requests that are not registry dist-tags are evaluated as semver ranges.
 This keeps version selection centralized and keeps dist-tag interpretation out of
@@ -164,20 +204,31 @@ semver code.
 Registry metadata interpretation must not panic on user- or registry-controlled
 content. Failures must be returned to callers as typed errors:
 
-- Missing package metadata is a resolver failure (owned by
-  `docs/specs/core/resolver/SPEC.md`).
+- A package absent from the registry, or a registry response that cannot be
+  read or parsed, surfaces as a **fetch** failure during metadata population
+  (before the resolver runs). Missing metadata discovered later, during
+  resolution (for example a transitive dependency whose metadata was never
+  fetched), surfaces as a **resolve** failure via `ResolutionError::MissingMetadata`
+  (owned by `docs/specs/core/resolver/SPEC.md`).
 - A requested range that cannot be satisfied or is invalid is a resolver failure
   (owned by `docs/specs/core/semver/SPEC.md`).
-- A selected version with no tarball URL is a fetch/download failure that must
-  occur before any network tarball request (owned with
+- A selected version with no reachable `tarball` URL (version key absent from
+  the `versions` map and no root `dist` fallback) is a fetch/download failure
+  that occurs before any network tarball request (owned with
   `docs/specs/core/install/cache/SPEC.md`).
 - A supported integrity or shasum value that does not match downloaded bytes is
   an integrity failure that blocks extraction, lockfile writes, and manifest
   writes (owned with `docs/specs/core/install/performance/SPEC.md` and
-  `docs/specs/core/install/recovery/SPEC.md`).
+  `docs/specs/core/install/recovery/SPEC.md`). Because the tarball is downloaded
+  and cached before verification, this failure is reported after the allowed
+  fetch/verify cache side effect, not before all installer side effects.
 
-Every registry-metadata failure must be reported before installer side effects
-and must not be hidden behind a panic.
+Registry metadata **read and interpretation** failures (parsing, version
+selection, dist lookup) must be reported before installer side effects and must
+not be hidden behind a panic. Integrity verification is intentionally excluded
+from this guarantee: the bytes it checks are produced by the fetch/verify step
+and are an allowed side effect per
+`docs/specs/core/install/recovery/SPEC.md`.
 
 ## Test Fixtures
 
@@ -209,3 +260,13 @@ not duplicate the contract text above.
   a peer-aware resolution strategy, platform gating, or `.bin` generation SPEC
   owns the active behavior. The linker SPEC already notes `.bin` generation is
   out of scope.
+- Making the ignored-field classification tolerant during deserialization. Today
+  several ignored fields (root `description`, root `maintainers`, per-version
+  `name`/`version`/`description`) are non-optional and can fail packument
+  parsing. Tracked in #113.
+- Gating root metadata fallbacks: rejecting dist-tag targets that are absent
+  from the `versions` map rather than silently falling through to root `dist`
+  and root `dependencies`. Tracked in #114.
+- Defining a deterministic tie-break (or stable candidate ordering) for version
+  keys that differ only in build metadata, so `max_satisfying` is repeatable
+  across runs. Tracked in #115.


### PR DESCRIPTION
Closes #110

## Contract

Adds the missing owning SPEC for npm registry metadata interpretation at
`docs/specs/core/registry/SPEC.md`. This is the M5 compatibility foundation and
the first narrow owner for registry metadata fields.

Classification (no SPEC exists → new SPEC, reflecting current code behavior in
`src/lib/registry/mod.rs`):

- **Consumed:** `name`, `dist-tags`, `versions`; per-version `version`,
  `dependencies`, `dist` (`tarball` / `integrity` / `shasum`); legacy root
  `version`/`dist`/`dependencies` fallbacks.
- **Ignored:** `devDependencies`, `peerDependencies`, `optionalDependencies`,
  `bundledDependencies`, `engines`, `os`, `cpu`, `bin`, and descriptive fields
  (`repository`, `description`, `maintainers`, `author`, `homepage`,
  `keywords`, `license`, `readme`, `time`, …).
- **Rejected:** selected version with no `tarball` URL; `sha512` SRI digest
  mismatch / invalid base64 / unsupported algorithm; non-hex or mismatched
  legacy `shasum`.

The registry boundary section pins dist-tag resolution (`latest`, `next`,
`beta`, …) before semver range evaluation, keeping version selection centralized
and out of semver code (owned by `docs/specs/core/semver/SPEC.md`).

## Changes

- `docs/specs/core/registry/SPEC.md` — new SPEC (Purpose, Contract, Registry
  Boundary, Error Cases, Test Fixtures, Open Questions).
- `docs/specs/core/README.md` — register `registry/SPEC.md` in the core
  contracts list.
- `docs/specs/README.md` — add the directory to the layout and the Current
  Index.

Scope note: docs-only. No code, lockfile, resolver, cache, or linker behavior
changes. Fixture expectations are linked (to
`docs/conventions/install_fixture_outputs.md` and existing
`src/lib/registry/mod.rs` tests), not duplicated.

## Validation

- `just format-check` — pass
- `just check` — pass
- `just test` — 148 passed, 0 failed (pre-push hook re-ran clippy + full test)

## Checklist

- [x] Owning SPEC identified (`core/registry`, previously missing)
- [x] Classification stated (no SPEC exists → new SPEC matching current behavior)
- [x] Done criteria from #110 met: consumed/ignored/rejected fields explicit;
      dist, dist-tags, dependencies, optional/peer deps, engines, OS/CPU, and
      bin classified; fixture expectations linked not duplicated
- [x] Indexes updated
- [x] Validation run with real evidence