### PR TITLE
compat(resolver): specify peer metadata non-enqueue and lockfile deferral (#134)

### DIFF
--- a/docs/specs/core/lockfile/SPEC.md
+++ b/docs/specs/core/lockfile/SPEC.md
@@ -65,6 +65,17 @@ Package entries record:
   provides a shasum.
 - `dependencies`: dependency edges as requested package references.
 
+`peerDependencies` and `optionalDependencies` are not recorded in lockfile v1.
+The current non-peer-aware, non-optional-aware strategy neither resolves nor
+links these edges, so recording them would freeze metadata that no install
+phase consumes. Peer and optional metadata remain preserved on the manifest
+(`docs/specs/core/manifest/SPEC.md`) and on registry packuments
+(`docs/specs/core/registry/SPEC.md`) without appearing in `rpm.lock`. A
+`relationship` value for peer or optional edges, and any lockfile
+representation of unmet peer or optional requirements, must be added by the
+peer-aware or optional-aware strategy SPEC that first consumes them; lockfile
+v1 does not reserve those values.
+
 ### Loading
 
 An absent or empty lockfile initializes as an empty v1 lockfile. Empty loading

--- a/docs/specs/core/resolver/SPEC.md
+++ b/docs/specs/core/resolver/SPEC.md
@@ -92,6 +92,20 @@ root-manifest read-and-preserve baseline for `peerDependencies` is owned by
 packuments remain ignored at the registry boundary
 (`docs/specs/core/registry/SPEC.md`).
 
+The presence of an unmet peer requirement is not a resolution or install
+failure under the non-peer-aware strategy. RPM performs no peer-set
+enforcement, peer placement, or peer-conflict detection today: a package whose
+`peerDependencies` target is absent, the wrong version, or otherwise
+unsatisfied still selects, downloads, verifies, and links normally, and the
+resolved graph contains only the package's ordinary dependencies. Peer
+requirements do not appear in the lockfile
+(`docs/specs/core/lockfile/SPEC.md`). Warnings or errors for unmet peer
+requirements are deferred to a peer-aware strategy SPEC; until then, peer
+metadata is observable only as preserved metadata, not as install output.
+This is an intentional deferral, not an absence of policy: callers must not
+infer that an install succeeded without peer warnings means the peer set is
+satisfied.
+
 Before an optional-aware strategy exists, optional dependencies are read and
 preserved on the manifest and on registry metadata but are not direct dependency
 requests, transitive dependency requests, or `node_modules` link targets. A

--- a/src/core/resolver/mod.rs
+++ b/src/core/resolver/mod.rs
@@ -494,6 +494,61 @@ mod tests {
     }
 
     #[test]
+    fn peer_dependency_metadata_is_preserved_without_enqueue_or_install_failure() {
+        let root = fixture_path(&["registry", "peer-preserve", "metadata"]);
+        let provider = FixtureMetadataProvider::from_fixture_root(&root);
+
+        // Request only the peer consumer. Its only edge is a peerDependencies
+        // entry; the peer target is never requested directly.
+        let graph = resolve_dependency_graph(
+            vec![DependencyRequest::new(
+                "@rpm-fixture/peer-consumer",
+                "^1.0.0",
+                DependencyRequestKind::DirectProduction,
+            )],
+            &provider,
+        )
+        .expect(
+            "unmet peer requirement must not fail resolution under the non-peer-aware strategy",
+        );
+
+        let expected = fs::read_to_string(fixture_path(&[
+            "registry",
+            "peer-preserve",
+            "expected",
+            "resolved-packages.txt",
+        ]))
+        .expect("expected resolved package list should be readable");
+        let resolved = graph
+            .packages()
+            .iter()
+            .map(|package| {
+                format!(
+                    "{}@{} requested {}",
+                    package.package_name, package.version, package.requests[0].requested
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(format!("{resolved}\n"), expected);
+
+        // The peer target must NOT be enqueued as an ordinary dependency: the
+        // graph contains only the consumer.
+        assert_eq!(graph.packages().len(), 1);
+        let consumer = graph
+            .package("@rpm-fixture/peer-consumer", "1.0.0")
+            .expect("peer consumer resolves to a graph node");
+        assert!(
+            consumer.dependencies.is_empty(),
+            "peerDependencies must not become ordinary dependency edges"
+        );
+        assert!(
+            graph.package("@rpm-fixture/peer-target", "1.0.0").is_none(),
+            "peer target must not appear in the resolved graph before a peer-aware strategy exists"
+        );
+    }
+
+    #[test]
     fn failed_version_selection_stops_before_reading_dependency_metadata() {
         let provider = FailingSelectionProvider {
             dependency_reads: Cell::new(0),

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -1063,6 +1063,7 @@ mod tests {
     fn semver_registry_fixtures_match_registry_metadata_shape() {
         let fixture_roots = [
             "tests/fixtures/registry/shared-transitive/metadata",
+            "tests/fixtures/registry/peer-preserve/metadata",
             "tests/fixtures/install-projects/lockfile-reproducible/registry",
             "tests/fixtures/install-projects/integrity-mismatch/registry",
             "tests/fixtures/install-projects/output-failure-after-resolution/registry",
@@ -1114,6 +1115,40 @@ mod tests {
             "https://registry.example.invalid/@rpm-fixture/alpha/-/alpha-1.0.0.tgz"
         );
         assert_eq!(alpha_dist.shasum.as_deref(), Some("fixture-alpha-1.0.0"));
+    }
+
+    #[test]
+    fn peer_dependencies_are_preserved_without_appearing_as_dependency_edges() {
+        let root = fixture_path(&["registry", "peer-preserve", "metadata"]);
+
+        let consumer = load_registry_fixture(&root, "@rpm-fixture/peer-consumer", "1.0.0");
+        let target = load_registry_fixture(&root, "@rpm-fixture/peer-target", "1.0.0");
+
+        // Peer metadata is preserved on the packument (the fixture carries it
+        // and deserialization succeeds, proven by load_registry_fixture), but it
+        // is not exposed as an ordinary dependency edge. The consumer has no
+        // `dependencies`, only `peerDependencies`; the target is never
+        // requested.
+        assert!(
+            consumer.get_dependencies_for_version("1.0.0").is_empty(),
+            "peer dependency must not surface as an ordinary dependency edge"
+        );
+        assert!(
+            target.get_dependencies_for_version("1.0.0").is_empty(),
+            "peer target has no ordinary dependencies"
+        );
+
+        // Round-trip the consumer through serde to prove peer metadata survives
+        // deserialization rather than being dropped at the registry boundary.
+        let raw =
+            fs::read_to_string(root.join(registry_fixture_file_name("@rpm-fixture/peer-consumer")))
+                .expect("peer-consumer fixture should be readable");
+        let reparsed: serde_json::Value =
+            serde_json::from_str(&raw).expect("peer-consumer fixture should parse as JSON");
+        assert_eq!(
+            reparsed["versions"]["1.0.0"]["peerDependencies"]["@rpm-fixture/peer-target"], "^1.0.0",
+            "peer dependency metadata must be preserved on the packument"
+        );
     }
 
     #[test]

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -1138,16 +1138,31 @@ mod tests {
             "peer target has no ordinary dependencies"
         );
 
-        // Round-trip the consumer through serde to prove peer metadata survives
-        // deserialization rather than being dropped at the registry boundary.
-        let raw =
-            fs::read_to_string(root.join(registry_fixture_file_name("@rpm-fixture/peer-consumer")))
-                .expect("peer-consumer fixture should be readable");
-        let reparsed: serde_json::Value =
-            serde_json::from_str(&raw).expect("peer-consumer fixture should parse as JSON");
+        // Inspect the peer metadata on the deserialized object directly. Reading
+        // the fixture JSON back and re-parsing it as a serde_json::Value would
+        // only prove the fixture file is well-formed, not that the registry
+        // deserializer preserves `peerDependencies` per
+        // `docs/specs/core/registry/SPEC.md`; the `ignored_field` deserializer
+        // could drop the field (or a future rename) and that round-trip would
+        // still pass. The fields are private but this test lives in the same
+        // module, so it can assert on them directly.
+        let consumer_peer = consumer
+            .version_metadata("1.0.0")
+            .expect("consumer carries the requested version")
+            .peer_dependencies
+            .as_ref();
         assert_eq!(
-            reparsed["versions"]["1.0.0"]["peerDependencies"]["@rpm-fixture/peer-target"], "^1.0.0",
-            "peer dependency metadata must be preserved on the packument"
+            consumer_peer.and_then(|map| map.get("@rpm-fixture/peer-target")),
+            Some(&"^1.0.0".to_string()),
+            "peer dependency metadata must survive deserialization on the packument"
+        );
+        assert!(
+            target
+                .version_metadata("1.0.0")
+                .expect("target carries the requested version")
+                .peer_dependencies
+                .is_none(),
+            "peer target carries no peer dependency metadata"
         );
     }
 

--- a/tests/fixtures/registry/peer-preserve/expected/resolved-packages.txt
+++ b/tests/fixtures/registry/peer-preserve/expected/resolved-packages.txt
@@ -1,0 +1,1 @@
+@rpm-fixture/peer-consumer@1.0.0 requested ^1.0.0

--- a/tests/fixtures/registry/peer-preserve/metadata/@rpm-fixture__peer-consumer.json
+++ b/tests/fixtures/registry/peer-preserve/metadata/@rpm-fixture__peer-consumer.json
@@ -1,0 +1,24 @@
+{
+  "_id": "@rpm-fixture/peer-consumer",
+  "name": "@rpm-fixture/peer-consumer",
+  "description": "Fixture package declaring a peer dependency that must be preserved, not enqueued",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/peer-consumer",
+      "version": "1.0.0",
+      "description": "Fixture package declaring a peer dependency that must be preserved, not enqueued",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/peer-consumer/-/peer-consumer-1.0.0.tgz",
+        "shasum": "fixture-peer-consumer-1.0.0",
+        "integrity": "sha512-fixture-peer-consumer-1.0.0"
+      },
+      "peerDependencies": {
+        "@rpm-fixture/peer-target": "^1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/registry/peer-preserve/metadata/@rpm-fixture__peer-target.json
+++ b/tests/fixtures/registry/peer-preserve/metadata/@rpm-fixture__peer-target.json
@@ -1,0 +1,21 @@
+{
+  "_id": "@rpm-fixture/peer-target",
+  "name": "@rpm-fixture/peer-target",
+  "description": "Fixture package that is a peer requirement target, intentionally not requested",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/peer-target",
+      "version": "1.0.0",
+      "description": "Fixture package that is a peer requirement target, intentionally not requested",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/peer-target/-/peer-target-1.0.0.tgz",
+        "shasum": "fixture-peer-target-1.0.0",
+        "integrity": "sha512-fixture-peer-target-1.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Contract

Closes #134 — compat: preserve peerDependencies metadata without ordinary enqueue.

The non-enqueue guard for `peerDependencies` was already stated in the manifest
(#131), resolver, and registry SPECs, but three done-criteria items from #134
were missing: (a) lockfile representation of peer metadata, (b) the
warn/fail behavior for unmet peer requirements, and (c) offline registry
fixture coverage proving metadata preservation and non-enqueue.

This patch closes those gaps:

- **lockfile v1 does not record peer/optional metadata.** A
  `relationship = "peer"` (or optional) value is not reserved; lockfile v1
  records only `direct`, `dev`, and `transitive`. The peer-aware or
  optional-aware strategy SPEC that first consumes these edges must add any
  lockfile representation.
- **Unmet peer requirements are not a resolution or install failure** under the
  non-peer-aware strategy. A package whose peer target is absent, wrong
  version, or otherwise unsatisfied still selects, downloads, verifies, and
  links normally. Warnings/errors for unmet peers are deferred to a peer-aware
  strategy SPEC. This is an intentional deferral: callers must not infer that
  a warning-free install means the peer set is satisfied.

## Changes

- `docs/specs/core/lockfile/SPEC.md`: add a paragraph stating
  `peerDependencies`/`optionalDependencies` are not recorded in lockfile v1 and
  no peer/optional `relationship` value is reserved.
- `docs/specs/core/resolver/SPEC.md`: add a paragraph defining unmet-peer
  behavior as a non-failure under the non-peer-aware strategy and deferring
  peer warnings to a future strategy SPEC.
- `tests/fixtures/registry/peer-preserve/`: offline registry packuments for
  `@rpm-fixture/peer-consumer` (carrying `peerDependencies`) and
  `@rpm-fixture/peer-target`, plus the expected `resolved-packages.txt`.
- `src/core/resolver/mod.rs`: test proving peer metadata is preserved, the peer
  consumer resolves with no ordinary dependency edges, and the peer target does
  not appear in the resolved graph (non-enqueue + unmet-peer non-failure).
- `src/lib/registry/mod.rs`: test proving `peerDependencies` does not surface as
  an ordinary dependency edge and survives a serde round-trip on the packument;
  the new fixture is added to the registry metadata shape check.

## Validation

- [x] `just format-check`
- [x] `just check`
- [x] `just lint` (clippy strict, `-D warnings`)
- [x] `just test` — 175 passed, 0 failed (includes the two new tests)
- [x] `just validate` — all code gates pass. `agent_assets.claude_security`
      fails on an untracked local `.claude/settings.local.json` allow rule;
      unrelated to this change (no such file is tracked or touched here).

## Checklist

- [x] Owning SPECs updated before implementation (lockfile, resolver).
- [x] Peer metadata preserved without ordinary enqueue.
- [x] Unmet peer requirement behavior specified (non-failure, deferred warnings).
- [x] Lockfile representation decision explicit (not recorded in v1).
- [x] Offline registry fixture added; no live npm used as oracle.
- [x] Resolver/registry fixtures do not mutate repo root, `.rpm`, `rpm.lock`, or `node_modules`.
