### PR TITLE
fix(registry): tolerate wrong-type values on all ignored metadata fields

### DIFF
--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -143,21 +143,19 @@ verification:
 
 Ignored means RPM may accept documents that carry these fields, but no active
 behavior depends on them. An ignored field that is invalid or missing must not
-fail resolution or install: ignored fields are deserialized leniently so a
-packument that omits or malforms them still parses. Specifically, root
-`description`, root `maintainers`, and the per-version `name`, `version`, and
-`description` fields tolerate both absence and any wrong-type value: a
-present-but-shape-mismatched value is discarded as absent during deserialization
-rather than failing the packument. `bundledDependencies` is modeled as an
-untagged enum that accepts either a map (package name to range) or an array
-(package names), matching npm, so it tolerates absence and either documented
-shape.
-
-A value that matches none of the documented shapes for a field with a fixed
-alternative set (`bundledDependencies`, `engines`) may still fail parsing,
-because those fields are not modeled as a free-form `serde_json::Value`. Such a
-failure reflects an unrecognized document shape rather than a consumed-field
-contract violation.
+fail resolution or install: every ignored field is deserialized leniently so a
+packument that omits or malforms any of them still parses. A
+present-but-wrong-type value is discarded as absent during deserialization
+rather than failing the packument, regardless of the field's expected shape.
+This applies uniformly to all ignored fields: string fields such as `main`,
+`license`, `readme`, and `readmeFilename`; map fields such as `scripts`,
+`devDependencies`, `peerDependencies`, and `optionalDependencies`; array fields
+such as `os`, `cpu`, and `keywords`; scalar fields such as `private` and
+`sequence`; and the untagged-enum fields `repository`, `author`,
+`bundledDependencies`, `engines`, `time`, `_rev`, and `homepage`. A wrong-type
+value for any of these (for example a SPDX object-form `license`, a numeric
+`engines`, or a string `scripts`) is dropped to its absence without aborting
+packument parsing. Well-typed values still round-trip into `Some(...)`.
 
 ### Unsupported metadata behavior
 
@@ -276,6 +274,9 @@ Fixture expectations are defined by the owning scenario and documented in
 - dist-tag resolution before semver range evaluation
 - missing dist rejected before fetch
 - integrity verification of supported, mismatched, invalid, and absent variants
+- wrong-type values on every ignored metadata field are discarded as absent
+  rather than failing the packument (issue #113), while well-typed values
+  round-trip into `Some(...)`
 
 New fixtures should cover dist metadata, dist-tags, dependencies, optional
 dependencies, peer dependencies, engines, OS/CPU, aliases, scoped packages, and

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -113,22 +113,52 @@ pub struct Version {
     pub version: Option<String>,
     #[serde(default, deserialize_with = "ignored_field")]
     pub description: Option<String>,
+    // The remaining ignored metadata fields use the same lenient deserializer
+    // so a present-but-wrong-type value (for example `license: { type, url }`
+    // or `engines: 42`) is discarded as absent rather than failing the whole
+    // packument. This honors the SPEC tolerance guarantee for ignored fields
+    // (issue #113) uniformly across every ignored field, not only the string
+    // fields above.
+    #[serde(default, deserialize_with = "ignored_field")]
     pub main: Option<String>,
+    #[serde(default, deserialize_with = "ignored_field")]
     pub types: Option<String>,
+    #[serde(default, deserialize_with = "ignored_field")]
     pub scripts: Option<HashMap<String, String>>,
+    #[serde(default, deserialize_with = "ignored_field")]
     pub repository: Option<Repository>,
     pub dependencies: Option<HashMap<String, String>>,
-    #[serde(rename = "devDependencies")]
+    #[serde(
+        rename = "devDependencies",
+        default,
+        deserialize_with = "ignored_field"
+    )]
     dev_dependencies: Option<HashMap<String, String>>,
