### PR TITLE
fix(registry): gate root metadata fallbacks on versions-map membership

### DIFF
--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -52,11 +52,13 @@ RPM reads two shapes of registry document:
 
 1. A full packument with a `versions` map keyed by version string plus a
    `dist-tags` map. This is the primary shape; the selected version's
-   `Version` record supplies dependencies and dist metadata.
+   `Version` record supplies dependencies and dist metadata. A version key that
+   is absent from the map is never substituted with root fields — the lookup
+   fails (see "Legacy root fallbacks" and "Unsupported metadata behavior").
 2. A legacy single-version shape that carries a top-level `version`, `dist`,
-   and `dependencies`. RPM consults these root fields as a fallback whenever a
-   per-version lookup misses (including when `versions` is absent). See
-   "Legacy root fallbacks" below for the exact fallback conditions.
+   and `dependencies` and no `versions` map. Root fields are the authoritative
+   record for this shape and are consulted in place of per-version metadata
+   (see "Legacy root fallbacks").
 
 ### Consumed metadata fields
 
@@ -198,7 +200,15 @@ Version selection precedence at the registry boundary:
 
 1. An empty request or `latest` resolves to the root `version` fallback when
    present; otherwise to the `latest` dist-tag when present. (The current
-   implementation checks root `version` before `dist-tags.latest`.)
+   implementation checks root `version` before `dist-tags.latest`.) The resolved
+   target is then subject to the same membership guard as step 2: it is returned
+   only when it exists in the `versions` map, or when no `versions` map is
+   present (legacy single-version shape). When a `versions` map is present but
+   the resolved target is absent from it, the request is rejected as
+   unsatisfiable rather than returning a version key with no per-version
+   metadata. This is what gates a dangling `latest` tag (and bare dependency
+   requests, which are normalized to `latest`) the same way an explicit dist-tag
+   is gated (issue #114).
 2. A request matching any `dist-tags` key resolves to that tag's target version
    string only when the target exists in the `versions` map, or when no
    `versions` map is present (legacy single-version shape). When a `versions`

--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -16,6 +16,7 @@ related_issues:
   - 50
   - 110
   - 113
+  - 114
 ---
 
 # Spec: Registry Metadata
@@ -71,21 +72,23 @@ Root document (`Registry`):
 - `versions`: map of version string to per-version `Version` record. The keys
   are the candidate version set for semver range selection.
 
-Legacy root fallbacks. RPM consults these root fields whenever a per-version
-lookup misses — that is, when the selected version key is not present in the
-`versions` map (including the case where `versions` is entirely absent):
+Legacy root fallbacks. RPM consults these root fields only for the legacy
+single-version shape — that is, when the `versions` map is entirely absent. When
+a `versions` map is present, a version key missing from the map is never
+silently substituted with root fields; the lookup fails instead (see
+"Unsupported metadata behavior"):
 
 - `version`: the single published version. Used by `latest`/empty selection
   ahead of `dist-tags.latest` (see "Registry Boundary").
-- `dist`: root-level dist metadata used when `get_dist_for_version` misses the
-  `versions` map.
+- `dist`: root-level dist metadata used when `get_dist_for_version` is consulted
+  for the legacy shape (no `versions` map).
 - `dependencies`: root-level dependency map used when
-  `get_dependencies_for_version` misses the `versions` map.
+  `get_dependencies_for_version` is consulted for the legacy shape (no
+  `versions` map).
 
-Note: because a dist-tag target is returned without checking the `versions` map
-(see "Registry Boundary"), a tag pointing at a version absent from the map also
-falls through to these root fields. Tightening this gating is tracked as a
-follow-up (see "Open Questions").
+Because root fallbacks are gated on the absence of the `versions` map, a
+dist-tag target absent from the map is rejected at selection time rather than
+falling through to root `dist`/`dependencies` (see "Registry Boundary").
 
 Per-version record (`Version`):
 
@@ -105,9 +108,9 @@ Distribution record (`Dist`):
 - `tarball`: tarball download URL. `Dist` (and therefore `Version.dist`) is a
   non-optional Serde field, so any `versions` entry that omits `dist` or
   `dist.tarball` fails packument parsing before version selection. The
-  post-selection "no tarball" path is therefore reached only when the selected
-  version key is absent from the `versions` map and no root `dist` fallback is
-  available; the fetch phase then fails before any network request.
+  post-selection "no tarball" path is reached when the selected version key is
+  absent from the `versions` map (root fallback no longer applies once a
+  `versions` map exists); the fetch phase then fails before any network request.
 - `integrity`: Subresource Integrity value. Authoritative when present. The
   supported algorithm is `sha512`. RPM may select any matching `sha512` token
   when the value contains multiple whitespace-separated tokens.
@@ -158,10 +161,17 @@ contract violation.
 
 RPM rejects the following as input errors rather than silently proceeding:
 
+- A dist-tag whose target version string is absent from the `versions` map when
+  a `versions` map is present. The tag is treated as unsatisfiable (a resolver
+  failure) rather than returning a version key with no per-version metadata.
+  This prevents a tag from silently selecting root `dist`/`dependencies` under
+  an unrelated version key (issue #114). When no `versions` map is present
+  (legacy single-version shape), the tag target resolves normally via root
+  fields.
 - A selected version with no `tarball` URL reachable after version selection
-  (i.e. the version key is absent from the `versions` map and no root `dist`
-  fallback exists). The download phase must return an error instead of writing a
-  placeholder cache file (owned with
+  (i.e. the version key is absent from the `versions` map; root `dist` no longer
+  applies once a `versions` map exists). The download phase must return an error
+  instead of writing a placeholder cache file (owned with
   `docs/specs/core/install/cache/SPEC.md`). Note that an entry inside the
   `versions` map with a missing `dist` or `dist.tarball` is rejected earlier,
   during Serde parsing of the packument.
@@ -190,9 +200,12 @@ Version selection precedence at the registry boundary:
    present; otherwise to the `latest` dist-tag when present. (The current
    implementation checks root `version` before `dist-tags.latest`.)
 2. A request matching any `dist-tags` key resolves to that tag's target version
-   string, returned without checking that the target exists in the `versions`
-   map. Downstream lookups then fall through to root fields when the target is
-   absent from the map (see "Legacy root fallbacks").
+   string only when the target exists in the `versions` map, or when no
+   `versions` map is present (legacy single-version shape). When a `versions`
+   map is present but the target is absent from it, the tag is rejected as
+   unsatisfiable rather than returning a version key with no per-version
+   metadata. This prevents a tag from silently selecting root `dist`/
+   `dependencies` under an unrelated version key (issue #114).
 3. Any other request is evaluated as a semver range against the `versions` keys
    by the semver facade. `max_satisfying` iterates the `versions` map in
    `HashMap` order and keeps the first candidate on equal precedence; because
@@ -266,9 +279,6 @@ not duplicate the contract text above.
   a peer-aware resolution strategy, platform gating, or `.bin` generation SPEC
   owns the active behavior. The linker SPEC already notes `.bin` generation is
   out of scope.
-- Gating root metadata fallbacks: rejecting dist-tag targets that are absent
-  from the `versions` map rather than silently falling through to root `dist`
-  and root `dependencies`. Tracked in #114.
 - Defining a deterministic tie-break (or stable candidate ordering) for version
   keys that differ only in build metadata, so `max_satisfying` is repeatable
   across runs. Tracked in #115.

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -300,7 +300,26 @@ impl Registry {
     pub fn select_version(&self, requested: &str) -> Result<String, SemverError> {
         if requested.is_empty() || requested == "latest" {
             if let Some(version) = self.get_latest_version() {
-                return Ok(version.to_owned());
+                // `latest`/empty selection resolves to either the root
+                // `version` field or the `latest` dist-tag (see
+                // `get_latest_version`). Either source is a version string that
+                // is subject to the same membership guard as an explicit
+                // dist-tag: a `versions` map is absent (legacy single-version
+                // shape, where root fields are the only record), or the target
+                // exists in the map. When a `versions` map is present but the
+                // resolved target is absent from it, reject as unsatisfiable
+                // instead of returning a version key with no per-version
+                // metadata — otherwise bare dependency requests (which are
+                // normalized to `latest`) would bypass the dist-tag guard and
+                // record the root tarball under an unrelated version key
+                // (issue #114).
+                return if self.versions.is_none() || self.version_metadata(version).is_some() {
+                    Ok(version.to_owned())
+                } else {
+                    Err(SemverError::UnsatisfiedRange {
+                        range: requested.to_string(),
+                    })
+                };
             }
         }
         if let Some(version) = self
@@ -1664,5 +1683,121 @@ mod tests {
         assert_eq!(dist.shasum.as_deref(), Some("fixture-legacy-single"));
         let deps = registry.get_dependencies_for_version("2.0.0");
         assert!(deps.contains(&"left-pad@^1.0.0".to_owned()));
+    }
+
+    #[test]
+    fn dangling_latest_tag_is_rejected_via_latest_path() {
+        // Regression for issue #114 via the `latest`/empty selection path: when
+        // a `versions` map is present and `dist-tags.latest` points at a version
+        // absent from the map, `select_version("latest")` and the bare
+        // `select_version("")` request (which is normalized to the latest path)
+        // must reject the tag as unsatisfiable — not bypass the dist-tag
+        // membership guard and return a version key with no per-version
+        // metadata. Returning it would let downstream lookups fall through to
+        // root `dist`/`dependencies`, recording the root tarball under an
+        // unrelated version key.
+        //
+        // Note: there is no root `version` field here, so `get_latest_version`
+        // falls through to `dist-tags.latest`, which is the dangling target.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "dangling-latest",
+              "name": "dangling-latest",
+              "description": "dangling-latest fixture",
+              "maintainers": [],
+              "dist-tags": {
+                "latest": "3.0.0"
+              },
+              "versions": {
+                "1.0.0": {
+                  "name": "dangling-latest",
+                  "version": "1.0.0",
+                  "description": "stable",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/dangling-latest/-/dangling-latest-1.0.0.tgz",
+                    "shasum": "fixture-dangling-latest-stable"
+                  }
+                }
+              },
+              "dist": {
+                "tarball": "https://registry.example.invalid/dangling-latest/-/dangling-latest-root.tgz",
+                "shasum": "fixture-dangling-latest-root"
+              },
+              "dependencies": {
+                "left-pad": "^1.0.0"
+              }
+            }"#,
+        );
+
+        // `latest` resolves to 3.0.0, which is absent from the `versions` map.
+        // It must be rejected rather than returning the dangling 3.0.0.
+        let error = registry
+            .select_version("latest")
+            .expect_err("dangling latest tag should be rejected via the latest path");
+        assert!(matches!(error, SemverError::UnsatisfiedRange { .. }));
+
+        // The bare (empty) request takes the same path and must also be
+        // rejected.
+        let error = registry
+            .select_version("")
+            .expect_err("dangling latest tag should be rejected via the empty path");
+        assert!(matches!(error, SemverError::UnsatisfiedRange { .. }));
+
+        // A present version key is unaffected.
+        assert_eq!(registry.select_version("1.0.0").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn dangling_root_version_is_rejected_via_latest_path() {
+        // Companion to `dangling_latest_tag_is_rejected_via_latest_path`: when
+        // a `versions` map is present and the root `version` field names a
+        // version absent from the map, the `latest`/empty path must reject it
+        // too. The implementation checks root `version` before `dist-tags.latest`,
+        // so this exercises the root-version branch of the membership guard.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "dangling-root-version",
+              "name": "dangling-root-version",
+              "description": "dangling-root-version fixture",
+              "maintainers": [],
+              "version": "3.0.0",
+              "dist-tags": {
+                "latest": "3.0.0"
+              },
+              "versions": {
+                "1.0.0": {
+                  "name": "dangling-root-version",
+                  "version": "1.0.0",
+                  "description": "stable",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/dangling-root-version/-/dangling-root-version-1.0.0.tgz",
+                    "shasum": "fixture-dangling-root-version-stable"
+                  }
+                }
+              },
+              "dist": {
+                "tarball": "https://registry.example.invalid/dangling-root-version/-/dangling-root-version-root.tgz",
+                "shasum": "fixture-dangling-root-version-root"
+              },
+              "dependencies": {
+                "left-pad": "^1.0.0"
+              }
+            }"#,
+        );
+
+        // Root `version` is 3.0.0, absent from the `versions` map. The
+        // `latest`/empty path must reject it instead of returning 3.0.0.
+        let error = registry
+            .select_version("latest")
+            .expect_err("dangling root version should be rejected via the latest path");
+        assert!(matches!(error, SemverError::UnsatisfiedRange { .. }));
+
+        let error = registry
+            .select_version("")
+            .expect_err("dangling root version should be rejected via the empty path");
+        assert!(matches!(error, SemverError::UnsatisfiedRange { .. }));
+
+        // A present version key is unaffected.
+        assert_eq!(registry.select_version("1.0.0").unwrap(), "1.0.0");
     }
 }

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -285,9 +285,16 @@ impl Registry {
     }
 
     pub fn get_dist_for_version(&self, version: &str) -> Option<&Dist> {
-        self.version_metadata(version)
-            .map(|metadata| &metadata.dist)
-            .or(self.dist.as_ref())
+        // Root `dist` is a fallback for the legacy single-version shape, where
+        // the entire `versions` map is absent. When a `versions` map is present,
+        // a version key missing from the map must NOT silently fall through to
+        // root `dist` — that would record the root tarball under an unrelated
+        // version key (issue #114).
+        match self.version_metadata(version) {
+            Some(metadata) => Some(&metadata.dist),
+            None if self.versions.is_none() => self.dist.as_ref(),
+            None => None,
+        }
     }
 
     pub fn select_version(&self, requested: &str) -> Result<String, SemverError> {
@@ -301,7 +308,20 @@ impl Registry {
             .as_ref()
             .and_then(|dist_tags| dist_tags.get(requested))
         {
-            return Ok(version.to_owned());
+            // A dist-tag target is only authoritative when the target version
+            // exists in the `versions` map, or when there is no `versions` map
+            // (legacy single-version shape, where root `dist`/`dependencies`
+            // are the only record). When a `versions` map is present but the
+            // target is absent from it, reject the tag as unsatisfiable instead
+            // of silently returning a version key with no per-version metadata
+            // (issue #114).
+            return if self.versions.is_none() || self.version_metadata(version).is_some() {
+                Ok(version.to_owned())
+            } else {
+                Err(SemverError::UnsatisfiedRange {
+                    range: requested.to_string(),
+                })
+            };
         }
         let Some(versions) = self.versions.as_ref() else {
             return self
@@ -324,16 +344,21 @@ impl Registry {
     }
 
     pub fn get_dependencies_for_version(&self, version: &str) -> Vec<String> {
-        self.version_metadata(version)
-            .map(|metadata| metadata.get_dependencies())
-            .unwrap_or_else(|| {
-                self.dependencies
-                    .as_ref()
-                    .iter()
-                    .flat_map(|x| x.iter())
-                    .map(|(k, v)| format!("{}@{}", k, v))
-                    .collect()
-            })
+        // Root `dependencies` is a fallback for the legacy single-version shape,
+        // where the entire `versions` map is absent. When a `versions` map is
+        // present, a version key missing from the map must NOT silently fall
+        // through to root `dependencies` (issue #114).
+        match self.version_metadata(version) {
+            Some(metadata) => metadata.get_dependencies(),
+            None if self.versions.is_none() => self
+                .dependencies
+                .as_ref()
+                .iter()
+                .flat_map(|x| x.iter())
+                .map(|(k, v)| format!("{}@{}", k, v))
+                .collect(),
+            None => Vec::new(),
+        }
     }
 
     pub fn get_tarball_name(&self) -> Option<String> {
@@ -699,6 +724,7 @@ mod tests {
         open_cache_staging_file, save_tarball_to_dir, verify_cached_tarball,
         verify_tarball_integrity, Registry,
     };
+    use crate::core::resolver::semver::SemverError;
     use crate::util::test_support::fixture_path;
     use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
     use sha1::Sha1;
@@ -1500,5 +1526,143 @@ mod tests {
         assert_eq!(version.name.as_deref(), Some("well-typed"));
         assert_eq!(version.version.as_deref(), Some("1.0.0"));
         assert_eq!(version.description.as_deref(), Some("version desc"));
+    }
+
+    #[test]
+    fn dist_tag_target_absent_from_versions_map_is_rejected() {
+        // Regression for issue #114: a dist-tag pointing at a version absent
+        // from the `versions` map must NOT resolve to that version when a
+        // `versions` map is present. Returning it would let downstream lookups
+        // fall through to root `dist`/`dependencies`, recording the root tarball
+        // under an unrelated version key. The tag is rejected instead.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "dangling-tag",
+              "name": "dangling-tag",
+              "description": "dangling-tag fixture",
+              "maintainers": [],
+              "dist-tags": {
+                "latest": "1.0.0",
+                "beta": "3.0.0"
+              },
+              "versions": {
+                "1.0.0": {
+                  "name": "dangling-tag",
+                  "version": "1.0.0",
+                  "description": "stable",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/dangling-tag/-/dangling-tag-1.0.0.tgz",
+                    "shasum": "fixture-dangling-stable"
+                  }
+                }
+              },
+              "dist": {
+                "tarball": "https://registry.example.invalid/dangling-tag/-/dangling-tag-root.tgz",
+                "shasum": "fixture-dangling-root"
+              },
+              "dependencies": {
+                "left-pad": "^1.0.0"
+              }
+            }"#,
+        );
+
+        // The `beta` tag points at 3.0.0, which is absent from the `versions`
+        // map. Even though root `dist`/`dependencies` exist, the tag must be
+        // rejected so RPM never records the root tarball as version 3.0.0.
+        let error = registry
+            .select_version("beta")
+            .expect_err("dangling dist-tag target should be rejected");
+        assert!(matches!(error, SemverError::UnsatisfiedRange { .. }));
+
+        // `latest` (present in the map) is unaffected.
+        assert_eq!(registry.select_version("latest").unwrap(), "1.0.0");
+        assert_eq!(registry.select_version("1.0.0").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn version_absent_from_versions_map_does_not_fall_back_to_root_fields() {
+        // Regression for issue #114: when a `versions` map is present, a version
+        // key missing from the map must not fall through to root `dist` or root
+        // `dependencies`, even if those root fields exist. Root fallbacks are
+        // reserved for the legacy single-version shape (no `versions` map).
+        let registry = registry_from_json(
+            r#"{
+              "_id": "no-fallback",
+              "name": "no-fallback",
+              "description": "no-fallback fixture",
+              "maintainers": [],
+              "dist-tags": { "latest": "1.0.0" },
+              "versions": {
+                "1.0.0": {
+                  "name": "no-fallback",
+                  "version": "1.0.0",
+                  "description": "stable",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/no-fallback/-/no-fallback-1.0.0.tgz",
+                    "shasum": "fixture-no-fallback-stable"
+                  }
+                }
+              },
+              "dist": {
+                "tarball": "https://registry.example.invalid/no-fallback/-/no-fallback-root.tgz",
+                "shasum": "fixture-no-fallback-root"
+              },
+              "dependencies": {
+                "left-pad": "^1.0.0"
+              }
+            }"#,
+        );
+
+        // 9.9.9 is absent from the `versions` map. Root `dist` must NOT be used.
+        assert!(
+            registry.get_dist_for_version("9.9.9").is_none(),
+            "absent version must not fall back to root dist when versions map exists"
+        );
+        // Root `dependencies` must NOT be used for an absent version key.
+        assert!(
+            registry.get_dependencies_for_version("9.9.9").is_empty(),
+            "absent version must not fall back to root dependencies when versions map exists"
+        );
+
+        // A present version key is unaffected and returns its own record.
+        let dist = registry.get_dist_for_version("1.0.0").unwrap();
+        assert_eq!(dist.shasum.as_deref(), Some("fixture-no-fallback-stable"));
+        assert!(registry.get_dependencies_for_version("1.0.0").is_empty());
+    }
+
+    #[test]
+    fn legacy_single_version_shape_still_uses_root_fallbacks() {
+        // The gating change must not break the legacy single-version shape,
+        // where the entire `versions` map is absent and root fields are the
+        // only metadata record. Here dist-tag targets and downstream lookups
+        // legitimately use root `dist`/`dependencies`.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "legacy-single",
+              "name": "legacy-single",
+              "version": "2.0.0",
+              "description": "legacy fixture",
+              "maintainers": [],
+              "dist-tags": { "beta": "2.0.0" },
+              "dist": {
+                "tarball": "https://registry.example.invalid/legacy-single/-/legacy-single-2.0.0.tgz",
+                "shasum": "fixture-legacy-single"
+              },
+              "dependencies": {
+                "left-pad": "^1.0.0"
+              }
+            }"#,
+        );
+
+        // No `versions` map: dist-tag target resolves to root version.
+        assert_eq!(registry.select_version("beta").unwrap(), "2.0.0");
+        assert_eq!(registry.select_version("latest").unwrap(), "2.0.0");
+        assert_eq!(registry.select_version("").unwrap(), "2.0.0");
+
+        // Root `dist`/`dependencies` are the fallback when no versions map.
+        let dist = registry.get_dist_for_version("2.0.0").unwrap();
+        assert_eq!(dist.shasum.as_deref(), Some("fixture-legacy-single"));
+        let deps = registry.get_dependencies_for_version("2.0.0");
+        assert!(deps.contains(&"left-pad@^1.0.0".to_owned()));
     }
 }


