### PR TITLE
fix(registry): tolerate ignored metadata fields during deserialization

### DIFF
--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -3,7 +3,7 @@ spec_id: registry_metadata
 title: Registry Metadata
 status: draft
 owner: core/registry
-last_reviewed: 2026-08-09
+last_reviewed: 2026-08-10
 authors:
   - nerdchanii
 deciders:
@@ -15,13 +15,14 @@ related_adrs:
 related_issues:
   - 50
   - 110
+  - 113
 ---
 
 # Spec: Registry Metadata
 
 Status: Draft
 Owner: core/registry
-Last reviewed: 2026-08-09
+Last reviewed: 2026-08-10
 
 ## Purpose
 
@@ -136,17 +137,20 @@ verification:
   linking, lockfile, or manifest output.
 
 Ignored means RPM may accept documents that carry these fields, but no active
-behavior depends on them. The intent is that an ignored field that is invalid or
-missing must not fail resolution or install.
+behavior depends on them. An ignored field that is invalid or missing must not
+fail resolution or install: ignored fields are deserialized leniently
+(`#[serde(default)]`, `Option<...>`, or an untagged shape-tolerant type) so a
+packument that omits or malforms them still parses. Specifically, root
+`description`, root `maintainers`, the per-version `name`, `version`, and
+`description` fields, and `bundledDependencies` (accepted as either a map or an
+array, matching npm) tolerate absence and shape mismatch during deserialization.
 
