### PR TITLE
docs(manifest): define peerDependencies read/preserve contract

### DIFF
--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -71,7 +71,7 @@ RPM does not treat unsupported metadata as successful compatibility.
 | dist-tags / `latest` / semver range selection boundary | `registry/SPEC.md`, `semver/SPEC.md` | dist-tags are registry selectors, not semver ranges; `latest` and tag precedence over ranges is defined | none |
 | build-metadata deterministic selection | `registry/SPEC.md` (Registry Boundary, precedence step 3) | registry-owned raw-key sort before `max_satisfying` makes selection repeatable across `HashMap` seedings | delivered: #115 / #117 landed |
 | optionalDependencies | `registry/SPEC.md` (ignored list) | classified as ignored (not enqueued); no active read / resolve / install / skip / report contract exists yet | draft: compat optionalDependencies contract |
-| peerDependencies | `resolver/SPEC.md`, `registry/SPEC.md` (ignored list) | non-peer-aware strategy must not enqueue peer deps as ordinary dependencies; no peer-requirement field is implemented (spec-only) | draft: compat peerDependencies preservation and diagnostics |
+| peerDependencies | `resolver/SPEC.md`, `registry/SPEC.md` (ignored list), `manifest/SPEC.md` (root read/preserve) | classified as ignored at the registry boundary with the non-peer-aware non-enqueue guard; root manifest reads and preserves `peerDependencies` without consuming them; active peer-aware resolution and diagnostics deferred | delivered: #130 |
 | engines, os, cpu | `registry/SPEC.md` (ignored list), `manifest/SPEC.md` (root read/preserve) | classified as ignored at the registry boundary with an explicit no-filtering/warning/rejection contract decision; root manifest reads and preserves npm-accurate `engines`/`os`/`cpu` without consuming them; active platform gating deferred | delivered: #127 |
 | package bin metadata | `linker/SPEC.md` (out of scope) | `.bin` generation is explicitly out of scope; `bin` is not modeled on registry types | M6 linker contract owns this |
 | scoped package names | `registry/SPEC.md`, `linker/SPEC.md`, `lockfile/SPEC.md` | scoped names are owned throughout: registry consumes the scoped `name`, linker preserves the scope directory in the link path, and lockfile records `name` including scope | none |