### PR DESCRIPTION
## Contract

Resolves the registry SPEC **gating root metadata fallbacks** requirement and the **#114 open question**. A dist-tag whose target is absent from the `versions` map must not silently fall through to root `dist`/`dependencies`, because that records the root tarball (whose integrity belongs to the root version) under an unrelated version key — a metadata integrity violation.

`docs/specs/core/registry/SPEC.md` — Legacy root fallbacks, Registry Boundary step 2, Unsupported metadata behavior.

Classification: **bug fix + SPEC clarification**. Root `dist`/`dependencies` fallbacks are now reserved for the legacy single-version shape (no `versions` map). When a `versions` map is present, a version key missing from the map is no longer substituted with root fields.

## Changes

- `src/lib/registry/mod.rs`
  - `select_version`: when a `versions` map exists and a dist-tag target is absent from it, return `SemverError::UnsatisfiedRange` instead of returning the dangling target. When no `versions` map exists (legacy shape), the tag resolves normally via root fields.
  - `get_dist_for_version`: root `dist` fallback now applies only when `versions` is `None`; an absent key with a present map returns `None`.
  - `get_dependencies_for_version`: root `dependencies` fallback now applies only when `versions` is `None`; an absent key with a present map returns an empty `Vec`.
- `docs/specs/core/registry/SPEC.md`
  - "Legacy root fallbacks" rewritten: root fields are consulted only for the legacy single-version shape (no `versions` map).
  - "Registry Boundary" step 2 rewritten: dist-tag targets must exist in the `versions` map (or the map must be absent) to resolve.
  - "Unsupported metadata behavior": added the dangling dist-tag rejection case; updated the "no tarball" path description.
  - Removed the resolved #114 "Open Questions" entry; added #114 to `related_issues`.
