### PR TITLE
test(fixtures): add npm compatibility fixtures for dist-tags, prerelease, engines/os/cpu

### DIFF
--- a/src/core/resolver/mod.rs
+++ b/src/core/resolver/mod.rs
@@ -730,4 +730,179 @@ mod tests {
             );
         }
     }
+
+    // M5 compatibility fixtures (issue #137). These cover the scenarios not
+    // already exercised by the peer-preserve (#134/#135) and optional-preserve
+    // (#133) fixtures above: dist-tag edge cases, prerelease exclusion, and
+    // engines/os/cpu preservation without filtering. Each scenario follows the
+    // same offline-registry + expected-list contract.
+
+    #[test]
+    fn dist_tag_spec_resolves_to_tagged_version() {
+        // A dependency request whose range text names a dist-tag (other than
+        // `latest`) resolves to that tag's target version. Owned by
+        // `docs/specs/core/registry/SPEC.md`: only requests that are not
+        // registry dist-tags are evaluated as semver ranges.
+        let root = fixture_path(&["registry", "dist-tags-edge", "metadata"]);
+        let provider = FixtureMetadataProvider::from_fixture_root(&root);
+
+        let graph = resolve_dependency_graph(
+            vec![DependencyRequest::new(
+                "@rpm-fixture/tag-consumer",
+                "^1.0.0",
+                DependencyRequestKind::DirectProduction,
+            )],
+            &provider,
+        )
+        .expect("dist-tag dependency edge should resolve");
+
+        let expected = fs::read_to_string(fixture_path(&[
+            "registry",
+            "dist-tags-edge",
+            "expected",
+            "resolved-packages.txt",
+        ]))
+        .expect("expected resolved package list should be readable");
+        let resolved = graph
+            .packages()
+            .iter()
+            .map(|package| {
+                format!(
+                    "{}@{} requested {}",
+                    package.package_name, package.version, package.requests[0].requested
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(format!("{resolved}\n"), expected);
+
+        // The consumer's only edge requested the `legacy` dist-tag, which must
+        // resolve to 1.0.0 rather than the `latest`/`stable` target of 1.2.0.
+        let tagged = graph
+            .package("@rpm-fixture/tagged", "1.0.0")
+            .expect("dist-tag target should resolve to the tagged version");
+        assert_eq!(tagged.requests[0].requested, "legacy");
+    }
+
+    #[test]
+    fn dangling_dist_tag_target_is_rejected_as_unsatisfied() {
+        // A dist-tag whose target version is absent from the `versions` map is
+        // rejected at selection time rather than returning a version key with
+        // no per-version metadata (issue #114, owned by
+        // `docs/specs/core/registry/SPEC.md`).
+        let root = fixture_path(&["registry", "dist-tags-edge", "metadata"]);
+        let provider = FixtureMetadataProvider::from_fixture_root(&root);
+
+        let error = resolve_dependency_graph(
+            vec![DependencyRequest::new(
+                "@rpm-fixture/dangling-tag",
+                "latest",
+                DependencyRequestKind::DirectProduction,
+            )],
+            &provider,
+        )
+        .expect_err("a dist-tag pointing at an absent version must fail resolution");
+
+        assert!(matches!(error, ResolutionError::VersionSelection { .. }));
+    }
+
+    #[test]
+    fn prerelease_version_is_excluded_from_normal_range_match() {
+        // node-semver excludes prerelease versions from range matches unless the
+        // range itself carries a prerelease at the same [major, minor, patch]
+        // tuple. A consumer requesting `^1.0.0` against a package that also
+        // publishes `1.1.0-beta.1` must resolve to the stable `1.0.0`. Owned by
+        // `docs/specs/core/semver/SPEC.md` (no RPM-specific semver dialect).
+        let root = fixture_path(&["registry", "prerelease-edge", "metadata"]);
+        let provider = FixtureMetadataProvider::from_fixture_root(&root);
+
+        let graph = resolve_dependency_graph(
+            vec![DependencyRequest::new(
+                "@rpm-fixture/prerelease-consumer",
+                "^1.0.0",
+                DependencyRequestKind::DirectProduction,
+            )],
+            &provider,
+        )
+        .expect("prerelease exclusion should not fail resolution");
+
+        let expected = fs::read_to_string(fixture_path(&[
+            "registry",
+            "prerelease-edge",
+            "expected",
+            "resolved-packages.txt",
+        ]))
+        .expect("expected resolved package list should be readable");
+        let resolved = graph
+            .packages()
+            .iter()
+            .map(|package| {
+                format!(
+                    "{}@{} requested {}",
+                    package.package_name, package.version, package.requests[0].requested
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(format!("{resolved}\n"), expected);
+
+        // The stable release must win over the prerelease.
+        let prerelease = graph
+            .package("@rpm-fixture/prerelease", "1.0.0")
+            .expect("stable release should be selected over the prerelease");
+        assert_eq!(prerelease.version, "1.0.0");
+        assert!(
+            graph
+                .package("@rpm-fixture/prerelease", "1.1.0-beta.1")
+                .is_none(),
+            "prerelease must not be selected by a non-prerelease range"
+        );
+    }
+
+    #[test]
+    fn engines_os_cpu_metadata_does_not_filter_version_selection() {
+        // RPM deserializes `engines`, `os`, and `cpu` with npm-accurate types
+        // but applies no filtering, warning, skip, or rejection policy at the
+        // registry boundary. A package declaring an incompatible platform still
+        // selects, so a consumer resolves normally. Owned by
+        // `docs/specs/core/registry/SPEC.md`.
+        let root = fixture_path(&["registry", "engines-os-cpu-preserve", "metadata"]);
+        let provider = FixtureMetadataProvider::from_fixture_root(&root);
+
+        let graph = resolve_dependency_graph(
+            vec![DependencyRequest::new(
+                "@rpm-fixture/platform-consumer",
+                "^1.0.0",
+                DependencyRequestKind::DirectProduction,
+            )],
+            &provider,
+        )
+        .expect("restrictive engines/os/cpu must not fail resolution");
+
+        let expected = fs::read_to_string(fixture_path(&[
+            "registry",
+            "engines-os-cpu-preserve",
+            "expected",
+            "resolved-packages.txt",
+        ]))
+        .expect("expected resolved package list should be readable");
+        let resolved = graph
+            .packages()
+            .iter()
+            .map(|package| {
+                format!(
+                    "{}@{} requested {}",
+                    package.package_name, package.version, package.requests[0].requested
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(format!("{resolved}\n"), expected);
+
+        // The platform-strict package must still be selected despite declaring
+        // `node >=99.0.0`, `os: ["!win32","!darwin"]`, and `cpu: ["x64"]`.
+        graph
+            .package("@rpm-fixture/platform-strict", "1.0.0")
+            .expect("platform-restrictive version must still resolve");
+    }
 }

--- a/src/core/resolver/mod.rs
+++ b/src/core/resolver/mod.rs
@@ -803,7 +803,13 @@ mod tests {
         )
         .expect_err("a dist-tag pointing at an absent version must fail resolution");
 
-        assert!(matches!(error, ResolutionError::VersionSelection { .. }));
+        assert!(matches!(
+            error,
+            ResolutionError::VersionSelection {
+                source: crate::core::resolver::semver::SemverError::UnsatisfiedRange { range },
+                ..
+            } if range == "latest"
+        ));
     }
 
     #[test]
@@ -900,7 +906,7 @@ mod tests {
         assert_eq!(format!("{resolved}\n"), expected);
 
         // The platform-strict package must still be selected despite declaring
-        // `node >=99.0.0`, `os: ["!win32","!darwin"]`, and `cpu: ["x64"]`.
+        // `node >=99.0.0`, `os: ["plan9"]`, and `cpu: ["ia64"]`.
         graph
             .package("@rpm-fixture/platform-strict", "1.0.0")
             .expect("platform-restrictive version must still resolve");

--- a/tests/fixtures/registry/dist-tags-edge/expected/resolved-packages.txt
+++ b/tests/fixtures/registry/dist-tags-edge/expected/resolved-packages.txt
@@ -1,0 +1,2 @@
+@rpm-fixture/tag-consumer@1.0.0 requested ^1.0.0
+@rpm-fixture/tagged@1.0.0 requested legacy

--- a/tests/fixtures/registry/dist-tags-edge/metadata/@rpm-fixture__dangling-tag.json
+++ b/tests/fixtures/registry/dist-tags-edge/metadata/@rpm-fixture__dangling-tag.json
@@ -1,0 +1,22 @@
+{
+  "_id": "@rpm-fixture/dangling-tag",
+  "name": "@rpm-fixture/dangling-tag",
+  "description": "Fixture package whose latest dist-tag targets a version absent from the versions map",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/dangling-tag",
+      "version": "1.0.0",
+      "description": "Fixture package whose latest dist-tag targets a version absent from the versions map",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/dangling-tag/-/dangling-tag-1.0.0.tgz",
+        "shasum": "fixture-dangling-tag-1.0.0",
+        "integrity": "sha512-fixture-dangling-tag-1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/registry/dist-tags-edge/metadata/@rpm-fixture__tag-consumer.json
+++ b/tests/fixtures/registry/dist-tags-edge/metadata/@rpm-fixture__tag-consumer.json
@@ -1,0 +1,24 @@
+{
+  "_id": "@rpm-fixture/tag-consumer",
+  "name": "@rpm-fixture/tag-consumer",
+  "description": "Fixture consumer that requests @rpm-fixture/tagged through dist-tag specs (latest, stable, legacy)",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/tag-consumer",
+      "version": "1.0.0",
+      "description": "Fixture consumer that requests @rpm-fixture/tagged through dist-tag specs (latest, stable, legacy)",
+      "dependencies": {
+        "@rpm-fixture/tagged": "legacy"
+      },
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/tag-consumer/-/tag-consumer-1.0.0.tgz",
+        "shasum": "fixture-tag-consumer-1.0.0",
+        "integrity": "sha512-fixture-tag-consumer-1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/registry/dist-tags-edge/metadata/@rpm-fixture__tagged.json
+++ b/tests/fixtures/registry/dist-tags-edge/metadata/@rpm-fixture__tagged.json
@@ -1,0 +1,46 @@
+{
+  "_id": "@rpm-fixture/tagged",
+  "name": "@rpm-fixture/tagged",
+  "description": "Fixture package with multiple dist-tags covering latest, stable, and legacy tag resolution",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.2.0",
+    "stable": "1.2.0",
+    "legacy": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/tagged",
+      "version": "1.0.0",
+      "description": "Fixture package with multiple dist-tags covering latest, stable, and legacy tag resolution",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/tagged/-/tagged-1.0.0.tgz",
+        "shasum": "fixture-tagged-1.0.0",
+        "integrity": "sha512-fixture-tagged-1.0.0"
+      }
+    },
+    "1.1.0": {
+      "name": "@rpm-fixture/tagged",
+      "version": "1.1.0",
+      "description": "Fixture package with multiple dist-tags covering latest, stable, and legacy tag resolution",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/tagged/-/tagged-1.1.0.tgz",
+        "shasum": "fixture-tagged-1.1.0",
+        "integrity": "sha512-fixture-tagged-1.1.0"
+      }
+    },
+    "1.2.0": {
+      "name": "@rpm-fixture/tagged",
+      "version": "1.2.0",
+      "description": "Fixture package with multiple dist-tags covering latest, stable, and legacy tag resolution",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/tagged/-/tagged-1.2.0.tgz",
+        "shasum": "fixture-tagged-1.2.0",
+        "integrity": "sha512-fixture-tagged-1.2.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/registry/engines-os-cpu-preserve/expected/resolved-packages.txt
+++ b/tests/fixtures/registry/engines-os-cpu-preserve/expected/resolved-packages.txt
@@ -1,0 +1,2 @@
+@rpm-fixture/platform-consumer@1.0.0 requested ^1.0.0
+@rpm-fixture/platform-strict@1.0.0 requested ^1.0.0

--- a/tests/fixtures/registry/engines-os-cpu-preserve/metadata/@rpm-fixture__platform-consumer.json
+++ b/tests/fixtures/registry/engines-os-cpu-preserve/metadata/@rpm-fixture__platform-consumer.json
@@ -1,0 +1,24 @@
+{
+  "_id": "@rpm-fixture/platform-consumer",
+  "name": "@rpm-fixture/platform-consumer",
+  "description": "Fixture consumer that requests a package declaring incompatible engines, os, and cpu without failing resolution",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/platform-consumer",
+      "version": "1.0.0",
+      "description": "Fixture consumer that requests a package declaring incompatible engines, os, and cpu without failing resolution",
+      "dependencies": {
+        "@rpm-fixture/platform-strict": "^1.0.0"
+      },
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/platform-consumer/-/platform-consumer-1.0.0.tgz",
+        "shasum": "fixture-platform-consumer-1.0.0",
+        "integrity": "sha512-fixture-platform-consumer-1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/registry/engines-os-cpu-preserve/metadata/@rpm-fixture__platform-strict.json
+++ b/tests/fixtures/registry/engines-os-cpu-preserve/metadata/@rpm-fixture__platform-strict.json
@@ -16,11 +16,10 @@
         "node": ">=99.0.0"
       },
       "os": [
-        "!win32",
-        "!darwin"
+        "plan9"
       ],
       "cpu": [
-        "x64"
+        "ia64"
       ],
       "dist": {
         "tarball": "https://registry.example.invalid/@rpm-fixture/platform-strict/-/platform-strict-1.0.0.tgz",

--- a/tests/fixtures/registry/engines-os-cpu-preserve/metadata/@rpm-fixture__platform-strict.json
+++ b/tests/fixtures/registry/engines-os-cpu-preserve/metadata/@rpm-fixture__platform-strict.json
@@ -1,0 +1,32 @@
+{
+  "_id": "@rpm-fixture/platform-strict",
+  "name": "@rpm-fixture/platform-strict",
+  "description": "Fixture package declaring restrictive engines, os, and cpu metadata that must not trigger filtering at the registry boundary",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/platform-strict",
+      "version": "1.0.0",
+      "description": "Fixture package declaring restrictive engines, os, and cpu metadata that must not trigger filtering at the registry boundary",
+      "dependencies": {},
+      "engines": {
+        "node": ">=99.0.0"
+      },
+      "os": [
+        "!win32",
+        "!darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/platform-strict/-/platform-strict-1.0.0.tgz",
+        "shasum": "fixture-platform-strict-1.0.0",
+        "integrity": "sha512-fixture-platform-strict-1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/registry/prerelease-edge/expected/resolved-packages.txt
+++ b/tests/fixtures/registry/prerelease-edge/expected/resolved-packages.txt
@@ -1,0 +1,2 @@
+@rpm-fixture/prerelease-consumer@1.0.0 requested ^1.0.0
+@rpm-fixture/prerelease@1.0.0 requested ^1.0.0

--- a/tests/fixtures/registry/prerelease-edge/metadata/@rpm-fixture__prerelease-consumer.json
+++ b/tests/fixtures/registry/prerelease-edge/metadata/@rpm-fixture__prerelease-consumer.json
@@ -1,0 +1,24 @@
+{
+  "_id": "@rpm-fixture/prerelease-consumer",
+  "name": "@rpm-fixture/prerelease-consumer",
+  "description": "Fixture consumer that requests @rpm-fixture/prerelease with a range excluding prereleases",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/prerelease-consumer",
+      "version": "1.0.0",
+      "description": "Fixture consumer that requests @rpm-fixture/prerelease with a range excluding prereleases",
+      "dependencies": {
+        "@rpm-fixture/prerelease": "^1.0.0"
+      },
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/prerelease-consumer/-/prerelease-consumer-1.0.0.tgz",
+        "shasum": "fixture-prerelease-consumer-1.0.0",
+        "integrity": "sha512-fixture-prerelease-consumer-1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/registry/prerelease-edge/metadata/@rpm-fixture__prerelease.json
+++ b/tests/fixtures/registry/prerelease-edge/metadata/@rpm-fixture__prerelease.json
@@ -1,0 +1,33 @@
+{
+  "_id": "@rpm-fixture/prerelease",
+  "name": "@rpm-fixture/prerelease",
+  "description": "Fixture package mixing a stable release and a prerelease to exercise node-semver prerelease exclusion",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/prerelease",
+      "version": "1.0.0",
+      "description": "Fixture package mixing a stable release and a prerelease to exercise node-semver prerelease exclusion",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/prerelease/-/prerelease-1.0.0.tgz",
+        "shasum": "fixture-prerelease-1.0.0",
+        "integrity": "sha512-fixture-prerelease-1.0.0"
+      }
+    },
+    "1.1.0-beta.1": {
+      "name": "@rpm-fixture/prerelease",
+      "version": "1.1.0-beta.1",
+      "description": "Fixture package mixing a stable release and a prerelease to exercise node-semver prerelease exclusion",
+      "dependencies": {},
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/prerelease/-/prerelease-1.1.0-beta.1.tgz",
+        "shasum": "fixture-prerelease-1.1.0-beta.1",
+        "integrity": "sha512-fixture-prerelease-1.1.0-beta.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Contract

Closes #137.

No SPEC change. This PR adds offline registry fixtures for the three M5 compatibility scenarios listed in #137 that were **not** already covered by existing fixtures:

| Scenario | Already covered? | This PR |
| --- | --- | --- |
| optionalDependencies (#133) | ✅ `registry/optional-preserve/` | — |
| peerDependencies (#134/#135) | ✅ `registry/peer-preserve/` | — |
| npm alias (#136) | ✅ resolver reject tests | — |
| scoped packages (#136/#171) | ✅ `@rpm-fixture/*` everywhere | — |
| **dist-tags edge cases** | ❌ | ✅ `registry/dist-tags-edge/` |
| **prerelease edge cases** | ❌ | ✅ `registry/prerelease-edge/` |
| **engines / os / cpu** | ❌ | ✅ `registry/engines-os-cpu-preserve/` |

Owning SPECs (unchanged, asserted by tests):
- `docs/specs/core/registry/SPEC.md` — dist-tag resolution order, dangling-tag rejection (#114), engines/os/cpu no-filter policy
- `docs/specs/core/semver/SPEC.md` — prerelease exclusion (no RPM-specific dialect)

## Changes

Three new `registry/` fixtures, each following the established `metadata/` + `expected/resolved-packages.txt` offline-registry contract:

1. **`dist-tags-edge/`** — `@rpm-fixture/tagged` exposes `latest`/`stable`/`legacy` tags; `@rpm-fixture/tag-consumer` requests it via the `legacy` dist-tag (resolves to `1.0.0`, not the `latest` target `1.2.0`). `@rpm-fixture/dangling-tag` has `latest` pointing at a version absent from `versions`, exercising the #114 rejection guard.

2. **`prerelease-edge/`** — `@rpm-fixture/prerelease` publishes `1.0.0` (stable) and `1.1.0-beta.1`. A consumer requesting `^1.0.0` resolves to the stable `1.0.0`, proving node-semver prerelease exclusion.

3. **`engines-os-cpu-preserve/`** — `@rpm-fixture/platform-strict` declares `engines.node >=99.0.0`, `os: ["plan9"]`, `cpu: ["ia64"]`. A consumer still resolves it normally, proving the registry boundary applies **no** platform filtering.

Four resolver tests consume the fixtures, mirroring the peer/optional preserve pattern (`FixtureMetadataProvider` + expected-list comparison).

## Validation

```
just format-check   # ok
just check          # ok (cargo check --locked --all-targets)
just lint           # ok (clippy strict, -D warnings)
just test           # ok — 185 passed (184 lib + 1 integration), 0 failed
audit-fixtures      # ok (fixture audit: ok)
fixture-smoke       # ok
```

The 4 new tests pass:
- `dist_tag_spec_resolves_to_tagged_version`
- `dangling_dist_tag_target_is_rejected_as_unsatisfied`
- `prerelease_version_is_excluded_from_normal_range_match`
- `engines_os_cpu_metadata_does_not_filter_version_selection`

`just validate` reports `agent_assets.claude_security=fail`, but that failure is caused by untracked, gitignored `.claude/settings.local.json` local allow-rules — it is pre-existing and unrelated to this change.

## Checklist

- [x] Each fixture represents one scenario.
- [x] Expected output is checked in.
- [x] No fixture uses live npm as the test oracle (all tarballs at `registry.example.invalid`).
- [x] Tests copy inputs through the existing `FixtureMetadataProvider` / temp-dir harness; original fixtures are never mutated.
- [x] No SPEC change required (existing contracts are asserted, not redefined).

<!-- rpm-agent-research:start -->
<!-- rpm-agent-research:end -->