@@ -86,14 +86,13 @@ Findings:
 - The dist-tag and semver range selection boundary is fully owned across
   `registry/SPEC.md` and `semver/SPEC.md`; the build-metadata deterministic
   tie-break closes the last selection-repeatability gap (#115 / #117).
-- The remaining M5 frontier is per-field classification: optional dependencies,
-  peer dependencies, package bin metadata, and npm aliases each need an
-  active-behavior contract (or an explicit deferred decision) before
-  implementation. Each is represented by a compat draft task in Project #7.
-  Engines, OS, and CPU metadata now have an explicit deferred policy: the
-  registry boundary classifies them as ignored with a no-filtering contract
-  decision, and the root manifest reads and preserves them without consuming
-  them (#127).
+- The remaining M5 frontier is per-field classification: package bin metadata
+  and npm aliases each need an active-behavior contract (or an explicit deferred
+  decision) before implementation. Each is represented by a compat draft task in
+  Project #7. Optional dependencies (#124), peer dependencies (#130), and
+  engines, OS, and CPU metadata (#127) now have explicit deferred policies: the
+  registry boundary classifies them as ignored, and the root manifest reads and
+  preserves them without consuming them.
 - Package `bin` metadata is intentionally deferred to the M6 linker milestone,
   where `.bin` generation is owned; it is listed here so the boundary is
   explicit, not so M5 implements it.

--- a/docs/specs/core/manifest/SPEC.md
+++ b/docs/specs/core/manifest/SPEC.md
@@ -15,6 +15,7 @@ related_adrs:
 related_issues:
   - 50
   - 127
+  - 130
 ---
 
 # Spec: Package Manifest
@@ -61,6 +62,24 @@ non-optional-aware strategy must not silently enqueue optional dependencies as
 ordinary dependencies; that non-enqueue guard is owned by
 `docs/specs/core/resolver/SPEC.md`. Per-version
 `optionalDependencies` on registry packuments remain ignored at the registry
+boundary (`docs/specs/core/registry/SPEC.md`).
+
+### Peer dependencies
+
+RPM reads and preserves the root `peerDependencies` map (`package name` to
+`range`) when it is present. Preserved entries are not consumed by install, add,
+or resolution today: they are not enqueued as dependency requests, they do not
+influence version selection, and they do not appear in the resolved graph,
+lockfile, or linked `node_modules`. A manifest that omits `peerDependencies`
+behaves identically to one without it.
+
+This read-and-preserve baseline makes RPM honest about a field it accepts today.
+The full peer-aware behavior (peer-requirement resolution, peer-set enforcement,
+and peer-conflict diagnostics) is intentionally deferred until a peer-aware
+strategy SPEC owns it. Until then, a non-peer-aware strategy must not silently
+enqueue peer dependencies as ordinary dependencies; that non-enqueue guard is
+owned by `docs/specs/core/resolver/SPEC.md`. Per-version
+`peerDependencies` on registry packuments remain ignored at the registry
 boundary (`docs/specs/core/registry/SPEC.md`).
 
 ### Engines, OS, and CPU metadata

--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -20,6 +20,7 @@ related_issues:
   - 120
   - 125
   - 127
+  - 130
 ---
 
 # Spec: Registry Metadata
@@ -136,8 +137,9 @@ verification:
   non-optional-aware strategy. Peer dependencies are represented as peer
   requirement metadata on resolved package records per
   `docs/specs/core/resolver/SPEC.md`; they must not be silently enqueued as
-  ordinary dependencies. Optional dependencies follow the same non-enqueue
-  guard: the root manifest field is read and preserved per
+  ordinary dependencies. The root manifest field is read and preserved per
+  `docs/specs/core/manifest/SPEC.md`. Optional dependencies follow the same
+  non-enqueue guard: the root manifest field is read and preserved per
   `docs/specs/core/manifest/SPEC.md`, and per-version optional dependencies on
   registry packuments remain ignored here until an optional-aware strategy
   consumes them.

--- a/docs/specs/core/resolver/SPEC.md
+++ b/docs/specs/core/resolver/SPEC.md
@@ -16,6 +16,7 @@ related_adrs:
 related_issues:
   - 50
   - 58
+  - 130
 ---
 
 # Spec: Resolver Strategy Boundary
@@ -85,7 +86,11 @@ Before a peer-aware strategy exists, peer dependencies are represented as peer
 requirement metadata on resolved package records or metadata records. They are
 not direct dependency requests, transitive dependency requests, manifest update
 inputs, or `node_modules` link targets by themselves. A non-peer-aware strategy
-must not silently enqueue peer dependencies as ordinary dependencies.
+must not silently enqueue peer dependencies as ordinary dependencies. The
+root-manifest read-and-preserve baseline for `peerDependencies` is owned by
+`docs/specs/core/manifest/SPEC.md`; per-version peer dependencies on registry
+packuments remain ignored at the registry boundary
+(`docs/specs/core/registry/SPEC.md`).
 
 Before an optional-aware strategy exists, optional dependencies are read and
 preserved on the manifest and on registry metadata but are not direct dependency

--- a/src/lib/package_manifest/mod.rs
+++ b/src/lib/package_manifest/mod.rs
@@ -52,6 +52,15 @@ pub struct PackageManifest {
         skip_serializing_if = "Option::is_none"
     )]
     pub optional_dependencies: Option<HashMap<String, VersionString>>,
+    // Read and preserved only; not enqueued as ordinary dependency requests
+    // until a peer-aware strategy owns peer-requirement resolution and
+    // diagnostics. See docs/specs/core/manifest/SPEC.md.
+    #[serde(
+        rename = "peerDependencies",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub peer_dependencies: Option<HashMap<String, VersionString>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -195,6 +204,18 @@ impl PackageManifest {
         deps
     }
 
+    /// Preserved `peerDependencies` map (package name to range). Read-only: RPM
+    /// does not enqueue peer dependencies as ordinary dependencies today.
+    pub fn get_peer_dependencies(&self) -> Vec<(String, String)> {
+        let mut deps = Vec::new();
+        if let Some(peer_deps) = &self.peer_dependencies {
+            for (key, version) in peer_deps {
+                deps.push((key.to_owned(), version.0.to_owned()))
+            }
+        }
+        deps
+    }
+
     /// Preserved `engines` map (engine name to range, for example
     /// `node -> >=14`). Read-only: RPM does not perform engine filtering today.
     pub fn get_engines(&self) -> Vec<(String, String)> {
@@ -295,6 +316,38 @@ mod package_json_test {
     }
 
     #[test]
+    fn read_file_preserves_peer_dependencies() {
+        let fixture = fixture_path(&["package_manifest", "manifest-with-peer-deps.json"]);
+        let package = PackageManifest::read_file(fixture.to_str().unwrap()).unwrap();
+
+        let peer_dependencies = package.get_peer_dependencies();
+        assert_eq!(package.name.as_deref(), Some("peer-app"));
+        assert!(peer_dependencies.contains(&("react".to_owned(), "^18.0.0".to_owned())));
+        // Peer deps are preserved but must not leak into ordinary deps.
+        assert!(!package
+            .get_dependencies()
+            .contains(&("react".to_owned(), "^18.0.0".to_owned())));
+    }
+
+    #[test]
+    fn peer_dependencies_round_trip_through_save() {
+        let temp_project = TempProject::new("package-manifest-peer").unwrap();
+        let temp_manifest_path = temp_project
+            .copy_fixture(
+                fixture_path(&["package_manifest", "manifest-with-peer-deps.json"]),
+                "package.json",
+            )
+            .unwrap();
+
+        let package = PackageManifest::read_file(temp_manifest_path.to_str().unwrap()).unwrap();
+        package.save_to_path(&temp_manifest_path).unwrap();
+
+        let saved = PackageManifest::read_file(temp_manifest_path.to_str().unwrap()).unwrap();
+        let peer_dependencies = saved.get_peer_dependencies();
+        assert!(peer_dependencies.contains(&("react".to_owned(), "^18.0.0".to_owned())));
+    }
+
+    #[test]
     fn read_file_preserves_engines_os_and_cpu() {
         let fixture = fixture_path(&["package_manifest", "manifest-with-engines-os-cpu.json"]);
         let package = PackageManifest::read_file(fixture.to_str().unwrap()).unwrap();
@@ -352,6 +405,7 @@ mod package_json_test {
         assert_eq!(package.name.as_deref(), Some("minimal-app"));
         assert!(package.get_dependencies().is_empty());
         assert!(package.get_dev_dependencies().is_empty());
+        assert!(package.get_peer_dependencies().is_empty());
         assert!(package.get_engines().is_empty());
         assert!(package.get_os().is_empty());
         assert!(package.get_cpu().is_empty());
@@ -416,6 +470,7 @@ mod package_json_test {
         assert!(package.get_dependencies().is_empty());
         assert!(package.get_dev_dependencies().is_empty());
         assert!(package.get_optional_dependencies().is_empty());
+        assert!(package.get_peer_dependencies().is_empty());
         assert!(package.get_engines().is_empty());
         assert!(package.get_os().is_empty());
         assert!(package.get_cpu().is_empty());

--- a/tests/fixtures/package_manifest/manifest-with-peer-deps.json
+++ b/tests/fixtures/package_manifest/manifest-with-peer-deps.json
@@ -1,0 +1,10 @@
+{
+  "name": "peer-app",
+  "version": "0.2.0",
+  "dependencies": {
+    "react": "^18.2.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
+  }
+}


### PR DESCRIPTION
## Contract

The M5 npm metadata compatibility audit listed `peerDependencies` as
`draft: compat peerDependencies preservation and diagnostics`
(`docs/specs/core/README.md` M5 audit table). This PR closes the read/preserve
half of that gap with an explicit deferred peer-aware policy and the
read-and-preserve baseline that the contract requires.

Real npm packages commonly declare `peerDependencies` (for example a React UI
library depending on `react`). RPM needs an explicit position before
compatibility work consumes the field, so it does not treat a peer requirement
as a silently-dropped or silently-enqueued dependency by accident. This is
sub-deliverable #4 of the M5 milestone contract (#120) delivery order.

## Prior behavior being fixed

Today the situation is split, mirroring the `optionalDependencies` (#124) and
`engines`/`os`/`cpu` (#127) gaps that already landed:

- **Registry packuments** (`src/lib/registry/mod.rs`): `peerDependencies` was
  already modeled as `Option<HashMap<String, String>>` and tolerated as an
  ignored field on both root and per-version records. The `registry/SPEC.md`
  ignored-fields bullet already stated the non-enqueue guard, but it did not
  cross-reference a root-manifest read/preserve owner.
- **Root manifest** (`src/lib/package_manifest/mod.rs`): there was **no**
  `peerDependencies` field. A root manifest that carried `peerDependencies`
  silently dropped it during deserialization. `manifest/SPEC.md` did not mention
  the field at all.

## Changes

### Classification contract

- **`docs/specs/core/manifest/SPEC.md`** — new "Peer dependencies" section: RPM
  reads and preserves the root `peerDependencies` map (`package name` to
  `range`); preserved values are not consumed by install, add, or resolution
  today and do not influence selection, the graph, the lockfile, or linking.
  Full peer-aware behavior (peer-requirement resolution, peer-set enforcement,
  peer-conflict diagnostics) is deferred until a peer-aware strategy SPEC owns
  it. `related_issues` includes #130.
- **`docs/specs/core/resolver/SPEC.md`** — the existing peer non-enqueue guard
  now cross-references the manifest read/preserve owner. `related_issues`
  includes #130.
- **`docs/specs/core/registry/SPEC.md`** — the ignored-list entry for
  `peerDependencies` now names the manifest SPEC as the root read/preserve
  owner. `related_issues` includes #130.

### Audit table (`docs/specs/core/README.md`)

- M5 audit table `peerDependencies` row: owner now `resolver/SPEC.md` +
  `registry/SPEC.md` + `manifest/SPEC.md`; follow-up `delivered: #130`.
- M5 frontier findings: peer dependencies removed from the unclassified frontier
  list alongside optional dependencies and engines/os/cpu, with a one-line note
  that they now have an explicit deferred policy.

### Active read/preserve (`src/lib/package_manifest/mod.rs`)

- New `peerDependencies` field (`Option<HashMap<String, VersionString>>`) with
  `#[serde(rename = "peerDependencies", default, skip_serializing_if = ...)]`
  so the SPEC is honest and a real npm-shaped manifest no longer drops the
  field. `skip_serializing_if` keeps manifest serialization identical when the
  field is absent.
- Read-only accessor `get_peer_dependencies` mirrors the established
  `get_optional_dependencies` non-consume pattern.
- `install.rs` and the resolver are deliberately unchanged — that is the
  non-peer-aware non-enqueue contract.

### Regression tests (`src/lib/package_manifest/mod.rs`)

- `read_file_preserves_peer_dependencies` — preserved and do not leak into
  ordinary dependencies.
- `peer_dependencies_round_trip_through_save` — save round-trip preserves
  values.
- Empty-manifest and minimal-manifest tests extended with `get_peer_dependencies`
  default-emptiness assertions.

### Fixture

- `tests/fixtures/package_manifest/manifest-with-peer-deps.json` — minimal
  manifest carrying `peerDependencies`.

## Out of scope

Active peer-aware resolution (peer-requirement matching, peer-set enforcement,
conflict diagnostics) remains a future peer-aware strategy and is captured as a
deferred decision in all three SPECs. It requires its own milestone and a
peer-resolution model; the audit table lists "peer dependency diagnostics" as a
separate draft task. Per-version `peerDependencies` consumption at the registry
boundary also remains ignored.

## Validation

- `just format-check` — passed (`cargo fmt --all --check`)
- `just check` — passed (`cargo check --locked --all-targets`)
- `just lint` — passed (clippy strict, `-D warnings`)
- `just test` — passed (173 lib + 1 binary tests, 0 failed; includes the two new
  tests `read_file_preserves_peer_dependencies` and
  `peer_dependencies_round_trip_through_save`)

## Checklist

- [x] Owning SPECs identified (`manifest/SPEC.md` read/preserve; `resolver/SPEC.md` + `registry/SPEC.md` cross-refs)
- [x] SPEC classified as contract decision (deferred peer-aware policy)
- [x] Manifest field added so a real npm-shaped manifest preserves `peerDependencies`
- [x] Regression tests cover preserve, round-trip, and missing-field defaults
- [x] M5 audit table updated to reflect the new ownership
- [x] Validation evidence recorded
- [x] No resolver/install/lockfile/linker behavior change (intentional)
- [x] Did not request `@codex review`; will not merge

Closes #130
Ref #120