### PR TITLE
docs(manifest): define optionalDependencies read/preserve contract

### DIFF
--- a/docs/specs/core/manifest/SPEC.md
+++ b/docs/specs/core/manifest/SPEC.md
@@ -3,7 +3,7 @@ spec_id: package_manifest
 title: Package Manifest
 status: draft
 owner: core/manifest
-last_reviewed: 2026-05-29
+last_reviewed: 2026-08-10
 authors:
   - nerdchanii
 deciders:
@@ -20,7 +20,7 @@ related_issues:
 
 Status: Draft
 Owner: core/manifest
-Last reviewed: 2026-05-29
+Last reviewed: 2026-08-10
 
 ## Purpose
 
@@ -42,6 +42,25 @@ errors must be returned to callers with the manifest path.
 
 The full npm `package.json` schema is intentionally out of scope for this
 contract today.
+
+### Optional dependencies
+
+RPM reads and preserves the root `optionalDependencies` map (`package name` to
+`range`) when it is present. Preserved entries are not consumed by install, add,
+or resolution today: they are not enqueued as dependency requests, they do not
+influence version selection, and they do not appear in the resolved graph,
+lockfile, or linked `node_modules`. A manifest that omits
+`optionalDependencies` behaves identically to one without it.
+
+This read-and-preserve baseline makes RPM honest about a field it accepts today.
+The full optional-aware behavior (resolve the entry as an ordinary dependency,
+attempt install, skip on failure, and report the outcome) is intentionally
+deferred until an optional-aware strategy SPEC owns it. Until then, a
+non-optional-aware strategy must not silently enqueue optional dependencies as
+ordinary dependencies; that non-enqueue guard is owned by
+`docs/specs/core/resolver/SPEC.md`. Per-version
+`optionalDependencies` on registry packuments remain ignored at the registry
+boundary (`docs/specs/core/registry/SPEC.md`).
 
 ## Error Cases
 

--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -129,10 +129,15 @@ verification:
 
 - `devDependencies`, `peerDependencies`, `optionalDependencies`, and
   `bundledDependencies` on both the root document and per-version records. RPM
-  does not enqueue these as dependency requests in the current non-peer-aware
-  strategy. Peer dependencies are represented as peer requirement metadata on
-  resolved package records per `docs/specs/core/resolver/SPEC.md`; they must not
-  be silently enqueued as ordinary dependencies.
+  does not enqueue these as dependency requests in the current non-peer-aware,
+  non-optional-aware strategy. Peer dependencies are represented as peer
+  requirement metadata on resolved package records per
+  `docs/specs/core/resolver/SPEC.md`; they must not be silently enqueued as
+  ordinary dependencies. Optional dependencies follow the same non-enqueue
+  guard: the root manifest field is read and preserved per
+  `docs/specs/core/manifest/SPEC.md`, and per-version optional dependencies on
+  registry packuments remain ignored here until an optional-aware strategy
+  consumes them.
 - `engines`, `os`, and `cpu`. RPM does not perform engine, OS, or CPU filtering.
   Platform incompatibility is not a resolver or install failure today.
 - `main`, `types`, `scripts`, `bin`/package bin metadata, `private`,
@@ -293,7 +298,11 @@ not duplicate the contract text above.
 ## Open Questions
 
 - When and how RPM begins consuming `peerDependencies`, `optionalDependencies`,
-  `engines`, `os`, `cpu`, and package `bin` metadata. These remain ignored until
-  a peer-aware resolution strategy, platform gating, or `.bin` generation SPEC
-  owns the active behavior. The linker SPEC already notes `.bin` generation is
-  out of scope.
+  `engines`, `os`, `cpu`, and package `bin` metadata as active behavior. These
+  remain ignored at the registry boundary until a peer-aware resolution
+  strategy, an optional-aware strategy, platform gating, or `.bin` generation
+  SPEC owns the active behavior. The linker SPEC already notes `.bin` generation
+  is out of scope. The root manifest `optionalDependencies` read-and-preserve
+  baseline is now owned by `docs/specs/core/manifest/SPEC.md`; per-version
+  `optionalDependencies` on registry packuments remain ignored here until an
+  optional-aware strategy consumes them as dependency edges.