- Tests: three new regression tests in `src/lib/registry/mod.rs`:
  - `dist_tag_target_absent_from_versions_map_is_rejected`
  - `version_absent_from_versions_map_does_not_fall_back_to_root_fields`
  - `legacy_single_version_shape_still_uses_root_fallbacks`

## Why reject instead of explicit fallback

Issue #114 offered two contracts: reject the dangling tag, or keep the root fallback but make it explicit and tested. Rejecting is the safer contract: a tag pointing at a version with no per-version `dist` record has no integrity basis for that version, and silently recording the root tarball under the tagged version breaks the link between a version key and its verified dist. The legacy single-version shape (no `versions` map) is the only case where root fields are the authoritative record, so the fallback is gated on the absence of the map.

Production callers (`FifoResolutionStrategy::resolve`, `InstallMetadata::select_version`) always pass versions that either exist in the `versions` map or are the root `version` field when the map is absent, so this tightening does not break any production code path.

## Validation

- `just format-check` — pass
- `just check` — pass
- `just lint` (clippy strict) — pass
- `just test` — 156 lib + 1 bin passed, 0 failed (3 new tests included)
- `just validate` — pass (includes `cargo doc -D warnings`)

## Checklist

- [x] Owning SPEC identified and updated
- [x] Regression coverage added (dangling tag, no-root-fallback, legacy shape)
- [x] No filesystem / install / lockfile mutation surface touched
- [x] Deterministic inputs only (no clock, no network, stable ordering)

Closes #114