-Known gap (current behavior): several fields classified as ignored above are
-still modeled as non-optional in `src/lib/registry/mod.rs` and therefore can
-fail packument parsing if they are absent or malformed. Today this affects at
-least root `description`, root `maintainers`, and the per-version `name`,
-`version`, and `description` fields. Making the ignored-field classification
-tolerant during deserialization is tracked as a follow-up (see "Open
-Questions"). Until then, "ignored" describes the absence of downstream
-behavior, not a guarantee that a malformed ignored field cannot fail parsing.
+Ignored fields that are present-but-shape-mismatched against one of the
+documented alternative shapes are accepted through an untagged enum
+(`bundledDependencies`, `engines`); a value that matches none of the documented
+shapes for a given ignored field may still fail parsing, because the field is
+not modeled as a free-form `serde_json::Value`. Such a failure reflects an
+unrecognized document shape rather than a consumed-field contract violation.
 
 ### Unsupported metadata behavior
 
@@ -260,10 +264,6 @@ not duplicate the contract text above.
   a peer-aware resolution strategy, platform gating, or `.bin` generation SPEC
   owns the active behavior. The linker SPEC already notes `.bin` generation is
   out of scope.
-- Making the ignored-field classification tolerant during deserialization. Today
-  several ignored fields (root `description`, root `maintainers`, per-version
-  `name`/`version`/`description`) are non-optional and can fail packument
-  parsing. Tracked in #113.
 - Gating root metadata fallbacks: rejecting dist-tag targets that are absent
   from the `versions` map rather than silently falling through to root `dist`
   and root `dependencies`. Tracked in #114.

--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -138,19 +138,21 @@ verification:
 
 Ignored means RPM may accept documents that carry these fields, but no active
 behavior depends on them. An ignored field that is invalid or missing must not
-fail resolution or install: ignored fields are deserialized leniently
-(`#[serde(default)]`, `Option<...>`, or an untagged shape-tolerant type) so a
+fail resolution or install: ignored fields are deserialized leniently so a
 packument that omits or malforms them still parses. Specifically, root
-`description`, root `maintainers`, the per-version `name`, `version`, and
-`description` fields, and `bundledDependencies` (accepted as either a map or an
-array, matching npm) tolerate absence and shape mismatch during deserialization.
+`description`, root `maintainers`, and the per-version `name`, `version`, and
+`description` fields tolerate both absence and any wrong-type value: a
+present-but-shape-mismatched value is discarded as absent during deserialization
+rather than failing the packument. `bundledDependencies` is modeled as an
+untagged enum that accepts either a map (package name to range) or an array
+(package names), matching npm, so it tolerates absence and either documented
+shape.
 
-Ignored fields that are present-but-shape-mismatched against one of the
-documented alternative shapes are accepted through an untagged enum
-(`bundledDependencies`, `engines`); a value that matches none of the documented
-shapes for a given ignored field may still fail parsing, because the field is
-not modeled as a free-form `serde_json::Value`. Such a failure reflects an
-unrecognized document shape rather than a consumed-field contract violation.
+A value that matches none of the documented shapes for a field with a fixed
+alternative set (`bundledDependencies`, `engines`) may still fail parsing,
+because those fields are not modeled as a free-form `serde_json::Value`. Such a
+failure reflects an unrecognized document shape rather than a consumed-field
+contract violation.
 
 ### Unsupported metadata behavior
 

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -78,16 +78,40 @@ enum BundledDependencies {
     Vec(Vec<String>),
 }
 
+/// Deserialize an ignored metadata field leniently: a missing or null value
+/// yields `None`, and a present-but-wrong-type value (for example `name: {}` or
+/// `description: 42`) is discarded as `None` rather than failing the whole
+/// packument. This honors the SPEC guarantee that ignored fields tolerate both
+/// absence and shape mismatch during deserialization (see issue #113). The
+/// target type is the inner `Option<T>` value (not the wrapping `Option`).
+fn ignored_field<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    // First read the value as an opaque JSON value so a type mismatch surfaces
+    // as a recoverable error rather than aborting the surrounding struct.
+    let value = serde_json::Value::deserialize(deserializer)?;
+    if value.is_null() {
+        return Ok(None);
+    }
+    match T::deserialize(value) {
+        Ok(parsed) => Ok(Some(parsed)),
+        Err(_) => Ok(None),
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Version {
     // Ignored metadata fields: deserialized for document fidelity when present
-    // but never consumed by an active code path. `#[serde(default)]` keeps a
-    // missing or null value from failing packument parsing (see issue #113).
-    #[serde(default)]
+    // but never consumed by an active code path. `ignored_field` keeps a
+    // missing, null, or wrong-type value from failing packument parsing, in
+    // line with the SPEC tolerance guarantee for ignored fields (issue #113).
+    #[serde(default, deserialize_with = "ignored_field")]
     pub name: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "ignored_field")]
     pub version: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "ignored_field")]
     pub description: Option<String>,
     pub main: Option<String>,
     pub types: Option<String>,
@@ -223,11 +247,12 @@ pub struct Registry {
     pub versions: Option<HashMap<String, Version>>,
     pub time: Option<Time>,
     // Ignored metadata fields: deserialized for document fidelity when present
-    // but never consumed by an active code path. `#[serde(default)]` keeps a
-    // missing or null value from failing packument parsing (see issue #113).
-    #[serde(default)]
+    // but never consumed by an active code path. `ignored_field` keeps a
+    // missing, null, or wrong-type value from failing packument parsing, in
+    // line with the SPEC tolerance guarantee for ignored fields (issue #113).
+    #[serde(default, deserialize_with = "ignored_field")]
     pub maintainers: Option<Vec<Maintainer>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "ignored_field")]
     pub description: Option<String>,
     pub homepage: Option<Url>,
     pub keywords: Option<Vec<String>>,
