### PR TITLE
compat(specs): define optionalDependencies contract and non-enqueue guard (#133)

### DIFF
--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -70,7 +70,7 @@ RPM does not treat unsupported metadata as successful compatibility.
 | dist-tag and root metadata fallback gating | `registry/SPEC.md` | a dist-tag target absent from `versions` is rejected; root `dist` / `dependencies` fallback only applies to the legacy single-version shape | delivered: #114 landed via #118 |
 | dist-tags / `latest` / semver range selection boundary | `registry/SPEC.md`, `semver/SPEC.md` | dist-tags are registry selectors, not semver ranges; `latest` and tag precedence over ranges is defined | none |
 | build-metadata deterministic selection | `registry/SPEC.md` (Registry Boundary, precedence step 3) | registry-owned raw-key sort before `max_satisfying` makes selection repeatable across `HashMap` seedings | delivered: #115 / #117 landed |
-| optionalDependencies | `registry/SPEC.md` (ignored list) | classified as ignored (not enqueued); no active read / resolve / install / skip / report contract exists yet | draft: compat optionalDependencies contract |
+| optionalDependencies | `registry/SPEC.md` (ignored list), `resolver/SPEC.md` (non-enqueue guard and deferred optional-aware policy), `manifest/SPEC.md` (root read/preserve) | classified as ignored at the registry boundary with the non-optional-aware non-enqueue guard; root manifest reads and preserves `optionalDependencies` without consuming them; the deferred optional-aware strategy policy (skip-and-warn on resolution/download/install failure, skip-silently on platform mismatch, record only successful installs) is now owned by the resolver and lockfile SPECs; active optional-aware resolution and reporting remain deferred | delivered: #133 |
 | peerDependencies | `resolver/SPEC.md`, `registry/SPEC.md` (ignored list), `manifest/SPEC.md` (root read/preserve) | classified as ignored at the registry boundary with the non-peer-aware non-enqueue guard; root manifest reads and preserves `peerDependencies` without consuming them; active peer-aware resolution and diagnostics deferred | delivered: #130 |
 | engines, os, cpu | `registry/SPEC.md` (ignored list), `manifest/SPEC.md` (root read/preserve) | classified as ignored at the registry boundary with an explicit no-filtering/warning/rejection contract decision; root manifest reads and preserves npm-accurate `engines`/`os`/`cpu` without consuming them; active platform gating deferred | delivered: #127 |
 | package bin metadata | `linker/SPEC.md` (out of scope) | `.bin` generation is explicitly out of scope; `bin` is not modeled on registry types | M6 linker contract owns this |
@@ -87,18 +87,21 @@ Findings:
   `registry/SPEC.md` and `semver/SPEC.md`; the build-metadata deterministic
   tie-break closes the last selection-repeatability gap (#115 / #117).
 - The remaining M5 frontier is per-field classification: package bin metadata
-  and optional dependencies each need an active-behavior contract (or an
-  explicit deferred decision) before implementation. Each is represented by a
-  compat draft task in Project #7. Peer dependencies (#130) and engines, OS,
-  and CPU metadata (#127) now have explicit deferred policies: the registry
-  boundary classifies them as ignored, and the root manifest reads and preserves
-  them without consuming them. npm aliases (#125) now have both the
-  classification and the active rejection landed (via #129). Scoped package and
-  npm alias edge-case contracts (#136) are now explicit across resolver,
-  registry, lockfile, cache, and linker ownership: scoped names split and
-  round-trip verbatim everywhere except the one registry lookup path that must
-  percent-encode `/` as `%2F`, and the cache filename that rewrites `/` to `-`;
-  the `%2F` lookup-path code fix is tracked by a follow-up issue.
+  still needs an active-behavior contract (or an explicit deferred decision)
+  before implementation; it is represented by a compat draft task in Project #7.
+  Optional dependencies (#133) now join peer dependencies (#130) and engines,
+  OS, and CPU metadata (#127) with explicit deferred policies: the registry
+  boundary classifies `optionalDependencies` as ignored with the
+  non-optional-aware non-enqueue guard, the root manifest reads and preserves
+  them without consuming them, and the resolver and lockfile SPECs own the
+  reserved failure policy for a future optional-aware strategy. npm aliases
+  (#125) now have both the classification and the active rejection landed (via
+  #129). Scoped package and npm alias edge-case contracts (#136) are now
+  explicit across resolver, registry, lockfile, cache, and linker ownership:
+  scoped names split and round-trip verbatim everywhere except the one registry
+  lookup path that must percent-encode `/` as `%2F`, and the cache filename that
+  rewrites `/` to `-`; the `%2F` lookup-path code fix is tracked by a follow-up
+  issue.
 - Package `bin` metadata is intentionally deferred to the M6 linker milestone,
   where `.bin` generation is owned; it is listed here so the boundary is
   explicit, not so M5 implements it.

--- a/docs/specs/core/lockfile/SPEC.md
+++ b/docs/specs/core/lockfile/SPEC.md
@@ -14,6 +14,7 @@ related_adrs:
   - 0002-single-crate-cli-core-boundary
 related_issues:
   - 50
+  - 133
   - 136
 ---
 
@@ -96,6 +97,17 @@ phase consumes. Peer and optional metadata remain preserved on the manifest
 representation of unmet peer or optional requirements, must be added by the
 peer-aware or optional-aware strategy SPEC that first consumes them; lockfile
 v1 does not reserve those values.
+
+The reserved lockfile policy for the first optional-aware strategy is:
+optional dependencies that are installed successfully are recorded with the
+same shape as ordinary dependencies (requested range and resolved version kept
+distinct), and optional dependencies that are skipped at any lifecycle stage
+are not recorded. This keeps `rpm.lock` a record of the actually installed
+graph rather than the requested optional set, so a later install reproduces the
+same skip deterministically instead of re-attempting an entry known to be
+uninstallable on this platform. Whether the skipped set is summarized in a
+separate lockfile section is an open question for that strategy SPEC; lockfile
+v1 records nothing about optional edges either way.
 
 ### Loading
 

--- a/docs/specs/core/manifest/SPEC.md
+++ b/docs/specs/core/manifest/SPEC.md
@@ -16,6 +16,7 @@ related_issues:
   - 50
   - 127
   - 130
+  - 133
 ---
 
 # Spec: Package Manifest
@@ -57,7 +58,11 @@ lockfile, or linked `node_modules`. A manifest that omits
 This read-and-preserve baseline makes RPM honest about a field it accepts today.
 The full optional-aware behavior (resolve the entry as an ordinary dependency,
 attempt install, skip on failure, and report the outcome) is intentionally
-deferred until an optional-aware strategy SPEC owns it. Until then, a
+deferred until an optional-aware strategy SPEC owns it. The reserved failure
+policy for that future strategy — skip-and-warn on resolution, download, and
+install failures, skip-silently on platform mismatch, record only successful
+installs — is owned by `docs/specs/core/resolver/SPEC.md`, with the lockfile
+recording policy owned by `docs/specs/core/lockfile/SPEC.md`. Until then, a
 non-optional-aware strategy must not silently enqueue optional dependencies as
 ordinary dependencies; that non-enqueue guard is owned by
 `docs/specs/core/resolver/SPEC.md`. Per-version

--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -21,6 +21,7 @@ related_issues:
   - 125
   - 127
   - 130
+  - 133
   - 136
   - 170
 ---
@@ -358,6 +359,12 @@ Fixture expectations are defined by the owning scenario and documented in
   while a range that only contains `npm:` at a non-prefix position is not
   rejected; the `npm:` scheme is matched ASCII case-insensitively, so mixed-case
   prefixes such as `NPM:` and `Npm:` are rejected too (issue #125)
+- `optionalDependencies` is preserved on the deserialized packument (root and
+  per-version) but is not exposed as an ordinary dependency edge, mirroring the
+  `peerDependencies` non-enqueue guard; the `registry/optional-preserve` fixture
+  covers the current non-optional-aware contract (issue #133). The
+  `peerDependencies` non-enqueue guard is covered by the
+  `registry/peer-preserve` fixture (issue #130).
 
 New fixtures should cover dist metadata, dist-tags, dependencies, optional
 dependencies, peer dependencies, engines, OS/CPU, aliases, scoped packages, and
@@ -374,9 +381,15 @@ not duplicate the contract text above.
   is out of scope. The root manifest `optionalDependencies` read-and-preserve
   baseline is now owned by `docs/specs/core/manifest/SPEC.md`; per-version
   `optionalDependencies` on registry packuments remain ignored here until an
-  optional-aware strategy consumes them as dependency edges. The root manifest
-  `engines`/`os`/`cpu` read-and-preserve baseline is now owned by
-  `docs/specs/core/manifest/SPEC.md` (#127); per-version `engines`/`os`/`cpu`
+  optional-aware strategy consumes them as dependency edges. The reserved
+  failure policy for that future optional-aware strategy (skip-and-warn on
+  resolution/download/install failure, skip-silently on platform mismatch,
+  record only successful installs) is owned by
+  `docs/specs/core/resolver/SPEC.md` and `docs/specs/core/lockfile/SPEC.md`
+  (#133); until that strategy exists, per-version optional dependencies on
+  registry packuments stay ignored here regardless of the root-manifest entry.
+  The root manifest `engines`/`os`/`cpu` read-and-preserve baseline is now owned
+  by `docs/specs/core/manifest/SPEC.md` (#127); per-version `engines`/`os`/`cpu`
   on registry packuments remain ignored here until a platform-gating strategy
   consumes them.
 - When and how RPM begins actively consuming npm alias declarations (resolving

--- a/docs/specs/core/resolver/SPEC.md
+++ b/docs/specs/core/resolver/SPEC.md
@@ -17,6 +17,7 @@ related_issues:
   - 50
   - 58
   - 130
+  - 133
   - 136
 ---
 
@@ -150,6 +151,51 @@ ordinary dependencies. The read-and-preserve baseline is owned by
 registry packuments remain ignored at the registry boundary
 (`docs/specs/core/registry/SPEC.md`).
 
+The presence of an unsatisfiable or uninstalled optional dependency is not a
+resolution or install failure under the non-optional-aware strategy. RPM
+performs no optional-aware enqueueing, install attempt, skip, or reporting
+today: a package whose `optionalDependencies` entry is absent, the wrong
+version, or otherwise unsatisfiable still selects, downloads, verifies, and
+links normally, and the resolved graph contains only the package's ordinary
+dependencies. Optional dependencies do not appear in the lockfile
+(`docs/specs/core/lockfile/SPEC.md`). This is an intentional deferral, not an
+absence of policy: callers must not infer that an install succeeded without
+optional-dependency warnings means the optional set is satisfied.
+
+### Optional-aware strategy policy (deferred)
+
+The contract below is reserved for the first optional-aware strategy SPEC that
+consumes `optionalDependencies` as installable edges. It records the failure
+mode for each optional-dependency lifecycle stage so a future optional-aware
+resolver and installer do not have to re-derive the policy and cannot silently
+choose a different one. Until that strategy exists, the non-optional-aware
+behavior above is authoritative and this subsection imposes no new active
+behavior.
+
+| Optional dependency lifecycle stage | Failure policy |
+| --- | --- |
+| Resolution failure (unsatisfiable range, missing metadata, alias rejection) | Skip the optional entry and warn; the install must not fail |
+| Download or integrity failure (network error, unsupported integrity, digest mismatch) | Skip the optional entry and warn; the install must not fail |
+| Extract or link failure for the optional package | Skip the optional entry and warn; the install must not fail |
+| Platform skip (engines/os/cpu mismatch when a platform-gating strategy owns it) | Skip the optional entry silently; platform-incompatible optional dependencies are expected and must not warn |
+
+An optional dependency that succeeds through every reached stage is recorded in
+the resolved graph and lockfile exactly like an ordinary dependency, with its
+requested range and resolved version kept distinct
+(`docs/specs/core/lockfile/SPEC.md`). A skipped optional dependency is not
+recorded: the lockfile reflects the actually installed graph, not the requested
+optional set, so a later install reproduces the same skip rather than re-attempting
+an entry that was known to be uninstallable on this platform. The skip decision
+itself must remain deterministic given the same metadata, registry state, and
+platform inputs; it must not depend on iteration order, network timing, or an
+uncontrolled clock.
+
+Optional-dependency warnings and exit behavior are deferred to a diagnostics
+SPEC (`docs/specs/core/lockfile/SPEC.md` records the lockfile deferral and
+issue #151 tracks diagnostics ownership): a warning must not be exposed as
+stable stderr or as a non-zero exit code until the owning diagnostics SPEC
+exists.
+
 The installer performance baseline in
 `docs/specs/core/install/performance/SPEC.md`
 documents the current recursive bottleneck and the measurement fixture for
@@ -182,6 +228,36 @@ resolver fixtures should not mutate the repository root, `.rpm`, `rpm.lock`, or
 The semver baseline fixtures are defined by
 `docs/specs/core/semver/SPEC.md` and must be used before installer flow relies
 on semver range behavior.
+
+### Optional-dependency non-enqueue guard fixture
+
+The `registry/optional-preserve` fixture proves the current non-optional-aware
+contract: a package whose only edge is an `optionalDependencies` entry resolves
+without enqueueing the optional target and without failing resolution. It
+mirrors the `registry/peer-preserve` fixture used for the peer non-enqueue
+guard. This is current-behavior coverage, not optional-aware implementation.
+
+### Planned optional-aware fixtures (for implementation follow-up)
+
+The scenarios below are listed for the optional-aware strategy that first
+consumes `optionalDependencies` as installable edges. They are not part of the
+current non-optional-aware test set; each must be paired with an owning
+implementation that follows the failure policy in
+"Optional-aware strategy policy (deferred)":
+
+- Successful optional dependency: the entry resolves, downloads, verifies, and
+  links, and the lockfile records it like an ordinary dependency.
+- Unavailable optional dependency (missing metadata or unsatisfiable range):
+  resolution skips the entry and warns, the install succeeds, and the lockfile
+  omits the skipped entry.
+- Optional dependency download or integrity failure: the install skips the
+  entry and warns, and the lockfile omits it.
+- Optional dependency extract or link failure: the install skips the entry and
+  warns, the rest of the install completes, and the lockfile omits it.
+- Platform-incompatible optional dependency (once a platform-gating strategy
+  exists): the entry is skipped silently and the lockfile omits it.
+- Deterministic skip: the same metadata, registry state, and platform inputs
+  produce the same skip decision across repeated installs.
 
 ## Resolved Follow-Up
 

--- a/docs/specs/core/resolver/SPEC.md
+++ b/docs/specs/core/resolver/SPEC.md
@@ -185,10 +185,20 @@ requested range and resolved version kept distinct
 (`docs/specs/core/lockfile/SPEC.md`). A skipped optional dependency is not
 recorded: the lockfile reflects the actually installed graph, not the requested
 optional set, so a later install reproduces the same skip rather than re-attempting
-an entry that was known to be uninstallable on this platform. The skip decision
-itself must remain deterministic given the same metadata, registry state, and
-platform inputs; it must not depend on iteration order, network timing, or an
-uncontrolled clock.
+an entry that was known to be uninstallable on this platform.
+
+The determinism requirement below applies only to skip decisions driven by
+deterministic inputs: a skip from an unsatisfiable range, missing metadata,
+alias rejection, unsupported integrity, or platform mismatch must be reproducible
+given the same metadata, registry state, and platform inputs, and must not
+depend on iteration order or an uncontrolled clock. A skip from a transient
+download or integrity failure (network error, digest mismatch) is a different
+case: it must produce the same skip outcome and warn at the time of the failure,
+but it is explicitly not required to be reproducible on the next install, because
+the triggering input (registry availability, network state) is itself
+non-deterministic. A later install must therefore be free to re-attempt an entry
+that skipped only because of a transient failure; only entries that skipped for a
+deterministic reason are expected to reproduce the skip.
 
 Optional-dependency warnings and exit behavior are deferred to a diagnostics
 SPEC (`docs/specs/core/lockfile/SPEC.md` records the lockfile deferral and

--- a/src/core/resolver/mod.rs
+++ b/src/core/resolver/mod.rs
@@ -564,6 +564,50 @@ mod tests {
     }
 
     #[test]
+    fn optional_dependency_metadata_is_preserved_without_enqueue_or_install_failure() {
+        let root = fixture_path(&["registry", "optional-preserve", "metadata"]);
+        let provider = FixtureMetadataProvider::from_fixture_root(&root);
+
+        // Request only the optional consumer. Its only edge is an
+        // `optionalDependencies` entry; the optional target is never requested
+        // directly. This is the non-optional-aware contract: a package whose
+        // only edge is optional must still resolve normally, and the optional
+        // entry must not be enqueued as an ordinary dependency. Mirrors the peer
+        // non-enqueue guard above; owned by
+        // `docs/specs/core/resolver/SPEC.md` (issue #133).
+        let graph = resolve_dependency_graph(
+            vec![DependencyRequest::new(
+                "@rpm-fixture/optional-consumer",
+                "^1.0.0",
+                DependencyRequestKind::DirectProduction,
+            )],
+            &provider,
+        )
+        .expect(
+            "uninstalled optional dependency must not fail resolution under the \
+             non-optional-aware strategy",
+        );
+
+        // The optional target must NOT be enqueued as an ordinary dependency:
+        // the graph contains only the consumer.
+        assert_eq!(graph.packages().len(), 1);
+        let consumer = graph
+            .package("@rpm-fixture/optional-consumer", "1.0.0")
+            .expect("optional consumer resolves to a graph node");
+        assert!(
+            consumer.dependencies.is_empty(),
+            "optionalDependencies must not become ordinary dependency edges"
+        );
+        assert!(
+            graph
+                .package("@rpm-fixture/optional-target", "1.0.0")
+                .is_none(),
+            "optional target must not appear in the resolved graph before an \
+             optional-aware strategy exists"
+        );
+    }
+
+    #[test]
     fn failed_version_selection_stops_before_reading_dependency_metadata() {
         let provider = FailingSelectionProvider {
             dependency_reads: Cell::new(0),

--- a/src/lib/registry/mod.rs
+++ b/src/lib/registry/mod.rs
@@ -1064,6 +1064,7 @@ mod tests {
         let fixture_roots = [
             "tests/fixtures/registry/shared-transitive/metadata",
             "tests/fixtures/registry/peer-preserve/metadata",
+            "tests/fixtures/registry/optional-preserve/metadata",
             "tests/fixtures/install-projects/lockfile-reproducible/registry",
             "tests/fixtures/install-projects/integrity-mismatch/registry",
             "tests/fixtures/install-projects/output-failure-after-resolution/registry",
@@ -1163,6 +1164,58 @@ mod tests {
                 .peer_dependencies
                 .is_none(),
             "peer target carries no peer dependency metadata"
+        );
+    }
+
+    #[test]
+    fn optional_dependencies_are_preserved_without_appearing_as_dependency_edges() {
+        let root = fixture_path(&["registry", "optional-preserve", "metadata"]);
+
+        let consumer = load_registry_fixture(&root, "@rpm-fixture/optional-consumer", "1.0.0");
+        let target = load_registry_fixture(&root, "@rpm-fixture/optional-target", "1.0.0");
+
+        // Optional metadata is preserved on the packument (the fixture carries
+        // it and deserialization succeeds, proven by load_registry_fixture), but
+        // it is not exposed as an ordinary dependency edge. The consumer has no
+        // `dependencies`, only `optionalDependencies`; the target is never
+        // requested. This mirrors the peerDependencies non-enqueue guard
+        // (`peer_dependencies_are_preserved_without_appearing_as_dependency_edges`)
+        // and is the current non-optional-aware contract owned by
+        // `docs/specs/core/registry/SPEC.md` (issue #133).
+        assert!(
+            consumer.get_dependencies_for_version("1.0.0").is_empty(),
+            "optional dependency must not surface as an ordinary dependency edge"
+        );
+        assert!(
+            target.get_dependencies_for_version("1.0.0").is_empty(),
+            "optional target has no ordinary dependencies"
+        );
+
+        // Inspect the optional metadata on the deserialized object directly.
+        // Reading the fixture JSON back and re-parsing it as a serde_json::Value
+        // would only prove the fixture file is well-formed, not that the
+        // registry deserializer preserves `optionalDependencies` per
+        // `docs/specs/core/registry/SPEC.md`; the `ignored_field` deserializer
+        // could drop the field (or a future rename) and that round-trip would
+        // still pass. The fields are private but this test lives in the same
+        // module, so it can assert on them directly.
+        let consumer_optional = consumer
+            .version_metadata("1.0.0")
+            .expect("consumer carries the requested version")
+            .optional_dependencies
+            .as_ref();
+        assert_eq!(
+            consumer_optional.and_then(|map| map.get("@rpm-fixture/optional-target")),
+            Some(&"^1.0.0".to_string()),
+            "optional dependency metadata must survive deserialization on the packument"
+        );
+        assert!(
+            target
+                .version_metadata("1.0.0")
+                .expect("target carries the requested version")
+                .optional_dependencies
+                .is_none(),
+            "optional target carries no optional dependency metadata"
         );
     }
 

--- a/tests/fixtures/registry/optional-preserve/expected/resolved-packages.txt
+++ b/tests/fixtures/registry/optional-preserve/expected/resolved-packages.txt
@@ -1,0 +1,1 @@
+@rpm-fixture/optional-consumer@1.0.0 requested ^1.0.0

--- a/tests/fixtures/registry/optional-preserve/metadata/@rpm-fixture__optional-consumer.json
+++ b/tests/fixtures/registry/optional-preserve/metadata/@rpm-fixture__optional-consumer.json
@@ -1,0 +1,24 @@
+{
+  "_id": "@rpm-fixture/optional-consumer",
+  "name": "@rpm-fixture/optional-consumer",
+  "description": "Fixture package declaring an optional dependency that must be preserved, not enqueued",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/optional-consumer",
+      "version": "1.0.0",
+      "description": "Fixture package declaring an optional dependency that must be preserved, not enqueued",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/optional-consumer/-/optional-consumer-1.0.0.tgz",
+        "shasum": "fixture-optional-consumer-1.0.0",
+        "integrity": "sha512-fixture-optional-consumer-1.0.0"
+      },
+      "optionalDependencies": {
+        "@rpm-fixture/optional-target": "^1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/registry/optional-preserve/metadata/@rpm-fixture__optional-target.json
+++ b/tests/fixtures/registry/optional-preserve/metadata/@rpm-fixture__optional-target.json
@@ -1,0 +1,21 @@
+{
+  "_id": "@rpm-fixture/optional-target",
+  "name": "@rpm-fixture/optional-target",
+  "description": "Fixture package that is an optional dependency target, intentionally not requested",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/optional-target",
+      "version": "1.0.0",
+      "description": "Fixture package that is an optional dependency target, intentionally not requested",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/optional-target/-/optional-target-1.0.0.tgz",
+        "shasum": "fixture-optional-target-1.0.0",
+        "integrity": "sha512-fixture-optional-target-1.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Contract

Closes #133.

Issue #133 asks RPM to decide, before implementation, how optionalDependencies are read, resolved, installed, skipped, recorded, and reported. This PR owns the contract rather than adding active optional-aware behavior.

SPEC status: stale / clarification. The current non-optional-aware baseline was less explicit than the peer baseline (PR #168 / #130): the non-enqueue guard existed only as resolver prose with no fixture or test, and no forward failure policy was recorded for the first optional-aware strategy. This PR brings optionalDependencies to the same ownership level as peerDependencies and reserves the optional-aware policy.

No active optional-aware behavior is introduced. This is contract ownership work, not implementation.

## Changes

- `docs/specs/core/resolver/SPEC.md` — add the non-enqueue guard prose for optionalDependencies, an explicit "uninstalled optional is not a failure" statement, a deferred optional-aware strategy policy table (skip-and-warn on resolution/download/install failure; skip-silently on platform mismatch; record only successful installs; deterministic skip), and planned fixture scenarios for the implementation follow-up.
- `docs/specs/core/lockfile/SPEC.md` — reserve the v1 recording policy: installed optional edges are recorded like ordinary dependencies; skipped optional edges are not recorded, so a later install reproduces the same skip deterministically.
- `docs/specs/core/manifest/SPEC.md` — point the read-and-preserve baseline at the resolver/lockfile deferred policy instead of re-deriving it.
- `docs/specs/core/registry/SPEC.md` — extend the Open Questions note so per-version optionalDependencies stays ignored until the optional-aware strategy consumes it; document the non-enqueue guard fixture coverage.
- `docs/specs/core/README.md` — mark the M5 optionalDependencies audit row delivered (#133).
- `tests/fixtures/registry/optional-preserve/` — new fixture mirroring `registry/peer-preserve`.
- `src/lib/registry/mod.rs` — `optional_dependencies_are_preserved_without_appearing_as_dependency_edges` guard test; register the new fixture root in the metadata-shape sanity test.
- `src/core/resolver/mod.rs` — `optional_dependency_metadata_is_preserved_without_enqueue_or_install_failure` guard test.

## Deferred policy summary (for the future optional-aware strategy)

| Optional dependency lifecycle stage | Failure policy |
| --- | --- |
| Resolution failure (unsatisfiable range, missing metadata, alias rejection) | Skip + warn; install must not fail |
| Download or integrity failure | Skip + warn; install must not fail |
| Extract or link failure | Skip + warn; install must not fail |
| Platform skip (engines/os/cpu, once platform-gating exists) | Skip silently |
| Lockfile | Record on success; omit on skip |

Warnings and exit behavior are deferred to diagnostics ownership (#151 / M8).

## Validation

- [x] `just format-check`
- [x] `just check`
- [x] `just lint`
- [x] `just test` — 180 lib + 1 bin passed; both new optional guard tests pass
- [x] `just audit-fixtures` — new fixture passes the structure audit
- [x] `just fixture-smoke`
- [x] `just docs`
- `just agent-assets` fails on `.claude/settings.local.json` unreviewed allow rules; this is a pre-existing local-config issue reproducible on `main` and unrelated to this change.

## Checklist

- [x] Owning SPECs updated before implementation (#133 done criterion)
- [x] Failure policy explicit per lifecycle stage (#133 done criterion)
- [x] Lockfile representation specified (record on success, omit on skip) (#133 done criterion)
- [x] Fixture scenarios listed for implementation follow-up (#133 done criterion)
- [x] No active optional-aware behavior introduced
- [x] No behavior change for existing installs