--- a/docs/specs/core/resolver/SPEC.md
+++ b/docs/specs/core/resolver/SPEC.md
@@ -3,7 +3,7 @@ spec_id: resolver_boundary
 title: Resolver Strategy Boundary
 status: draft
 owner: core/resolver
-last_reviewed: 2026-06-18
+last_reviewed: 2026-08-10
 authors:
   - nerdchanii
 deciders:
@@ -22,7 +22,7 @@ related_issues:
 
 Status: Draft
 Owner: core/resolver
-Last reviewed: 2026-06-18
+Last reviewed: 2026-08-10
 
 ## Purpose
 
@@ -86,6 +86,15 @@ requirement metadata on resolved package records or metadata records. They are
 not direct dependency requests, transitive dependency requests, manifest update
 inputs, or `node_modules` link targets by themselves. A non-peer-aware strategy
 must not silently enqueue peer dependencies as ordinary dependencies.
+
+Before an optional-aware strategy exists, optional dependencies are read and
+preserved on the manifest and on registry metadata but are not direct dependency
+requests, transitive dependency requests, or `node_modules` link targets. A
+non-optional-aware strategy must not silently enqueue optional dependencies as
+ordinary dependencies. The read-and-preserve baseline is owned by
+`docs/specs/core/manifest/SPEC.md`; per-version optional dependencies on
+registry packuments remain ignored at the registry boundary
+(`docs/specs/core/registry/SPEC.md`).
 
 The installer performance baseline in
 `docs/specs/core/install/performance/SPEC.md`

