### PR TITLE
fix(registry): percent-encode scoped-name segment (%2F) in lookup path (#170)

### DIFF
--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -22,6 +22,7 @@ related_issues:
   - 127
   - 130
   - 136
+  - 170
 ---
 
 # Spec: Registry Metadata
@@ -292,12 +293,13 @@ use the raw scoped name (`@scope/name`), and only the registry lookup path
 percent-encodes it. This keeps one encoding rule at one boundary instead of
 duplicating it across lockfile, cache, and linking.
 
-The current production registry client (`src/lib/api/mod.rs`) assembles the
-lookup URL from the raw scoped name without percent-encoding the `/`. Offline
-fixture resolution routes `@scope/name` to a local `@scope__name.json` file, so
-this gap is not exercised by the fixture-backed test suite. A correct registry
-client must percent-encode `/` as `%2F` in the name segment before the network
-request; the code fix is tracked by a follow-up issue (see "Open Questions").
+The production registry client (`src/lib/api/mod.rs`) percent-encodes `/` as
+`%2F` in the name segment via `registry_lookup_url` before the network request
+(issue #170). Offline fixture resolution is unaffected: it routes
+`@scope/name` to a local `@scope__name.json` file and never reaches the
+production URL builder, so the fixture-backed test suite exercises the fixture
+mapping rather than the encoded path. The encoded-path derivation itself is
+covered by a focused unit test on `registry_lookup_url`.
 
 ## Error Cases
 
@@ -382,9 +384,3 @@ not duplicate the contract text above.
   currently rejected as input errors (issue #125); active consumption would
   require its own milestone, a lockfile record shape distinguishing install
   name from resolved name, and resolver changes, and is therefore deferred.
-- Percent-encoding `/` as `%2F` in the scoped-name segment of the registry
-  lookup path (see "Scoped package registry paths"). The contract is stated
-  here; the production registry client in `src/lib/api/mod.rs` does not yet
-  encode the name segment, and the offline fixture harness routes scoped names
-  to local files so the gap is unobserved by the fixture suite. The code fix is
-  tracked by #170.

--- a/src/lib/api/mod.rs
+++ b/src/lib/api/mod.rs
@@ -14,7 +14,7 @@ pub async fn get_registry(lib_name: &str, version: &str) -> std::io::Result<Regi
         return Ok(registry);
     }
 
-    let request_url = format!("{}/{}/{}", REGISTRY_PATH, lib_name, version);
+    let request_url = registry_lookup_url(lib_name, version);
     let registry = reqwest::get(&request_url)
         .await
         .map_err(|error| Error::other(format!("failed to fetch registry {request_url}: {error}")))?
@@ -45,13 +45,26 @@ pub async fn get_tarball(tarball_url: &str) -> std::io::Result<Vec<u8>> {
 }
 
 pub async fn get_registry_text(lib_name: &str, version: &str) -> std::io::Result<String> {
-    let request_url = format!("{}/{}/{}", REGISTRY_PATH, lib_name, version);
+    let request_url = registry_lookup_url(lib_name, version);
     reqwest::get(&request_url)
         .await
         .map_err(|error| Error::other(format!("failed to fetch registry {request_url}: {error}")))?
         .text()
         .await
         .map_err(|error| Error::other(format!("failed to read registry {request_url}: {error}")))
+}
+
+/// Assemble the registry lookup URL for a package name and version segment.
+///
+/// npm serves a scoped packument at a single path segment, so the scoped name
+/// (`@scope/name`) must be percent-encoded with `/` as `%2F` (for example
+/// `@babel/core` → `/@babel%2Fcore`). Unscoped names carry no `/` and remain
+/// byte-identical. The version segment stays a separate path component. The
+/// package identity stays verbatim everywhere else; only this registry lookup
+/// path encodes the name (see `docs/specs/core/registry/SPEC.md`).
+fn registry_lookup_url(lib_name: &str, version: &str) -> String {
+    let encoded_name = lib_name.replace('/', "%2F");
+    format!("{}/{encoded_name}/{version}", REGISTRY_PATH)
 }
 
 #[cfg(test)]
@@ -446,5 +459,19 @@ mod tests {
         assert!(error
             .to_string()
             .contains("invalid fixture tarball URL path"));
+    }
+
+    #[test]
+    fn registry_lookup_url_percent_encodes_scoped_name_segment() {
+        let url = registry_lookup_url("@babel/core", "2.3.1");
+        assert_eq!(url, "https://registry.npmjs.org/@babel%2Fcore/2.3.1");
+        assert!(url.contains("%2F"));
+    }
+
+    #[test]
+    fn registry_lookup_url_leaves_unscoped_name_unchanged() {
+        let url = registry_lookup_url("express", "4.18.2");
+        assert_eq!(url, "https://registry.npmjs.org/express/4.18.2");
+        assert!(!url.contains("%2F"));
     }
 }


### PR DESCRIPTION
## Contract

npm serves a scoped packument at a single path segment, so the registry lookup
path must encode the scoped name (`@scope/name`) as `@scope%2Fname` with the
version segment as a separate path component (for example `@babel/core` at
`2.3.1` → `/@babel%2Fcore/2.3.1`). This is the code implementation of the
"Scoped package registry paths" contract already merged in
`docs/specs/core/registry/SPEC.md` (#136 / PR #169). Unscoped names carry no
`/` and remain byte-identical. The package identity stays verbatim everywhere
else (resolver key, lockfile key, cache filename base, linker path); only the
registry lookup path encodes the name.

## Changes

- Introduce `registry_lookup_url(lib_name, version)` in `src/lib/api/mod.rs`
  that percent-encodes `/` as `%2F` in the name segment and keeps the version
  as a separate path component.
- Route both `get_registry` and `get_registry_text` through
  `registry_lookup_url` so the production network path encodes the scoped name.
- Add two focused unit tests on `registry_lookup_url`: one asserts the encoded
  path for a scoped name (`@babel/core` → `/@babel%2Fcore/2.3.1`, contains
  `%2F`), the other asserts an unscoped name is unchanged (`express` →
  `/express/4.18.2`, no `%2F`).
- Update `docs/specs/core/registry/SPEC.md` to reflect the implemented encoding
  (the "Scoped package registry paths" section no longer describes a gap) and
  remove the resolved Open Question that tracked this fix; add #170 to
  `related_issues`.

## Validation

- `just format-check` — pass.
- `just check` (`cargo check --locked --all-targets`) — pass.
- `just lint` (clippy strict, `-D warnings`) — pass.
- `just test` — 178 lib tests + 1 main test pass (0 failed), including the
  existing scoped fixture install test (`@rpm-fixture/alpha`) unchanged and the
  two new `registry_lookup_url` tests.
- pre-push hook re-ran clippy + full test suite — pass.
- `just validate` — every gate passes except `agent_assets.claude_security`,
  which fails on untracked local-only `.claude/settings.local.json` allow rules
  unrelated to this change (no `git ls-files` entry; pre-existing on `main`).

The offline fixture harness is unaffected: it routes `@scope/name` to a local
`@scope__name.json` file and never reaches the production URL builder, so the
fixture-backed test suite exercises the fixture mapping rather than the encoded
path. The encoded-path derivation itself is covered by the focused unit tests.

## Checklist

- [x] Scope is focused on one behavior, bug, or mechanical change.
- [x] Behavior changes include relevant tests or fixtures.
- [x] SPEC impact is classified when contract-affecting.
- [x] PR has at least one approved label: `enhancement`.
- [x] `Closes #` below is replaced with a real issue number.
- [x] PR is ready for review when implementation is complete.

Closes #170