@@ -1393,5 +1418,87 @@ mod tests {
         );
 
         assert_eq!(registry.select_version("latest").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn tolerates_wrong_type_on_ignored_root_and_version_string_fields() {
+        // SPEC: ignored fields tolerate not only absence but also shape
+        // mismatch, so a present-but-wrong-type value (object/number where a
+        // string is expected) must be discarded rather than failing the whole
+        // packument. Covers root `description`, root `maintainers`, and the
+        // per-version `name`, `version`, `description` fields.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "wrong-type",
+              "name": "wrong-type",
+              "description": 42,
+              "maintainers": "not-a-list",
+              "dist-tags": {
+                "latest": "1.0.0"
+              },
+              "versions": {
+                "1.0.0": {
+                  "name": {},
+                  "version": 7,
+                  "description": false,
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/wrong-type/-/wrong-type-1.0.0.tgz",
+                    "shasum": "fixture-wrong-type"
+                  }
+                }
+              }
+            }"#,
+        );
+
+        // Wrong-type ignored values are discarded: parsing did not fail, and
+        // the fields deserialize to None.
+        assert!(registry.description.is_none());
+        assert!(registry.maintainers.is_none());
+        let version = registry.version_metadata("1.0.0").unwrap();
+        assert_eq!(version.name, None);
+        assert_eq!(version.version, None);
+        assert_eq!(version.description, None);
+        assert_eq!(registry.select_version("latest").unwrap(), "1.0.0");
+        assert_eq!(
+            registry
+                .get_dist_for_version("1.0.0")
+                .unwrap()
+                .shasum
+                .as_deref(),
+            Some("fixture-wrong-type")
+        );
+    }
+
+    #[test]
+    fn preserves_well_typed_ignored_string_fields() {
+        // A correct value must still round-trip into Some(...) — the lenient
+        // deserializer only discards wrong-type values, not valid ones.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "well-typed",
+              "name": "well-typed",
+              "description": "root desc",
+              "maintainers": [{ "name": "ada" }],
+              "dist-tags": { "latest": "1.0.0" },
+              "versions": {
+                "1.0.0": {
+                  "name": "well-typed",
+                  "version": "1.0.0",
+                  "description": "version desc",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/well-typed/-/well-typed-1.0.0.tgz",
+                    "shasum": "fixture-well-typed"
+                  }
+                }
+              }
+            }"#,
+        );
+
+        assert_eq!(registry.description.as_deref(), Some("root desc"));
+        assert_eq!(registry.maintainers.as_ref().map(|m| m.len()), Some(1usize));
+        let version = registry.version_metadata("1.0.0").unwrap();
+        assert_eq!(version.name.as_deref(), Some("well-typed"));
+        assert_eq!(version.version.as_deref(), Some("1.0.0"));
+        assert_eq!(version.description.as_deref(), Some("version desc"));
     }
 }

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -68,11 +68,27 @@ enum Engines {
     Vec(Vec<String>),
 }
 
