### PR TITLE
docs(specs): add M6 runtime-linking and lifecycle gap audit (#138)

### DIFF
--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -105,3 +105,65 @@ Findings:
 - Package `bin` metadata is intentionally deferred to the M6 linker milestone,
   where `.bin` generation is owned; it is listed here so the boundary is
   explicit, not so M5 implements it.
+
+## M6 Ownership and Gap Audit
+
+The M6 audit maps each runtime-linking and lifecycle-script behavior area to its
+owning SPEC/ADR and records whether the contract is explicitly stated. M6 is a
+runtime usability milestone: it must make installed packages runnable in normal
+Node workflows while keeping linker behavior separate from lifecycle/script
+execution behavior. It must not fold resolver, cache, or npm metadata
+compatibility expansion into runtime usability work. Every gap below is assigned
+an owning SPEC and a follow-up ticket so `.bin` generation and lifecycle
+behavior become SPEC-owned *before* implementation, satisfying the M6 exit
+criteria.
+
+| M6 behavior area | Owning SPEC / ADR | Contract status | Follow-up |
+| --- | --- | --- | --- |
+| package-local dependency links | `linker/SPEC.md` | unscoped and scoped (`@scope/name`) dependency symlinks are defined; raw scoped name is reused verbatim; filesystem failures are returned as errors | none |
+| `.bin` generation | `linker/SPEC.md` (Out Of Scope) | explicitly deferred: `.bin` generation is not defined by the current linker contract and must be specified and implemented separately | #139 |
+| `bin` field interpretation (string vs object form) | `manifest/SPEC.md`, `registry/SPEC.md` | not modeled in any SPEC; the manifest mentions `scripts` only in its Purpose, and `bin` is on the registry ignored list; the string form (`{ "bin": "./cli.js" }`) is not covered | #139 |
+| scoped vs unscoped binary links in `.bin` | `linker/SPEC.md` (deferred) | no SPEC names binary-name mapping from scoped packages (e.g. `@scope/name` exposing which binary names) | #139 |
+| executable shims / symlinks in `.bin` | none | no SPEC mentions shim or symlink generation; `shim` appears zero times under `docs/specs/` | #139 |
+| platform considerations (`.cmd`, shebang) | none | no SPEC covers Windows `.cmd` wrappers, shebang interpretation, or the executable bit | #139 (deferred decision expected) |
+| `rpm run` PATH prepend | `cli/run/SPEC.md` | `rpm run` prepends the project `node_modules/.bin` to `PATH` and propagates the child exit code; running a script must not reinstall or mutate install output | none |
+| missing `.bin` directory behavior in `rpm run` | `cli/run/SPEC.md` | the run SPEC assumes `.bin` is populated but does not own how it is populated or behavior when it is absent | #143 |
+| lifecycle script fields (`preinstall`, `install`, `postinstall`, `prepare`, ...) | none | not covered by any SPEC; not even marked as deferred; the manifest Purpose names `scripts` but defines no field contract | #141 |
+| script command parsing | none | no SPEC defines whether script values are strings-only, arrays, or how command parsing and shell invocation behave | #141 |
+| lifecycle execution as an install phase | `install/recovery/SPEC.md` | absent from the phase pipeline: the recovery contract enforces `resolve`, `fetch`, `extract`, `link`, `write` labels and has no `scripts` phase | #141 |
+| lifecycle script failure preserving install state | `install/recovery/SPEC.md` | no contract for rollback or partial-success prevention when a lifecycle script fails mid-install; the M3/M4 side-effect audit tables have no lifecycle row | #141 |
+
+Findings:
+
+- Runtime linking is split into an owned core and an explicitly deferred
+  frontier. Package-local dependency links (unscoped and scoped) are already
+  owned by `linker/SPEC.md` and need no M6 contract change. `.bin` generation is
+  the deferred frontier: it is named in the linker SPEC's Out Of Scope section
+  and in the M5 audit row above as owned by the M6 linker contract, so #139
+  brings it under contract.
+- The `.bin` cluster carries five related gaps (`.bin` generation, `bin` field
+  interpretation, scoped vs unscoped binary links, shims/symlinks, platform
+  considerations). #139 owns the `.bin` and `bin` contract as one unit so the
+  link layout, the manifest field form, and the binary-name mapping are decided
+  together before any linker implementation in #140. Platform-specific shim or
+  `.cmd` behavior may be explicitly deferred inside #139 rather than implemented
+  in M6.
+- Lifecycle scripts are the larger ownership gap: they are not covered by any
+  SPEC and are not even marked as deferred anywhere. The manifest SPEC names
+  `scripts` in its Purpose but defines no field contract, the recovery SPEC's
+  phase pipeline has no `scripts` phase, and the M3/M4 side-effect audits have no
+  lifecycle row. #141 owns the whole lifecycle cluster: supported phases,
+  ordering, environment, PATH, failure behavior, and rollback expectations, plus
+  the recovery SPEC update that adds a `scripts` phase and the invariant that a
+  failed script phase cannot publish partial successful install state.
+- `rpm run` integration is mostly owned: `cli/run/SPEC.md` already prepends
+  `node_modules/.bin` to PATH and propagates exit codes without reinstalling. The
+  one remaining gap — behavior when `.bin` is absent — is owned by #143, which
+  proves project-local binaries are reachable through `rpm run` without mutating
+  install output.
+- The delivery order follows the issue: (1) this contract and gap audit, (2) #139
+  `.bin` and `bin` contract, (3) `.bin` fixture coverage, (4) #140 first `.bin`
+  link forms, (5) #141 lifecycle policy, (6) #142 first lifecycle phase with
+  failure-safe install state, (7) #143 `rpm run` PATH verification. Lifecycle
+  behavior is kept separable from linker behavior throughout so #139/#140 can
+  land without forcing #141/#142, and vice versa.

--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -127,9 +127,9 @@ criteria.
 | executable shims / symlinks in `.bin` | none | no SPEC mentions shim or symlink generation; `shim` appears zero times under `docs/specs/` | #139 |
 | platform considerations (`.cmd`, shebang) | none | no SPEC covers Windows `.cmd` wrappers, shebang interpretation, or the executable bit | #139 (deferred decision expected) |
 | `rpm run` PATH prepend | `cli/run/SPEC.md` | `rpm run` prepends the project `node_modules/.bin` to `PATH` and propagates the child exit code; running a script must not reinstall or mutate install output | none |
-| missing `.bin` directory behavior in `rpm run` | `cli/run/SPEC.md` | the run SPEC assumes `.bin` is populated but does not own how it is populated or behavior when it is absent | #143 |
-| lifecycle script fields (`preinstall`, `install`, `postinstall`, `prepare`, ...) | none | not covered by any SPEC; not even marked as deferred; the manifest Purpose names `scripts` but defines no field contract | #141 |
-| script command parsing | none | no SPEC defines whether script values are strings-only, arrays, or how command parsing and shell invocation behave | #141 |
+| missing `.bin` directory behavior in `rpm run` | `cli/run/SPEC.md` | the run SPEC assumes `.bin` is populated and does not own how it is populated (that is linker work), but it already owns the absent-binary case: a binary that is missing from `PATH` (including when `node_modules/.bin` is absent) must surface the shell's readable error and non-zero status (`cli/run/SPEC.md` Error Cases); #143 proves project-local binaries are reachable without mutating install output rather than redefining that existing behavior | #143 |
+| lifecycle script fields (`preinstall`, `install`, `postinstall`, `prepare`, ...) | `registry/SPEC.md` (ignored per-version), `manifest/SPEC.md` (root field) | the registry SPEC already classifies per-version `scripts` as ignored metadata and requires no install behavior to depend on it, including tolerant wrong-type handling; what is unowned is active lifecycle execution — there is no field contract for which hook names run, in what order, with what environment — so #141 must explicitly update the registry contract (including its tolerant wrong-type behavior) before #142 consumes transitive scripts, rather than treating the field as absent from every SPEC | #141 |
+| script command parsing | `cli/run/SPEC.md` (shell invocation only) | shell invocation is already owned for `rpm run`: scripts execute through the platform shell so command chaining, quoting, and environment assignment follow normal package-script semantics; what is unowned is the lifecycle-specific part — whether hook values are strings-only or arrays, and whether lifecycle hooks reuse the `rpm run` shell model or define a departure — so #141 must share or explicitly diverge from the existing run SPEC rather than create a second script-execution contract | #141 |
 | lifecycle execution as an install phase | `install/recovery/SPEC.md` | absent from the phase pipeline: the recovery contract enforces `resolve`, `fetch`, `extract`, `link`, `write` labels and has no `scripts` phase | #141 |
 | lifecycle script failure preserving install state | `install/recovery/SPEC.md` | no contract for rollback or partial-success prevention when a lifecycle script fails mid-install; the M3/M4 side-effect audit tables have no lifecycle row | #141 |
 
@@ -148,14 +148,17 @@ Findings:
   together before any linker implementation in #140. Platform-specific shim or
   `.cmd` behavior may be explicitly deferred inside #139 rather than implemented
   in M6.
-- Lifecycle scripts are the larger ownership gap: they are not covered by any
-  SPEC and are not even marked as deferred anywhere. The manifest SPEC names
-  `scripts` in its Purpose but defines no field contract, the recovery SPEC's
-  phase pipeline has no `scripts` phase, and the M3/M4 side-effect audits have no
-  lifecycle row. #141 owns the whole lifecycle cluster: supported phases,
-  ordering, environment, PATH, failure behavior, and rollback expectations, plus
-  the recovery SPEC update that adds a `scripts` phase and the invariant that a
-  failed script phase cannot publish partial successful install state.
+- Lifecycle scripts are the larger ownership gap: they are not covered by an
+  active execution SPEC. Per-version `scripts` are already classified as ignored
+  registry metadata (`registry/SPEC.md`) and the manifest SPEC names `scripts` in
+  its Purpose but defines no field contract, the recovery SPEC's phase pipeline
+  has no `scripts` phase, and the M3/M4 side-effect audits have no lifecycle row.
+  #141 owns the whole lifecycle cluster: supported phases, ordering, environment,
+  PATH, failure behavior, and rollback expectations, plus the registry SPEC
+  update that moves `scripts` from ignored to consumed (including its tolerant
+  wrong-type behavior) before #142 consumes transitive scripts, and the recovery
+  SPEC update that adds a `scripts` phase and the invariant that a failed script
+  phase cannot publish partial successful install state.
 - `rpm run` integration is mostly owned: `cli/run/SPEC.md` already prepends
   `node_modules/.bin` to PATH and propagates exit codes without reinstalling. The
   one remaining gap — behavior when `.bin` is absent — is owned by #143, which


### PR DESCRIPTION
## Contract

Closes #138 — m6.0 milestone contract and runtime linking gap audit.

This delivers the repo-side artifact for the M6 milestone contract: a `## M6 Ownership and Gap Audit` section in `docs/specs/core/README.md`, mirroring the M4 (#105) and M5 (#121) milestone-contract pattern. The audit satisfies the M6 exit criteria that `.bin` generation and lifecycle behavior become SPEC-owned *before* implementation.

## Changes

- `docs/specs/core/README.md`: append `## M6 Ownership and Gap Audit` section.

The audit maps each runtime-linking and lifecycle-script behavior area to an owning SPEC and a follow-up ticket:

| Cluster | Gaps | Owning follow-up |
| --- | --- | --- |
| Runtime linking (owned core) | package-local dependency links (unscoped/scoped) | none — already owned by `linker/SPEC.md` |
| `.bin` generation frontier | `.bin` generation, `bin` field interpretation (string vs object), scoped vs unscoped binary links, shims/symlinks, platform considerations (`.cmd`/shebang) | #139 (contract) → #140 (implementation) |
| `rpm run` integration | PATH prepend (owned); missing `.bin` directory behavior | #143 |
| Lifecycle scripts | script fields, command parsing, execution as install phase, failure preserving install state | #141 (policy) → #142 (implementation) |

Lifecycle behavior is kept separable from linker behavior so #139/#140 can land without forcing #141/#142, and vice versa.

### Scope decisions

- **Included:** the M6 gap audit artifact only (the milestone-contract deliverable, per the M4/M5 precedent).
- **Excluded (separate follow-up issues):** the actual `.bin` and lifecycle SPEC contracts (#139, #141), their implementations (#140, #142), and the `rpm run` integration proof (#143). The milestone-contract issue does not duplicate SPEC authority; it assigns ownership and ordering.
- **No behavior change:** docs-only; no source, fixture, lockfile, or CLI surface change.

## Validation

- `just format-check` — pass (cargo fmt --check; no source changed)
- `just check` — pass (cargo check --locked --all-targets)
- No markdown linter is configured in the repo; the table shape mirrors the existing M4/M5 audit sections verbatim.

## Checklist

- [x] M6 audit section follows the M4/M5 table + Findings format
- [x] Every gap has an owning SPEC and a follow-up ticket
- [x] M6 exit criteria documented: `.bin` and lifecycle are SPEC-owned before implementation
- [x] No SPEC authority overridden — audit only assigns ownership and ordering
- [x] Lifecycle kept separable from linker per the issue out-of-scope statement