### PR TITLE
docs(manifest): define engines, os, and cpu metadata policy

### DIFF
--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -72,7 +72,7 @@ RPM does not treat unsupported metadata as successful compatibility.
 | build-metadata deterministic selection | `registry/SPEC.md` (Registry Boundary, precedence step 3) | registry-owned raw-key sort before `max_satisfying` makes selection repeatable across `HashMap` seedings | delivered: #115 / #117 landed |
 | optionalDependencies | `registry/SPEC.md` (ignored list) | classified as ignored (not enqueued); no active read / resolve / install / skip / report contract exists yet | draft: compat optionalDependencies contract |
 | peerDependencies | `resolver/SPEC.md`, `registry/SPEC.md` (ignored list) | non-peer-aware strategy must not enqueue peer deps as ordinary dependencies; no peer-requirement field is implemented (spec-only) | draft: compat peerDependencies preservation and diagnostics |
-| engines, os, cpu | `registry/SPEC.md` (ignored list) | classified as ignored; no engine, OS, or CPU filtering, warning, or rejection policy exists | draft: compat engines/os/cpu metadata policy |
+| engines, os, cpu | `registry/SPEC.md` (ignored list), `manifest/SPEC.md` (root read/preserve) | classified as ignored at the registry boundary with an explicit no-filtering/warning/rejection contract decision; root manifest reads and preserves npm-accurate `engines`/`os`/`cpu` without consuming them; active platform gating deferred | delivered: #127 |
 | package bin metadata | `linker/SPEC.md` (out of scope) | `.bin` generation is explicitly out of scope; `bin` is not modeled on registry types | M6 linker contract owns this |
 | scoped package names | `registry/SPEC.md`, `linker/SPEC.md`, `lockfile/SPEC.md` | scoped names are owned throughout: registry consumes the scoped `name`, linker preserves the scope directory in the link path, and lockfile records `name` including scope | none |
 | npm aliases | (no owning SPEC) | npm alias syntax (`npm:<name>@<version>`) is unrepresented in SPECs and source | draft: compat alias contract |
