### PR TITLE
docs(specs): M5 ownership/gap audit for npm metadata compatibility

### DIFF
--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -65,16 +65,17 @@ RPM does not treat unsupported metadata as successful compatibility.
 
 | M5 compatibility area | Owning SPEC / ADR | Contract status | Follow-up |
 | --- | --- | --- | --- |
-| registry metadata fields consumed by RPM | `registry/SPEC.md` | consumed / ignored / rejected classification is explicit (root `name`, `dist-tags`, `versions`; per-version `dependencies`, `dist`; `dist.tarball`, `dist.integrity`, `dist.shasum`) | delivered: #110 landed via #112 |
-| ignored-field tolerant deserialization | `registry/SPEC.md` | ignored fields deserialize leniently; root `description`, root `maintainers`, and per-version `name` / `version` / `description` tolerate absence and wrong-type values; `bundledDependencies` accepts map or array | delivered: #113 landed via #116 |
+| registry metadata fields consumed by RPM | `registry/SPEC.md` | consumed / ignored / rejected classification is explicit (root `name`, `dist-tags`, `versions`; per-version `dependencies`, `dist`; `dist.tarball`, `dist.integrity`, `dist.shasum`); legacy single-version shape also consumes root `version`, `dist`, and `dependencies` as documented in the SPEC's "Legacy root fallbacks" section | delivered: #110 landed via #112 |
+| ignored-field tolerant deserialization | `registry/SPEC.md` | every ignored metadata field deserializes leniently: a missing, null, or wrong-type value is discarded as absent rather than failing the packument, and `bundledDependencies` accepts map or array (applies uniformly to all ignored fields, not only the originally-tolerated set) | delivered: #113 landed via #116; uniform coverage landed via #122 |
 | dist-tag and root metadata fallback gating | `registry/SPEC.md` | a dist-tag target absent from `versions` is rejected; root `dist` / `dependencies` fallback only applies to the legacy single-version shape | delivered: #114 landed via #118 |
 | dist-tags / `latest` / semver range selection boundary | `registry/SPEC.md`, `semver/SPEC.md` | dist-tags are registry selectors, not semver ranges; `latest` and tag precedence over ranges is defined | none |
-| build-metadata deterministic selection | `registry/SPEC.md` (Registry Boundary, precedence step 3) | registry-owned raw-key sort before `max_satisfying` makes selection repeatable across `HashMap` seedings | #115 / #117 (awaiting-merge) |
+| build-metadata deterministic selection | `registry/SPEC.md` (Registry Boundary, precedence step 3) | registry-owned raw-key sort before `max_satisfying` makes selection repeatable across `HashMap` seedings | delivered: #115 / #117 landed |
 | optionalDependencies | `registry/SPEC.md` (ignored list) | classified as ignored (not enqueued); no active read / resolve / install / skip / report contract exists yet | draft: compat optionalDependencies contract |
 | peerDependencies | `resolver/SPEC.md`, `registry/SPEC.md` (ignored list) | non-peer-aware strategy must not enqueue peer deps as ordinary dependencies; no peer-requirement field is implemented (spec-only) | draft: compat peerDependencies preservation and diagnostics |
 | engines, os, cpu | `registry/SPEC.md` (ignored list) | classified as ignored; no engine, OS, or CPU filtering, warning, or rejection policy exists | draft: compat engines/os/cpu metadata policy |
 | package bin metadata | `linker/SPEC.md` (out of scope) | `.bin` generation is explicitly out of scope; `bin` is not modeled on registry types | M6 linker contract owns this |
-| npm aliases and scoped package edge cases | (no owning SPEC) | npm alias syntax (`npm:<name>@<version>`) and scoped package edge cases are unrepresented in SPECs and source | draft: compat alias and scoped package contract |
+| scoped package names | `registry/SPEC.md`, `linker/SPEC.md`, `lockfile/SPEC.md` | scoped names are owned throughout: registry consumes the scoped `name`, linker preserves the scope directory in the link path, and lockfile records `name` including scope | none |
+| npm aliases | (no owning SPEC) | npm alias syntax (`npm:<name>@<version>`) is unrepresented in SPECs and source | draft: compat alias contract |
 
 Findings:
 