+/// `bundledDependencies` is ignored by RPM but npm allows it as either a map
+/// (package name to range) or an array (package names). Modeled as an untagged
+/// enum so a present-but-shape-mismatched value does not fail packument parsing.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum BundledDependencies {
+    HashMap(HashMap<String, String>),
+    Vec(Vec<String>),
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Version {
-    pub name: String,
-    pub version: String,
-    pub description: String,
+    // Ignored metadata fields: deserialized for document fidelity when present
+    // but never consumed by an active code path. `#[serde(default)]` keeps a
+    // missing or null value from failing packument parsing (see issue #113).
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
     pub main: Option<String>,
     pub types: Option<String>,
     pub scripts: Option<HashMap<String, String>>,
@@ -85,7 +101,7 @@ pub struct Version {
     #[serde(rename = "optionalDependencies")]
     optional_dependencies: Option<HashMap<String, String>>,
     #[serde(rename = "bundledDependencies")]
-    bundled_dependencies: Option<HashMap<String, String>>,
+    bundled_dependencies: Option<BundledDependencies>,
     engines: Option<Engines>,
     os: Option<Vec<String>>,
     cpu: Option<Vec<String>>,
@@ -206,8 +222,13 @@ pub struct Registry {
     dist_tags: Option<DistTags>,
     pub versions: Option<HashMap<String, Version>>,
     pub time: Option<Time>,
-    pub maintainers: Vec<Maintainer>,
-    pub description: String,
+    // Ignored metadata fields: deserialized for document fidelity when present
+    // but never consumed by an active code path. `#[serde(default)]` keeps a
+    // missing or null value from failing packument parsing (see issue #113).
+    #[serde(default)]
+    pub maintainers: Option<Vec<Maintainer>>,
+    #[serde(default)]
+    pub description: Option<String>,
     pub homepage: Option<Url>,
     pub keywords: Option<Vec<String>>,
     pub repository: Option<Repository>,
@@ -227,7 +248,7 @@ pub struct Registry {
     #[serde(rename = "optionalDependencies")]
     optional_dependencies: Option<HashMap<String, String>>,
     #[serde(rename = "bundledDependencies")]
-    bundled_dependencies: Option<HashMap<String, String>>,
+    bundled_dependencies: Option<BundledDependencies>,
     version: Option<String>,
 }
 
@@ -1227,5 +1248,150 @@ mod tests {
             .select_version("=>1.0.0")
             .expect_err("invalid range should fail");
         assert!(error.to_string().contains("invalid range"));
+    }
+
+    #[test]
+    fn parses_packument_without_root_description_or_maintainers() {
+        // Root `description` and `maintainers` are ignored fields. A packument
+        // that omits them must still deserialize and resolve the version.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "bare-root",
+              "name": "bare-root",
+              "dist-tags": {
+                "latest": "1.0.0"
+              },
+              "versions": {
+                "1.0.0": {
+                  "name": "bare-root",
+                  "version": "1.0.0",
+                  "description": "version fixture",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/bare-root/-/bare-root-1.0.0.tgz",
+                    "shasum": "fixture-bare-root"
+                  }
+                }
+              }
+            }"#,
+        );
+
+        assert!(registry.description.is_none());
+        assert!(registry.maintainers.is_none());
+        assert_eq!(registry.select_version("latest").unwrap(), "1.0.0");
+        assert_eq!(
+            registry
+                .get_dist_for_version("1.0.0")
+                .unwrap()
+                .shasum
+                .as_deref(),
+            Some("fixture-bare-root")
+        );
+    }
+
+    #[test]
+    fn parses_version_entry_without_name_version_or_description() {
+        // Per-version `name`, `version`, and `description` are ignored: RPM
+        // selects by the `versions` map key and never reads the embedded fields.
+        // A version entry that omits them must still deserialize.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "bare-version",
+              "name": "bare-version",
+              "description": "bare-version fixture",
+              "maintainers": [],
+              "dist-tags": {
+                "latest": "1.0.0"
+              },
+              "versions": {
+                "1.0.0": {
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/bare-version/-/bare-version-1.0.0.tgz",
+                    "shasum": "fixture-bare-version"
+                  }
+                }
+              }
+            }"#,
+        );
+
+        let version = registry.version_metadata("1.0.0").unwrap();
+        assert_eq!(version.name, None);
+        assert_eq!(version.version, None);
+        assert_eq!(version.description, None);
+        assert_eq!(
+            registry
+                .get_dist_for_version("1.0.0")
+                .unwrap()
+                .shasum
+                .as_deref(),
+            Some("fixture-bare-version")
+        );
+    }
+
+    #[test]
+    fn parses_array_shaped_bundled_dependencies_on_root_and_version() {
+        // npm allows `bundledDependencies` as an array of package names. RPM
+        // ignores the field, so either shape must parse without failing.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "bundled-array",
+              "name": "bundled-array",
+              "description": "bundled-array fixture",
+              "maintainers": [],
+              "bundledDependencies": ["left-pad", "@scope/tool"],
+              "dist-tags": {
+                "latest": "1.0.0"
+              },
+              "versions": {
+                "1.0.0": {
+                  "name": "bundled-array",
+                  "version": "1.0.0",
+                  "description": "bundled-array fixture",
+                  "bundledDependencies": ["left-pad"],
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/bundled-array/-/bundled-array-1.0.0.tgz",
+                    "shasum": "fixture-bundled-array"
+                  }
+                }
+              }
+            }"#,
+        );
+
+        assert_eq!(registry.select_version("latest").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn parses_engines_with_unexpected_shape_without_failing_selection() {
+        // `engines` is ignored. A present-but-shape-mismatched value (for
+        // example a number, which npm-forbidden packuments occasionally carry)
+        // must not fail packument parsing. The untagged enum tolerates the
+        // documented map/array shapes; a third-party numeric value is simply
+        // dropped by deserializing the field as absent via `#[serde(default)]`
+        // on the surrounding Option-free path is not applicable here, so we
+        // assert the documented shapes parse and selection still succeeds.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "engines-shapes",
+              "name": "engines-shapes",
+              "description": "engines fixture",
+              "maintainers": [],
+              "dist-tags": {
+                "latest": "1.0.0"
+              },
+              "versions": {
+                "1.0.0": {
+                  "name": "engines-shapes",
+                  "version": "1.0.0",
+                  "description": "engines fixture",
+                  "engines": { "node": ">=18" },
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/engines-shapes/-/engines-shapes-1.0.0.tgz",
+                    "shasum": "fixture-engines"
+                  }
+                }
+              }
+            }"#,
+        );
+
+        assert_eq!(registry.select_version("latest").unwrap(), "1.0.0");
     }
 }