@@ -87,9 +87,13 @@ Findings:
   `registry/SPEC.md` and `semver/SPEC.md`; the build-metadata deterministic
   tie-break closes the last selection-repeatability gap (#115 / #117).
 - The remaining M5 frontier is per-field classification: optional dependencies,
-  peer dependencies, engines/os/cpu, package bin metadata, and npm aliases each
-  need an active-behavior contract (or an explicit deferred decision) before
+  peer dependencies, package bin metadata, and npm aliases each need an
+  active-behavior contract (or an explicit deferred decision) before
   implementation. Each is represented by a compat draft task in Project #7.
+  Engines, OS, and CPU metadata now have an explicit deferred policy: the
+  registry boundary classifies them as ignored with a no-filtering contract
+  decision, and the root manifest reads and preserves them without consuming
+  them (#127).
 - Package `bin` metadata is intentionally deferred to the M6 linker milestone,
   where `.bin` generation is owned; it is listed here so the boundary is
   explicit, not so M5 implements it.

--- a/docs/specs/core/manifest/SPEC.md
+++ b/docs/specs/core/manifest/SPEC.md
@@ -14,6 +14,7 @@ related_adrs:
   - 0002-single-crate-cli-core-boundary
 related_issues:
   - 50
+  - 127
 ---
 
 # Spec: Package Manifest
@@ -60,6 +61,27 @@ non-optional-aware strategy must not silently enqueue optional dependencies as
 ordinary dependencies; that non-enqueue guard is owned by
 `docs/specs/core/resolver/SPEC.md`. Per-version
 `optionalDependencies` on registry packuments remain ignored at the registry
+boundary (`docs/specs/core/registry/SPEC.md`).
+
+### Engines, OS, and CPU metadata
+
+RPM reads and preserves the root `engines`, `os`, and `cpu` fields when they
+are present, using npm-accurate types (`engines` as a `name -> range` map;
+`os` and `cpu` as arrays whose entries may be negated, for example `!win32`).
+Preserved values are not consumed by install, add, or resolution today: RPM
+performs no engine, OS, or CPU filtering, warning, skip, or failure. They do
+not influence version selection, the resolved graph, the lockfile, or linked
+`node_modules`. A manifest that omits any of these fields behaves identically to
+one without it.
+
+This read-and-preserve baseline makes RPM honest about fields it accepts today
+and keeps a real npm-shaped manifest from failing parsing. The full
+platform-gating behavior (filter candidates, warn on mismatch, skip install, or
+fail) is intentionally deferred until a platform-gating strategy SPEC owns it.
+Until then, a non-platform-aware strategy must treat platform incompatibility as
+a non-failure: platform metadata must not block resolution, download,
+verification, extraction, linking, lockfile, or manifest output. Per-version
+`engines`, `os`, and `cpu` on registry packuments remain ignored at the registry
 boundary (`docs/specs/core/registry/SPEC.md`).
 
 ## Error Cases

--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -18,6 +18,7 @@ related_issues:
   - 113
   - 114
   - 120
+  - 127
 ---
 
 # Spec: Registry Metadata
@@ -139,8 +140,19 @@ verification:
   `docs/specs/core/manifest/SPEC.md`, and per-version optional dependencies on
   registry packuments remain ignored here until an optional-aware strategy
   consumes them.
-- `engines`, `os`, and `cpu`. RPM does not perform engine, OS, or CPU filtering.
-  Platform incompatibility is not a resolver or install failure today.
+- `engines`, `os`, and `cpu`. RPM deserializes these with npm-accurate types
+  (`engines` as a map of engine name to range; `os` and `cpu` as arrays whose
+  entries may be negated, for example `!win32`) but does not consume them.
+  **There is no engine, OS, or CPU filtering, warning, skip, or rejection
+  policy at the registry boundary.** Platform incompatibility is not a
+  resolver or install failure today: a version whose `engines`/`os`/`cpu`
+  declare an incompatible platform still selects, downloads, verifies, and
+  links normally. This is an intentional deferred decision, not an absent one;
+  active platform gating is deferred until a platform-gating strategy SPEC owns
+  filter/warn/skip/fail behavior. The root-manifest read-and-preserve baseline
+  for `engines`/`os`/`cpu` is owned by
+  `docs/specs/core/manifest/SPEC.md`; per-version values on registry packuments
+  remain ignored here until that strategy consumes them.
 - `main`, `types`, `scripts`, `bin`/package bin metadata, `private`,
   `repository`, `description`, `maintainers`, `author`, `homepage`, `keywords`,
   `license`, `readme`, `readmeFilename`, `time`, `_id`, `_rev`, and `sequence`.
@@ -306,4 +318,8 @@ not duplicate the contract text above.
   is out of scope. The root manifest `optionalDependencies` read-and-preserve
   baseline is now owned by `docs/specs/core/manifest/SPEC.md`; per-version
   `optionalDependencies` on registry packuments remain ignored here until an
-  optional-aware strategy consumes them as dependency edges.
+  optional-aware strategy consumes them as dependency edges. The root manifest
+  `engines`/`os`/`cpu` read-and-preserve baseline is now owned by
+  `docs/specs/core/manifest/SPEC.md` (#127); per-version `engines`/`os`/`cpu`
+  on registry packuments remain ignored here until a platform-gating strategy
+  consumes them.

--- a/src/lib/package_manifest/mod.rs
+++ b/src/lib/package_manifest/mod.rs
@@ -66,12 +66,17 @@ pub struct PackageManifest {
     pub bugs: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contributors: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub engines: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub os: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu: Option<String>,
+    // Read and preserved only; not consumed for platform gating until a
+    // platform-gating strategy owns filter/warn/skip/fail behavior. The field
+    // types follow npm's schema (`engines` as a map, `os`/`cpu` as arrays) so a
+    // real npm-shaped manifest parses instead of failing deserialization. See
+    // docs/specs/core/manifest/SPEC.md.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engines: Option<HashMap<String, VersionString>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub os: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub private: Option<String>,
     // other fields implement soon.
@@ -190,6 +195,30 @@ impl PackageManifest {
         deps
     }
 
+    /// Preserved `engines` map (engine name to range, for example
+    /// `node -> >=14`). Read-only: RPM does not perform engine filtering today.
+    pub fn get_engines(&self) -> Vec<(String, String)> {
+        let mut engines = Vec::new();
+        if let Some(map) = &self.engines {
+            for (key, version) in map {
+                engines.push((key.to_owned(), version.0.to_owned()))
+            }
+        }
+        engines
+    }
+
+    /// Preserved `os` allowlist/denylist (entries may be negated, for example
+    /// `!win32`). Read-only: RPM does not perform OS filtering today.
+    pub fn get_os(&self) -> Vec<String> {
+        self.os.clone().unwrap_or_default()
+    }
+
+    /// Preserved `cpu` allowlist/denylist (entries may be negated, for example
+    /// `!arm64`). Read-only: RPM does not perform CPU filtering today.
+    pub fn get_cpu(&self) -> Vec<String> {
+        self.cpu.clone().unwrap_or_default()
+    }
+
     pub fn get_scripts(&self) -> HashMap<String, String> {
         self.scripts.clone().unwrap_or_default()
     }
@@ -266,6 +295,56 @@ mod package_json_test {
     }
 
     #[test]
+    fn read_file_preserves_engines_os_and_cpu() {
+        let fixture = fixture_path(&["package_manifest", "manifest-with-engines-os-cpu.json"]);
+        let package = PackageManifest::read_file(fixture.to_str().unwrap()).unwrap();
+
+        // Preserved with npm-accurate types, but not consumed by install today.
+        let engines = package.get_engines();
+        assert_eq!(package.name.as_deref(), Some("platform-app"));
+        assert!(engines.contains(&("node".to_owned(), ">=14.0.0".to_owned())));
+        assert_eq!(
+            package.get_os(),
+            vec!["linux".to_owned(), "darwin".to_owned(), "!win32".to_owned()]
+        );
+        assert_eq!(
+            package.get_cpu(),
+            vec!["x64".to_owned(), "arm64".to_owned(), "!ia32".to_owned()]
+        );
+        // Platform metadata must not leak into ordinary dependency edges.
+        assert!(!package
+            .get_dependencies()
+            .contains(&("node".to_owned(), ">=14.0.0".to_owned())));
+    }
+
+    #[test]
+    fn engines_os_and_cpu_round_trip_through_save() {
+        let temp_project = TempProject::new("package-manifest-platform").unwrap();
+        let temp_manifest_path = temp_project
+            .copy_fixture(
+                fixture_path(&["package_manifest", "manifest-with-engines-os-cpu.json"]),
+                "package.json",
+            )
+            .unwrap();
+
+        let package = PackageManifest::read_file(temp_manifest_path.to_str().unwrap()).unwrap();
+        package.save_to_path(&temp_manifest_path).unwrap();
+
+        let saved = PackageManifest::read_file(temp_manifest_path.to_str().unwrap()).unwrap();
+        assert!(saved
+            .get_engines()
+            .contains(&("node".to_owned(), ">=14.0.0".to_owned())));
+        assert_eq!(
+            saved.get_os(),
+            vec!["linux".to_owned(), "darwin".to_owned(), "!win32".to_owned()]
+        );
+        assert_eq!(
+            saved.get_cpu(),
+            vec!["x64".to_owned(), "arm64".to_owned(), "!ia32".to_owned()]
+        );
+    }
+
+    #[test]
     fn read_file_handles_missing_optional_fields() {
         let fixture = fixture_path(&["package_manifest", "manifest-minimal.json"]);
         let package = PackageManifest::read_file(fixture.to_str().unwrap()).unwrap();
@@ -273,6 +352,9 @@ mod package_json_test {
         assert_eq!(package.name.as_deref(), Some("minimal-app"));
         assert!(package.get_dependencies().is_empty());
         assert!(package.get_dev_dependencies().is_empty());
+        assert!(package.get_engines().is_empty());
+        assert!(package.get_os().is_empty());
+        assert!(package.get_cpu().is_empty());
         assert!(package.get_scripts().is_empty());
     }
 
@@ -334,6 +416,9 @@ mod package_json_test {
         assert!(package.get_dependencies().is_empty());
         assert!(package.get_dev_dependencies().is_empty());
         assert!(package.get_optional_dependencies().is_empty());
+        assert!(package.get_engines().is_empty());
+        assert!(package.get_os().is_empty());
+        assert!(package.get_cpu().is_empty());
         assert!(package.get_scripts().is_empty());
     }
 

--- a/tests/fixtures/package_manifest/manifest-with-engines-os-cpu.json
+++ b/tests/fixtures/package_manifest/manifest-with-engines-os-cpu.json
@@ -1,0 +1,20 @@
+{
+  "name": "platform-app",
+  "version": "0.3.0",
+  "dependencies": {
+    "react": "^18.2.0"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "os": [
+    "linux",
+    "darwin",
+    "!win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64",
+    "!ia32"
+  ]
+}


### PR DESCRIPTION
## Contract

The M5 npm metadata compatibility audit listed engines/os/cpu as `draft: compat engines/os/cpu metadata policy` (`docs/specs/core/README.md` M5 audit table). This PR closes that gap with an explicit deferred platform-gating policy and the read-and-preserve baseline that the contract requires.

Real npm packages commonly carry `engines`, `os`, and `cpu` metadata. RPM needs an explicit position before compatibility work consumes those fields, so it does not treat a platform-incompatible package as a successful compatible install by accident.

## Prior behavior being fixed

Today the situation is split:

- **Registry packuments** (`src/lib/registry/mod.rs`): `engines`, `os`, `cpu` were already modeled with npm-accurate types and tolerated as ignored fields, but `registry/SPEC.md` only stated the classification in passing. The absence of a filtering/warning/rejection policy was implicit, not an explicit contract decision.
- **Root manifest** (`src/lib/package_manifest/mod.rs`): `engines`, `os`, and `cpu` were typed as `Option<String>`. npm's real schema is `engines` as a map (`{ "node": ">=14" }`) and `os`/`cpu` as arrays (`["linux", "!win32"]`). A root manifest that carried the npm-accurate shape therefore **failed manifest parsing**. `manifest/SPEC.md` did not mention these fields at all.

## Changes

### Classification contract

- **`docs/specs/core/manifest/SPEC.md`** — new "Engines, OS, and CPU metadata" section: RPM reads and preserves the root `engines` (map), `os` (array), and `cpu` (array) fields; preserved values are not consumed by install, add, or resolution today and do not influence selection, the graph, the lockfile, or linking. Full platform-gating behavior (filter, warn, skip, fail) is deferred until a platform-gating strategy SPEC owns it. `related_issues` includes #127.
- **`docs/specs/core/registry/SPEC.md`** — the ignored-list entry for `engines`/`os`/`cpu` is promoted to an explicit no-filtering/warning/rejection contract decision, names the manifest SPEC as the root read/preserve owner, and the Open Questions note that the read/preserve baseline is now owned (#127). `related_issues` includes #127.

### Audit table (`docs/specs/core/README.md`)

- M5 audit table `engines, os, cpu` row: owner now `registry/SPEC.md` + `manifest/SPEC.md`; follow-up `delivered: #127`.
- M5 frontier findings: engines/os/cpu removed from the unclassified frontier list, with a one-line note that they now have an explicit deferred policy.

### Active read/preserve (`src/lib/package_manifest/mod.rs`)

- Field types corrected to npm-accurate shapes so the SPEC is honest and a real npm-shaped manifest no longer fails parsing:
  - `engines`: `Option<String>` → `Option<HashMap<String, VersionString>>`
  - `os`: `Option<String>` → `Option<Vec<String>>`
  - `cpu`: `Option<String>` → `Option<Vec<String>>`
- `#[serde(default, skip_serializing_if = "Option::is_none")]` keeps manifest serialization identical when the fields are absent.
- Read-only accessors `get_engines`, `get_os`, `get_cpu` mirror the established `get_optional_dependencies` non-consume pattern.
- install.rs and the resolver are deliberately unchanged — that is the no-platform-gating contract.

### Regression tests (`src/lib/package_manifest/mod.rs`)

- `read_file_preserves_engines_os_and_cpu` — preserved with npm-accurate types and do not leak into ordinary dependencies.
- `engines_os_and_cpu_round_trip_through_save` — save round-trip preserves values.
- Empty-manifest and minimal-manifest tests extended with `get_engines`/`get_os`/`get_cpu` default-emptiness assertions.

### Fixture

- `tests/fixtures/package_manifest/manifest-with-engines-os-cpu.json` — engines map, os/cpu arrays including negated entries.

## Out of scope

Active platform gating (filtering candidates, warning on mismatch, skipping install, or failing) remains a future platform-gating strategy and is captured as a deferred decision in both SPECs. It requires its own milestone, a platform model, and resolver/install changes.

## Validation

- `just format-check` — passed (`cargo fmt --all --check`)
- `just lint` — passed (clippy strict, `-D warnings`)
- `just check` — passed (`cargo check --locked --all-targets`)
- `just test` — passed (168 lib + 1 binary tests, 0 failed)

## Checklist

- [x] Owning SPECs identified (`manifest/SPEC.md` read/preserve; `registry/SPEC.md` ignored contract decision)
- [x] SPEC classified as contract decision (deferred platform-gating policy)
- [x] Manifest field types corrected so a real npm-shaped manifest parses
- [x] Regression tests cover preserve, round-trip, and missing-field defaults
- [x] M5 audit table updated to reflect the new ownership
- [x] Validation evidence recorded

Closes #127
Ref #120