--- a/src/lib/package_manifest/mod.rs
+++ b/src/lib/package_manifest/mod.rs
@@ -43,6 +43,15 @@ pub struct PackageManifest {
     pub dependencies: HashMap<String, VersionString>,
     #[serde(rename = "devDependencies", skip_serializing_if = "Option::is_none")]
     pub dev_dependecies: Option<HashMap<String, VersionString>>,
+    // Read and preserved only; not enqueued as dependency requests until an
+    // optional-aware strategy owns resolve/install/skip behavior. See
+    // docs/specs/core/manifest/SPEC.md.
+    #[serde(
+        rename = "optionalDependencies",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub optional_dependencies: Option<HashMap<String, VersionString>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -171,6 +180,16 @@ impl PackageManifest {
         deps
     }
 
+    pub fn get_optional_dependencies(&self) -> Vec<(String, String)> {
+        let mut deps = Vec::new();
+        if let Some(optional_deps) = &self.optional_dependencies {
+            for (key, version) in optional_deps {
+                deps.push((key.to_owned(), version.0.to_owned()))
+            }
+        }
+        deps
+    }
+
     pub fn get_scripts(&self) -> HashMap<String, String> {
         self.scripts.clone().unwrap_or_default()
     }
@@ -212,6 +231,38 @@ mod package_json_test {
         assert!(dependencies.contains(&("vite".to_owned(), "~5.2.0".to_owned())));
         assert!(dev_dependencies.contains(&("typescript".to_owned(), "^5.4.0".to_owned())));
         assert_eq!(scripts.get("test").map(String::as_str), Some("cargo test"));
+    }
+
+    #[test]
+    fn read_file_preserves_optional_dependencies() {
+        let fixture = fixture_path(&["package_manifest", "manifest-with-optional-deps.json"]);
+        let package = PackageManifest::read_file(fixture.to_str().unwrap()).unwrap();
+
+        let optional_dependencies = package.get_optional_dependencies();
+        assert_eq!(package.name.as_deref(), Some("optional-app"));
+        assert!(optional_dependencies.contains(&("fsevents".to_owned(), "^2.3.3".to_owned())));
+        // Optional deps are preserved but must not leak into ordinary deps.
+        assert!(!package
+            .get_dependencies()
+            .contains(&("fsevents".to_owned(), "^2.3.3".to_owned())));
+    }
+
+    #[test]
+    fn optional_dependencies_round_trip_through_save() {
+        let temp_project = TempProject::new("package-manifest-optional").unwrap();
+        let temp_manifest_path = temp_project
+            .copy_fixture(
+                fixture_path(&["package_manifest", "manifest-with-optional-deps.json"]),
+                "package.json",
+            )
+            .unwrap();
+
+        let package = PackageManifest::read_file(temp_manifest_path.to_str().unwrap()).unwrap();
+        package.save_to_path(&temp_manifest_path).unwrap();
+
+        let saved = PackageManifest::read_file(temp_manifest_path.to_str().unwrap()).unwrap();
+        let optional_dependencies = saved.get_optional_dependencies();
+        assert!(optional_dependencies.contains(&("fsevents".to_owned(), "^2.3.3".to_owned())));
     }
 
     #[test]
@@ -282,6 +333,7 @@ mod package_json_test {
         assert_eq!(package.get_bin(), None);
         assert!(package.get_dependencies().is_empty());
         assert!(package.get_dev_dependencies().is_empty());
+        assert!(package.get_optional_dependencies().is_empty());
         assert!(package.get_scripts().is_empty());
     }
 

--- a/tests/fixtures/package_manifest/manifest-with-optional-deps.json
+++ b/tests/fixtures/package_manifest/manifest-with-optional-deps.json
@@ -1,0 +1,10 @@
+{
+  "name": "optional-app",
+  "version": "0.2.0",
+  "dependencies": {
+    "react": "^18.2.0"
+  },
+  "optionalDependencies": {
+    "fsevents": "^2.3.3"
+  }
+}


### PR DESCRIPTION
## Contract decision

SPEC-led definition of RPM's position on `optionalDependencies`, ahead of an
optional-aware strategy. This mirrors the established peer-dependency
non-enqueue pattern and makes RPM honest about a field it already accepts.
This is the next sub-deliverable in #120's M5 delivery order ("Define optional
dependency behavior before implementation").

Classification: `no SPEC exists` → `create/minimal SPEC` (manifest) + `SPEC is
stale` refinements (resolver, registry cross-references). No behavior
reclassification at the registry boundary; per-version `optionalDependencies`
remain ignored there.

## Changes

- **`docs/specs/core/manifest/SPEC.md`** (primary deliverable): new "Optional
  dependencies" subsection. RPM reads and preserves the root
  `optionalDependencies` map; preserved entries are not enqueued as dependency
  requests and do not influence version selection, the resolved graph, the
  lockfile, or linked `node_modules`. Full optional-aware behavior (resolve,
  attempt install, skip on failure, report) is deferred until an optional-aware
  strategy SPEC owns it. `last_reviewed` bumped to 2026-08-10.
- **`docs/specs/core/resolver/SPEC.md`**: add the non-optional-aware non-enqueue
  guard next to the peer-dependency guard. `last_reviewed` bumped to 2026-08-10.
- **`docs/specs/core/registry/SPEC.md`**: cross-reference the new manifest
  ownership in the ignored-fields bullet and the Open Questions entry; per-version
  optional dependencies remain ignored at the registry boundary.
- **`src/lib/package_manifest/mod.rs`**: add the `optionalDependencies` field
  (`#[serde(rename, default, skip_serializing_if)]`) and a read-only
  `get_optional_dependencies()` accessor so the SPEC matches the code. `install.rs`
  and the resolver are deliberately unchanged — that is the non-enqueue contract.
  `skip_serializing_if` keeps serialized manifests byte-identical when the field is
  absent.
- **`tests/fixtures/package_manifest/manifest-with-optional-deps.json`**: minimal
  manifest carrying `optionalDependencies`.

## Validation

- [x] `just format-check` — pass
- [x] `just check` (`cargo check --locked --all-targets`) — pass
- [x] `just lint` (`cargo clippy ... -D warnings`) — pass
- [x] `just test` — 166 + 1 passed; includes the two new tests:
  - `read_file_preserves_optional_dependencies`
  - `optional_dependencies_round_trip_through_save`
- [x] `just validate` — `agent-assets` reports `claude_security=fail`, confirmed
  **pre-existing on clean `origin/main`** (unrelated to this change; it is an
  agent-asset linter, not a package-manager contract check).

## Checklist

- [x] Owning SPEC updated (manifest, resolver, registry)
- [x] Code matches SPEC; field read/preserved, never enqueued
- [x] Regression coverage: fixture + 2 unit tests + empty-manifest default
- [x] No unrelated files staged; atomic single commit
- [x] No resolver/install/lockfile/linker behavior change (intentional)
- [x] Did not request `@codex review`; will not merge

## Scope note

This does **not** close #120 — it is one sub-deliverable of the M5 milestone
contract (peer deps, engines/os/cpu, aliases, and scoped edge cases remain).
Closes nothing; uses `Ref #120`.

Ref #120