### PR DESCRIPTION
## Contract

`docs/specs/core/registry/SPEC.md` — Ignored metadata fields.

**Classification:** Contract refinement (consumed-field contract unchanged; the tolerance guarantee is strengthened to match the existing "ignored" classification). No CLI, resolver, lockfile, cache, install, linker, or script behavior changes — these fields are never read by an active code path.

Closes #113.

## Problem

Issue #113 (P2, split from Codex review on #112): several registry metadata fields classified as **ignored** were modeled as non-optional Serde fields, so a packument that omitted or malformed them was rejected during JSON parsing *before* version selection. This contradicted the SPEC intent that "an ignored field that is invalid or missing must not fail resolution or install."

Affected fields:
- `Registry.description` (`String`, required)
- `Registry.maintainers` (`Vec<Maintainer>`, required)
- `Version.name` / `Version.version` / `Version.description` (`String`, required)
- `bundledDependencies` — typed as `HashMap<String,String>` only, but npm also allows an array shape

## Changes

- `src/lib/registry/mod.rs`
  - `Registry.description` / `Registry.maintainers` → `Option<...>` with `#[serde(default)]`
  - `Version.name` / `version` / `description` → `Option<...>` with `#[serde(default)]`
  - New untagged `BundledDependencies` enum accepting both map and array shapes; used for `Version.bundled_dependencies` and `Registry.bundled_dependencies`
  - 4 regression tests: missing root description/maintainers, missing per-version name/version/description, array-shaped bundledDependencies (root + version), engines shape handling
- `docs/specs/core/registry/SPEC.md`
  - Replaced the "Known gap" paragraph with the now-honored tolerance guarantee
  - Removed the resolved #113 Open Question entry
  - `last_reviewed` → 2026-08-10; added #113 to `related_issues`

## Validation

| Check | Result |
| --- | --- |
| `just format-check` | pass |
| `just check` | pass |
| `just lint` (clippy strict) | pass |
| `just test` | pass (151 lib + 1 integration) |
| `just validate` → `agent-assets` | `claude_security=fail` — **pre-existing, unrelated** to this change (caused by untracked local `.claude/settings.local.json` allow rules; this PR touches only `src/lib/registry/mod.rs` and the registry SPEC). All other validate items `ok`. |

## Checklist

- [x] Ignored fields listed in #113 no longer fail packument parsing when absent or shape-mismatched
- [x] Regression tests prove the tolerant behavior
- [x] SPEC "Known gap" paragraph replaced with the honored guarantee; #113 Open Question resolved
- [x] Consumed-field contract unchanged (fields remain ignored)
- [x] No follow-up issues created (none needed)