-    #[serde(rename = "peerDependencies")]
+    #[serde(
+        rename = "peerDependencies",
+        default,
+        deserialize_with = "ignored_field"
+    )]
     peer_dependencies: Option<HashMap<String, String>>,
-    #[serde(rename = "optionalDependencies")]
+    #[serde(
+        rename = "optionalDependencies",
+        default,
+        deserialize_with = "ignored_field"
+    )]
     optional_dependencies: Option<HashMap<String, String>>,
-    #[serde(rename = "bundledDependencies")]
+    #[serde(
+        rename = "bundledDependencies",
+        default,
+        deserialize_with = "ignored_field"
+    )]
     bundled_dependencies: Option<BundledDependencies>,
+    #[serde(default, deserialize_with = "ignored_field")]
     engines: Option<Engines>,
+    #[serde(default, deserialize_with = "ignored_field")]
     os: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "ignored_field")]
     cpu: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "ignored_field")]
     private: Option<bool>,
     pub dist: Dist,
     // publishConfig: HashMap<String, String>,
@@ -239,12 +269,13 @@ pub enum AuthorType {
 pub struct Registry {
     #[serde(rename = "_id")]
     pub id: String,
-    #[serde(rename = "_rev")]
+    #[serde(rename = "_rev", default, deserialize_with = "ignored_field")]
     pub rev: Option<String>,
     pub name: String,
     #[serde(rename = "dist-tags")]
     dist_tags: Option<DistTags>,
     pub versions: Option<HashMap<String, Version>>,
+    #[serde(default, deserialize_with = "ignored_field")]
     pub time: Option<Time>,
     // Ignored metadata fields: deserialized for document fidelity when present
     // but never consumed by an active code path. `ignored_field` keeps a
@@ -254,25 +285,48 @@ pub struct Registry {
     pub maintainers: Option<Vec<Maintainer>>,
     #[serde(default, deserialize_with = "ignored_field")]
     pub description: Option<String>,
+    #[serde(default, deserialize_with = "ignored_field")]
     pub homepage: Option<Url>,
+    #[serde(default, deserialize_with = "ignored_field")]
     pub keywords: Option<Vec<String>>,
+    #[serde(default, deserialize_with = "ignored_field")]
     pub repository: Option<Repository>,
+    #[serde(default, deserialize_with = "ignored_field")]
     pub author: Option<AuthorType>,
     // pub bugs: Option<Bugs>,
+    #[serde(default, deserialize_with = "ignored_field")]
     pub license: Option<String>,
+    #[serde(default, deserialize_with = "ignored_field")]
     pub readme: Option<String>,
-    #[serde(rename = "readmeFilename")]
+    #[serde(rename = "readmeFilename", default, deserialize_with = "ignored_field")]
     pub readme_file_name: Option<String>,
     pub dist: Option<Dist>,
+    #[serde(default, deserialize_with = "ignored_field")]
     sequence: Option<i32>,
     pub dependencies: Option<HashMap<String, String>>,
-    #[serde(rename = "devDependencies")]
+    #[serde(
+        rename = "devDependencies",
+        default,
+        deserialize_with = "ignored_field"
+    )]
     dev_dependencies: Option<HashMap<String, String>>,
-    #[serde(rename = "peerDependencies")]
+    #[serde(
+        rename = "peerDependencies",
+        default,
+        deserialize_with = "ignored_field"
+    )]
     peer_dependencies: Option<HashMap<String, String>>,
-    #[serde(rename = "optionalDependencies")]
+    #[serde(
+        rename = "optionalDependencies",
+        default,
+        deserialize_with = "ignored_field"
+    )]
     optional_dependencies: Option<HashMap<String, String>>,
-    #[serde(rename = "bundledDependencies")]
+    #[serde(
+        rename = "bundledDependencies",
+        default,
+        deserialize_with = "ignored_field"
+    )]
     bundled_dependencies: Option<BundledDependencies>,
     version: Option<String>,
 }