--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -54,3 +54,41 @@ Findings:
   completed: #93 (measurement harness, landed via #106), #94 (graph dedup
   proof), #103 (download dedup proof), #96 (phase side-effect audit, landed
   via #107), and #97 (fixture output convention, landed via #108).
+
+## M5 Ownership and Gap Audit
+
+The M5 audit maps each npm metadata compatibility area to its owning SPEC/ADR
+and records whether the contract is explicitly stated. M5 is an npm metadata
+compatibility milestone: it must classify every registry metadata category as
+consumed, ignored, or rejected before any category gains active behavior, so
+RPM does not treat unsupported metadata as successful compatibility.
+
+| M5 compatibility area | Owning SPEC / ADR | Contract status | Follow-up |
+| --- | --- | --- | --- |
+| registry metadata fields consumed by RPM | `registry/SPEC.md` | consumed / ignored / rejected classification is explicit (root `name`, `dist-tags`, `versions`; per-version `dependencies`, `dist`; `dist.tarball`, `dist.integrity`, `dist.shasum`) | delivered: #110 landed via #112 |
+| ignored-field tolerant deserialization | `registry/SPEC.md` | ignored fields deserialize leniently; root `description`, root `maintainers`, and per-version `name` / `version` / `description` tolerate absence and wrong-type values; `bundledDependencies` accepts map or array | delivered: #113 landed via #116 |
+| dist-tag and root metadata fallback gating | `registry/SPEC.md` | a dist-tag target absent from `versions` is rejected; root `dist` / `dependencies` fallback only applies to the legacy single-version shape | delivered: #114 landed via #118 |
+| dist-tags / `latest` / semver range selection boundary | `registry/SPEC.md`, `semver/SPEC.md` | dist-tags are registry selectors, not semver ranges; `latest` and tag precedence over ranges is defined | none |
+| build-metadata deterministic selection | `registry/SPEC.md` (Registry Boundary, precedence step 3) | registry-owned raw-key sort before `max_satisfying` makes selection repeatable across `HashMap` seedings | #115 / #117 (awaiting-merge) |
+| optionalDependencies | `registry/SPEC.md` (ignored list) | classified as ignored (not enqueued); no active read / resolve / install / skip / report contract exists yet | draft: compat optionalDependencies contract |
+| peerDependencies | `resolver/SPEC.md`, `registry/SPEC.md` (ignored list) | non-peer-aware strategy must not enqueue peer deps as ordinary dependencies; no peer-requirement field is implemented (spec-only) | draft: compat peerDependencies preservation and diagnostics |
+| engines, os, cpu | `registry/SPEC.md` (ignored list) | classified as ignored; no engine, OS, or CPU filtering, warning, or rejection policy exists | draft: compat engines/os/cpu metadata policy |
+| package bin metadata | `linker/SPEC.md` (out of scope) | `.bin` generation is explicitly out of scope; `bin` is not modeled on registry types | M6 linker contract owns this |
+| npm aliases and scoped package edge cases | (no owning SPEC) | npm alias syntax (`npm:<name>@<version>`) and scoped package edge cases are unrepresented in SPECs and source | draft: compat alias and scoped package contract |
+
+Findings:
+
+- Ownership exists for the registry metadata boundary. The consumed / ignored /
+  rejected classification landed in #112, and the deserialization behavior that
+  the classification implies was made tolerant in #116 and gated against stale
+  root fallbacks in #118.
+- The dist-tag and semver range selection boundary is fully owned across
+  `registry/SPEC.md` and `semver/SPEC.md`; the build-metadata deterministic
+  tie-break closes the last selection-repeatability gap (#115 / #117).
+- The remaining M5 frontier is per-field classification: optional dependencies,
+  peer dependencies, engines/os/cpu, package bin metadata, and npm aliases each
+  need an active-behavior contract (or an explicit deferred decision) before
+  implementation. Each is represented by a compat draft task in Project #7.
+- Package `bin` metadata is intentionally deferred to the M6 linker milestone,
+  where `.bin` generation is owned; it is listed here so the boundary is
+  explicit, not so M5 implements it.

--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -17,6 +17,7 @@ related_issues:
   - 110
   - 113
   - 114
+  - 120
 ---
 
 # Spec: Registry Metadata


### PR DESCRIPTION
## Contract

Resolves the **M5 npm metadata compatibility** milestone front-loaded audit.
Mirrors the M4 pattern (#105 SPEC audit + #92 milestone contract). M5 must
classify every registry metadata category as consumed, ignored, or rejected
before any category gains active behavior, so RPM does not treat unsupported
npm metadata as successful compatibility.

Classification: **planning / SPEC audit**. No behavior change, no code change,
no SPEC contract text rewritten. This PR adds the audit and the milestone
contract; per-field contracts (optionalDeps, peerDeps, engines/os/cpu, bin,
aliases) are deliberately left to their own compat tickets.

Owning SPEC: `docs/specs/core/registry/SPEC.md` (M5 foundation) and
`docs/specs/core/README.md` (audit home, matching the M4 section).

## Changes

- `docs/specs/core/README.md`
  - New "M5 Ownership and Gap Audit" section with a table mapping each npm
    metadata compatibility area to its owning SPEC/ADR, contract status, and
    follow-up.
  - Findings paragraph summarizing delivered groundwork (#110/#112, #113/#116,
    #114/#118, #115/#117) and the remaining frontier (per-field contracts).
- `docs/specs/core/registry/SPEC.md`
  - Frontmatter `related_issues` now lists `120` (m5.0 milestone contract).
  - No body change. (The build-metadata Open Question entry was removed by #117,
    which now lands in this branch via rebase; the registry SPEC body shown here
    is the post-#117 / post-#122 tree.)

## Review feedback (Codex, commit d58f452)

The Codex review left four P2 findings on the M5 audit table, all written
against a base that predated #117 and #122. This branch was rebased onto main
to include both, and the table cells were reconciled with the current tree:

- Consumed fields row: added the legacy single-version root `version`, `dist`,
  and `dependencies` fields read by `select_version` / `get_dist_for_version` /
  `get_dependencies_for_version` when the `versions` map is absent (SPEC
  "Legacy root fallbacks").
- Tolerant deserialization row: #122 applied `ignored_field` uniformly to every
  ignored field, so the row now states the uniform guarantee instead of the
  narrow five-field enumeration; follow-up credits #122.
- Build-metadata row: #117 landed via rebase, so the follow-up is marked
  delivered; the row body already described the landed contract.
- Scoped vs alias row: split into scoped package names (owned across
  registry/linker/lockfile SPECs) and npm aliases (genuinely unowned), removing
  a false unowned gap for scoped packages.

## What this PR does NOT do

- Does not define per-field contracts for optionalDependencies, peerDependencies,
  engines/os/cpu, bin, or npm aliases — each is a separate Project #7 compat
  draft task.
- Does not change any source code or SPEC contract text.

## Validation

- `just format-check` — pass
- `just check` — pass
- `just lint` (clippy strict) — pass
- `just test` — 164 lib + 1 bin passed, 0 failed

(docs-only change; the Cargo gates are run for baseline confirmation.)

## Checklist

- [x] Owning SPEC identified and updated (frontmatter; audit in README.md)
- [x] Mirrors the M4 audit pattern (#105 / #92)
- [x] No filesystem / install / lockfile mutation surface touched
- [x] Deterministic inputs only (no code, no clock, no network)
- [x] Codex review feedback reconciled with the post-#117 / post-#122 tree

Closes #120