@@ -1432,12 +1486,10 @@ mod tests {
     #[test]
     fn parses_engines_with_unexpected_shape_without_failing_selection() {
         // `engines` is ignored. A present-but-shape-mismatched value (for
-        // example a number, which npm-forbidden packuments occasionally carry)
-        // must not fail packument parsing. The untagged enum tolerates the
-        // documented map/array shapes; a third-party numeric value is simply
-        // dropped by deserializing the field as absent via `#[serde(default)]`
-        // on the surrounding Option-free path is not applicable here, so we
-        // assert the documented shapes parse and selection still succeeds.
+        // example a number, which malformed packuments occasionally carry) must
+        // not fail packument parsing: it is discarded as absent by the lenient
+        // `ignored_field` deserializer. The documented map/array shapes still
+        // deserialize to Some(...).
         let registry = registry_from_json(
             r#"{
               "_id": "engines-shapes",
@@ -1463,6 +1515,170 @@ mod tests {
         );
 
         assert_eq!(registry.select_version("latest").unwrap(), "1.0.0");
+    }
+
+    #[test]
+    fn tolerates_wrong_type_on_all_ignored_metadata_fields() {
+        // SPEC: every ignored metadata field tolerates not only absence but
+        // also shape mismatch, so a present-but-wrong-type value is discarded
+        // as absent rather than failing the whole packument (issue #113). This
+        // regression covers the fields that previously used a plain `Option<T>`
+        // and would abort packument parsing on a wrong-type value. The shapes
+        // here mirror real-world npm variation: SPDX object-form `license`,
+        // numeric `engines`, string `scripts`, numeric `repository`, object
+        // `os`/`cpu`, string `private`, object `keywords`, number `homepage`,
+        // number `readme`/`readmeFilename`, object `_rev`, array `author`,
+        // number `time`, string `sequence`, and wrong-type dependency maps.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "wrong-type-ignored",
+              "_rev": 42,
+              "name": "wrong-type-ignored",
+              "description": "wrong-type ignored fields",
+              "maintainers": [{ "name": "ada" }],
+              "time": 1700000000,
+              "homepage": 7,
+              "keywords": "not-a-list",
+              "repository": 404,
+              "author": ["not", "an", "object", "or", "string"],
+              "license": { "type": "MIT", "url": "https://example.invalid/mit" },
+              "readme": false,
+              "readmeFilename": {},
+              "sequence": "not-a-number",
+              "devDependencies": "not-a-map",
+              "peerDependencies": 3,
+              "optionalDependencies": false,
+              "bundledDependencies": 99,
+              "dist-tags": {
+                "latest": "1.0.0"
+              },
+              "versions": {
+                "1.0.0": {
+                  "name": "wrong-type-ignored",
+                  "version": "1.0.0",
+                  "description": "version desc",
+                  "main": {},
+                  "types": 5,
+                  "scripts": "not-a-map",
+                  "repository": 1,
+                  "devDependencies": "no",
+                  "peerDependencies": 2,
+                  "optionalDependencies": true,
+                  "bundledDependencies": 12,
+                  "engines": 404,
+                  "os": "linux",
+                  "cpu": "x64",
+                  "private": "yes",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/wrong-type-ignored/-/wrong-type-ignored-1.0.0.tgz",
+                    "shasum": "fixture-wrong-type-ignored"
+                  }
+                }
+              }
+            }"#,
+        );
+
+        // Wrong-type ignored values are discarded to None on the root.
+        assert_eq!(registry.rev, None);
+        assert!(registry.time.is_none());
+        assert!(registry.homepage.is_none());
+        assert!(registry.keywords.is_none());
+        assert!(registry.repository.is_none());
+        assert!(registry.author.is_none());
+        assert_eq!(registry.license, None);
+        assert_eq!(registry.readme, None);
+        assert_eq!(registry.readme_file_name, None);
+        assert_eq!(registry.sequence, None);
+        assert!(registry.dev_dependencies.is_none());
+        assert!(registry.peer_dependencies.is_none());
+        assert!(registry.optional_dependencies.is_none());
+        assert!(registry.bundled_dependencies.is_none());
+
+        // Well-typed ignored values on the root still round-trip.
+        assert_eq!(
+            registry.description.as_deref(),
+            Some("wrong-type ignored fields")
+        );
+        assert_eq!(registry.maintainers.as_ref().map(|m| m.len()), Some(1usize));
+
+        let version = registry.version_metadata("1.0.0").unwrap();
+        assert_eq!(version.main, None);
+        assert_eq!(version.types, None);
+        assert!(version.scripts.is_none());
+        assert!(version.repository.is_none());
+        assert!(version.dev_dependencies.is_none());
+        assert!(version.peer_dependencies.is_none());
+        assert!(version.optional_dependencies.is_none());
+        assert!(version.bundled_dependencies.is_none());
+        assert!(version.engines.is_none());
+        assert!(version.os.is_none());
+        assert!(version.cpu.is_none());
+        assert_eq!(version.private, None);
+
+        // Selection and dist lookup still work end-to-end.
+        assert_eq!(registry.select_version("latest").unwrap(), "1.0.0");
+        assert_eq!(
+            registry
+                .get_dist_for_version("1.0.0")
+                .unwrap()
+                .shasum
+                .as_deref(),
+            Some("fixture-wrong-type-ignored")
+        );
+    }
+
+    #[test]
+    fn preserves_well_typed_ignored_non_string_fields() {
+        // The lenient deserializer only discards wrong-type values; a correct
+        // value still round-trips into Some(...). Guards against the lenient
+        // path silently dropping every value for the newly-protected fields.
+        let registry = registry_from_json(
+            r#"{
+              "_id": "well-typed-non-string",
+              "_rev": "1-abc",
+              "name": "well-typed-non-string",
+              "description": "root desc",
+              "maintainers": [],
+              "keywords": ["a", "b"],
+              "repository": { "type": "git", "url": "https://example.invalid/r.git" },
+              "author": "Ada <ada@example.invalid>",
+              "license": "MIT",
+              "sequence": 9,
+              "dist-tags": { "latest": "1.0.0" },
+              "versions": {
+                "1.0.0": {
+                  "name": "well-typed-non-string",
+                  "version": "1.0.0",
+                  "description": "version desc",
+                  "main": "lib/index.js",
+                  "scripts": { "test": "echo ok" },
+                  "repository": "https://example.invalid/r.git",
+                  "engines": { "node": ">=18" },
+                  "os": ["linux"],
+                  "cpu": ["x64"],
+                  "private": true,
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/well-typed-non-string/-/well-typed-non-string-1.0.0.tgz",
+                    "shasum": "fixture-well-typed-non-string"
+                  }
+                }
+              }
+            }"#,
+        );
+
+        assert_eq!(registry.rev.as_deref(), Some("1-abc"));
+        assert_eq!(registry.keywords.as_ref().map(|k| k.len()), Some(2usize));
+        assert_eq!(registry.license.as_deref(), Some("MIT"));
+        assert_eq!(registry.sequence, Some(9));
+        let version = registry.version_metadata("1.0.0").unwrap();
+        assert_eq!(version.main.as_deref(), Some("lib/index.js"));
+        assert_eq!(version.scripts.as_ref().map(|s| s.len()), Some(1usize));
+        assert_eq!(version.os.as_ref().map(|o| o.len()), Some(1usize));
+        assert_eq!(version.cpu.as_ref().map(|c| c.len()), Some(1usize));
+        assert_eq!(version.private, Some(true));
+        // Repository round-trips through its untagged enum; assert presence via
+        // is_some rather than PartialEq (the enum does not derive it).
+        assert!(version.repository.is_some());
     }
 
     #[test]

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -267,8 +267,13 @@ pub enum AuthorType {
 /// When Request to registry, return this struct json data
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Registry {
-    #[serde(rename = "_id")]
-    pub id: String,
+    // `_id` is an ignored field per SPEC (docs/specs/core/registry/SPEC.md): it
+    // is deserialized for document fidelity but never consumed by an active
+    // code path. The lenient deserializer keeps a missing, null, or wrong-type
+    // value from failing packument parsing, in line with the SPEC tolerance
+    // guarantee that applies uniformly to every ignored field (issue #113).
+    #[serde(rename = "_id", default, deserialize_with = "ignored_field")]
+    pub id: Option<String>,
     #[serde(rename = "_rev", default, deserialize_with = "ignored_field")]
     pub rev: Option<String>,
     pub name: String,
@@ -1679,6 +1684,75 @@ mod tests {
         // Repository round-trips through its untagged enum; assert presence via
         // is_some rather than PartialEq (the enum does not derive it).
         assert!(version.repository.is_some());
+    }
+
+    #[test]
+    fn tolerates_missing_and_wrong_type_on_ignored_id_field() {
+        // SPEC lists `_id` as an ignored field (docs/specs/core/registry/SPEC.md
+        // "Ignored metadata fields"). Per the SPEC's uniform tolerance guarantee,
+        // a packument that omits `_id` or carries a wrong-type `_id` must still
+        // parse rather than failing before version selection. Regression for the
+        // gap surfaced in PR #122 review: `Registry.id` was a required `String`,
+        // so a missing or wrong-type `_id` aborted deserialization even though
+        // no active code path reads `id`. The lenient `ignored_field` deserializer
+        // drops these to `None` while a well-typed value still round-trips.
+        let missing = registry_from_json(
+            r#"{
+              "name": "no-id",
+              "dist-tags": { "latest": "1.0.0" },
+              "versions": {
+                "1.0.0": {
+                  "name": "no-id",
+                  "version": "1.0.0",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/no-id/-/no-id-1.0.0.tgz",
+                    "shasum": "fixture-no-id"
+                  }
+                }
+              }
+            }"#,
+        );
+        assert_eq!(missing.id, None);
+        assert_eq!(missing.select_version("latest").unwrap(), "1.0.0");
+
+        let wrong_type = registry_from_json(
+            r#"{
+              "_id": 42,
+              "name": "num-id",
+              "dist-tags": { "latest": "1.0.0" },
+              "versions": {
+                "1.0.0": {
+                  "name": "num-id",
+                  "version": "1.0.0",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/num-id/-/num-id-1.0.0.tgz",
+                    "shasum": "fixture-num-id"
+                  }
+                }
+              }
+            }"#,
+        );
+        assert_eq!(wrong_type.id, None);
+        assert_eq!(wrong_type.select_version("latest").unwrap(), "1.0.0");
+
+        let well_typed = registry_from_json(
+            r#"{
+              "_id": "well-typed-id",
+              "name": "well-typed-id",
+              "dist-tags": { "latest": "1.0.0" },
+              "versions": {
+                "1.0.0": {
+                  "name": "well-typed-id",
+                  "version": "1.0.0",
+                  "dist": {
+                    "tarball": "https://registry.example.invalid/well-typed-id/-/well-typed-id-1.0.0.tgz",
+                    "shasum": "fixture-well-typed-id"
+                  }
+                }
+              }
+            }"#,
+        );
+        assert_eq!(well_typed.id.as_deref(), Some("well-typed-id"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #123.

## Summary

The registry metadata SPEC (issue #113) requires every ignored metadata field to tolerate both absence **and** shape mismatch: a present-but-wrong-type value must be discarded as absent rather than failing the whole packument. The code only honored this for **five** string/list fields via the lenient `ignored_field` deserializer. The other ~19 ignored fields used plain `Option<T>` or untagged enums, so a real-world npm packument carrying, for example, an SPDX object-form `license`, a numeric `engines`, or a string `scripts` would fail packument parsing entirely — violating the SPEC guarantee and making RPM unable to consume otherwise-valid packages.

## Contract reference

`docs/specs/core/registry/SPEC.md` "Ignored metadata fields" (issue #113):

> An ignored field that is invalid or missing must not fail resolution or install: every ignored field is deserialized leniently so a packument that omits or malforms any of them still parses. A present-but-wrong-type value is discarded as absent during deserialization rather than failing the packument.

## Change

- Apply `#[serde(default, deserialize_with = "ignored_field")]` uniformly to every ignored field on `Version` and `Registry`, so all of them drop a wrong-type value to absence without aborting deserialization.
- Consumed fields (`dependencies`, `dist`, `versions`, `dist_tags`, root fallback `version`, `name`) keep their strict shapes — no consumed-field behavior change.
- The `ignored_field` deserializer already reads the value as an opaque `serde_json::Value` first, so it is compatible with the untagged-enum fields (`repository`, `author`, `bundledDependencies`, `engines`, `time`).
- `_id` is treated as ignored (it is listed in the SPEC ignored set and no active code path reads `Registry.id`): `Registry.id` is now `Option<String>` with the lenient deserializer, so a missing, null, or non-string `_id` no longer aborts deserialization before version selection. This closes the gap flagged in P2 review.

## Regression coverage

| Test | Purpose |
| --- | --- |
| `tolerates_wrong_type_on_all_ignored_metadata_fields` | Exercises wrong-type values across **every** newly-protected field (root + per-version), including SPDX object-form `license`, numeric `engines`, string `scripts`, numeric `repository`, string `os`/`cpu`, string `private`, object `keywords`, number `homepage`/`readme`/`readmeFilename`, object `_rev`, array `author`, number `time`, string `sequence`, and wrong-type dependency maps. Asserts each is dropped to `None` and selection/dist lookup still work end-to-end. Verified to **fail** when any single field's tolerance is reverted. |
| `preserves_well_typed_ignored_non_string_fields` | Guards against the lenient path silently dropping well-typed non-string values (round-trips valid `main`, `scripts`, `engines`, `os`, `cpu`, `private`, `keywords`, `license`, `sequence`, `repository`). |
| `tolerates_missing_and_wrong_type_on_ignored_id_field` | Covers `_id` specifically: absent, numeric (`42`), and well-typed values, asserting absent/wrong-type drop to `None` while selection still succeeds and a well-typed value round-trips. |
| `parses_engines_with_unexpected_shape_without_failing_selection` | Comment sharpened — it previously hedged around the untested wrong-type case. |

## SPEC update

`docs/specs/core/registry/SPEC.md` "Ignored metadata fields" now states the tolerance guarantee reads uniformly across all ignored fields, and the now-obsolete "fixed alternative set" carve-out for `bundledDependencies` and `engines` is removed (those fields are now lenient too). The "Test Fixtures" contract list records the new wrong-type tolerance regression.

## Validation

| Gate | Result |
| --- | --- |
| `just format-check` | ✅ pass |
| `just check` (workspace, all targets) | ✅ pass |
| `just lint` (clippy strict) | ✅ pass |
| registry lib tests (`cargo test -p rpm --lib registry`) | ✅ 42 pass, including the new `_id` regression |
| `just test` | ✅ pass (pre-push hook) |

## Review resolution

- **P2 (Codex, PR #122):** "`_id` should follow the ignored-field guarantee — `Registry.id` was a required `String`, so a missing/wrong-type `_id` rejected the packument before version selection." → **Accepted.** `_id` is in the SPEC ignored set and `Registry.id` has no active reader, so it is now `Option<String>` with `ignored_field`, mirroring `_rev`. Regression test added. Commit `4a679c3`.

## Out of scope

- No consumed-field deserialization change (`dependencies`, `dist`, etc.).
- No lockfile, resolver, cache, or install behavior change.
- No new npm compatibility feature — only implements the tolerance the SPEC already required.

## Related

- Tracking issue: #123
- SPEC: `docs/specs/core/registry/SPEC.md` (Ignored metadata fields, issue #113)
- Code: `src/lib/registry/mod.rs` (`Version`, `Registry`, `ignored_field`)
