### PR TITLE
docs(specs): define package bin field and node_modules/.bin link contract (#139)

### DIFF
--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -73,7 +73,7 @@ RPM does not treat unsupported metadata as successful compatibility.
 | optionalDependencies | `registry/SPEC.md` (ignored list), `resolver/SPEC.md` (non-enqueue guard and deferred optional-aware policy), `manifest/SPEC.md` (root read/preserve) | classified as ignored at the registry boundary with the non-optional-aware non-enqueue guard; root manifest reads and preserves `optionalDependencies` without consuming them; the deferred optional-aware strategy policy (skip-and-warn on resolution/download/install failure, skip-silently on platform mismatch, record only successful installs) is now owned by the resolver and lockfile SPECs; active optional-aware resolution and reporting remain deferred | delivered: #133 |
 | peerDependencies | `resolver/SPEC.md`, `registry/SPEC.md` (ignored list), `manifest/SPEC.md` (root read/preserve) | classified as ignored at the registry boundary with the non-peer-aware non-enqueue guard; root manifest reads and preserves `peerDependencies` without consuming them; active peer-aware resolution and active diagnostic emission are deferred, but the *shape* of peer-requirement diagnostics (missing-peer vs incompatible-range distinguishability, human-readable-only, exit codes / machine-readable output deferred to M8) is now owned by the resolver SPEC | delivered: #130 (read/preserve + non-enqueue); #135 (diagnostic shape) |
 | engines, os, cpu | `registry/SPEC.md` (ignored list), `manifest/SPEC.md` (root read/preserve) | classified as ignored at the registry boundary with an explicit no-filtering/warning/rejection contract decision; root manifest reads and preserves npm-accurate `engines`/`os`/`cpu` without consuming them; active platform gating deferred | delivered: #127 |
-| package bin metadata | `linker/SPEC.md` (out of scope) | `.bin` generation is explicitly out of scope; `bin` is not modeled on registry types | M6 linker contract owns this |
+| package bin metadata | `manifest/SPEC.md`, `registry/SPEC.md`, `linker/SPEC.md` | `.bin` generation and `bin` field interpretation (string vs object) are now owned by the linker, manifest, and registry SPECs; per-version `bin` is read and preserved for `.bin` generation | delivered: #139 |
 | scoped package names | `resolver/SPEC.md`, `registry/SPEC.md`, `lockfile/SPEC.md`, `install/cache/SPEC.md`, `linker/SPEC.md` | scoped names are owned throughout: resolver splits `@scope/name` on the scope separator, registry consumes the scoped `name` and must percent-encode `/` as `%2F` only in the lookup path, lockfile and linker keep the raw scoped name, and the cache filename is the only place `/` is rewritten (to `-`); the `%2F` lookup-path code fix is tracked by a follow-up issue | delivered: #136 (contract); `%2F` code fix follow-up |
 | npm aliases | `registry/SPEC.md` (Unsupported metadata behavior) | npm alias declarations (`npm:<name>@<version>` range values) are classified as rejected input errors and actively rejected at the dependency-declaration boundary for both root-manifest and transitive paths, with a typed error naming the offending package and alias target | delivered: #125 landed via #129 |
 
@@ -102,9 +102,9 @@ Findings:
   lookup path that must percent-encode `/` as `%2F`, and the cache filename that
   rewrites `/` to `-`; the `%2F` lookup-path code fix is tracked by a follow-up
   issue.
-- Package `bin` metadata is intentionally deferred to the M6 linker milestone,
-  where `.bin` generation is owned; it is listed here so the boundary is
-  explicit, not so M5 implements it.
+- Package `bin` metadata was deferred to the M6 linker milestone, where `.bin`
+  generation is now owned; the M6 `.bin` and `bin` field contract landed in
+  #139. It is listed here so the boundary is explicit.
 
 ## M6 Ownership and Gap Audit
 
@@ -121,11 +121,11 @@ criteria.
 | M6 behavior area | Owning SPEC / ADR | Contract status | Follow-up |
 | --- | --- | --- | --- |
 | package-local dependency links | `linker/SPEC.md` | unscoped and scoped (`@scope/name`) dependency symlinks are defined; raw scoped name is reused verbatim; filesystem failures are returned as errors | none |
-| `.bin` generation | `linker/SPEC.md` (Out Of Scope) | explicitly deferred: `.bin` generation is not defined by the current linker contract and must be specified and implemented separately | #139 |
-| `bin` field interpretation (string vs object form) | `manifest/SPEC.md`, `registry/SPEC.md` | not modeled in any SPEC; the manifest mentions `scripts` only in its Purpose, and `bin` is on the registry ignored list; the string form (`{ "bin": "./cli.js" }`) is not covered | #139 |
-| scoped vs unscoped binary links in `.bin` | `linker/SPEC.md` (deferred) | no SPEC names binary-name mapping from scoped packages (e.g. `@scope/name` exposing which binary names) | #139 |
-| executable shims / symlinks in `.bin` | none | no SPEC mentions shim or symlink generation; `shim` appears zero times under `docs/specs/` | #139 |
-| platform considerations (`.cmd`, shebang) | none | no SPEC covers Windows `.cmd` wrappers, shebang interpretation, or the executable bit | #139 (deferred decision expected) |
+| `.bin` generation | `linker/SPEC.md` | link layout is defined: one `node_modules/.bin/<name>` entry per exposed binary, pointing at the target file inside the installed package directory; lifecycle scripts are kept separate | delivered: #139 |
+| `bin` field interpretation (string vs object form) | `manifest/SPEC.md`, `registry/SPEC.md` | both forms read and preserved: string form exposes one binary (unscoped = package name, scoped = unscoped name); object form uses map keys verbatim; wrong-type values discarded as absent | delivered: #139 |
+| scoped vs unscoped binary links in `.bin` | `linker/SPEC.md` | binary-name mapping is defined: scoped string form drops the scope prefix, object form uses keys verbatim | delivered: #139 |
+| executable shims / symlinks in `.bin` | `linker/SPEC.md` | `.bin` entries are symlinks on every platform; RPM does not synthesize or rewrite shebangs | delivered: #139 |
+| platform considerations (`.cmd`, shebang) | `linker/SPEC.md` | explicitly deferred inside #139: the link layout is defined; Windows `.cmd`/`.ps1` shim generation, executable-bit handling, and permission normalization are deferred until a platform-packaging strategy SPEC (M10 / #163) owns them | delivered: #139 (active layout); deferred to M10 (platform shims) |
 | `rpm run` PATH prepend | `cli/run/SPEC.md` | `rpm run` prepends the project `node_modules/.bin` to `PATH` and propagates the child exit code; running a script must not reinstall or mutate install output | none |
 | missing `.bin` directory behavior in `rpm run` | `cli/run/SPEC.md` | the run SPEC assumes `.bin` is populated and does not own how it is populated (that is linker work), but it already owns the absent-binary case: a binary that is missing from `PATH` (including when `node_modules/.bin` is absent) must surface the shell's readable error and non-zero status (`cli/run/SPEC.md` Error Cases); #143 proves project-local binaries are reachable without mutating install output rather than redefining that existing behavior | #143 |
 | lifecycle script fields (`preinstall`, `install`, `postinstall`, `prepare`, ...) | `registry/SPEC.md` (ignored per-version), `manifest/SPEC.md` (root field) | the registry SPEC already classifies per-version `scripts` as ignored metadata and requires no install behavior to depend on it, including tolerant wrong-type handling; what is unowned is active lifecycle execution — there is no field contract for which hook names run, in what order, with what environment — so #141 must explicitly update the registry contract (including its tolerant wrong-type behavior) before #142 consumes transitive scripts, rather than treating the field as absent from every SPEC | #141 |
@@ -135,19 +135,19 @@ criteria.
 
 Findings:
 
-- Runtime linking is split into an owned core and an explicitly deferred
-  frontier. Package-local dependency links (unscoped and scoped) are already
-  owned by `linker/SPEC.md` and need no M6 contract change. `.bin` generation is
-  the deferred frontier: it is named in the linker SPEC's Out Of Scope section
-  and in the M5 audit row above as owned by the M6 linker contract, so #139
-  brings it under contract.
-- The `.bin` cluster carries five related gaps (`.bin` generation, `bin` field
+- Runtime linking is split into an owned core and a now-contracted `.bin`
+  frontier. Package-local dependency links (unscoped and scoped) are owned by
+  `linker/SPEC.md` and needed no M6 contract change. `.bin` generation was the
+  deferred frontier named in the linker SPEC's Out Of Scope section and in the
+  M5 audit row above; #139 has now brought it under contract.
+- The `.bin` cluster carried five related gaps (`.bin` generation, `bin` field
   interpretation, scoped vs unscoped binary links, shims/symlinks, platform
-  considerations). #139 owns the `.bin` and `bin` contract as one unit so the
-  link layout, the manifest field form, and the binary-name mapping are decided
-  together before any linker implementation in #140. Platform-specific shim or
-  `.cmd` behavior may be explicitly deferred inside #139 rather than implemented
-  in M6.
+  considerations). #139 owned the `.bin` and `bin` contract as one unit so the
+  link layout, the manifest field form, and the binary-name mapping were decided
+  together before any linker implementation in #140. The symlink link layout is
+  defined for every platform; platform-specific shim or `.cmd` behavior is
+  explicitly deferred inside #139 until M10 / #163 owns a platform-packaging
+  strategy.
 - Lifecycle scripts are the larger ownership gap: they are not covered by an
   active execution SPEC. Per-version `scripts` are already classified as ignored
   registry metadata (`registry/SPEC.md`) and the manifest SPEC names `scripts` in

--- a/docs/specs/core/linker/SPEC.md
+++ b/docs/specs/core/linker/SPEC.md
@@ -14,6 +14,7 @@ related_adrs:
   - 0002-single-crate-cli-core-boundary
 related_issues:
   - 50
+  - 139
 ---
 
 # Spec: Node Modules Linker
@@ -64,10 +65,73 @@ Strict dependency visibility remains a design constraint: package-local
 `node_modules` entries should expose declared dependencies, not unrelated
 packages from the root package set.
 
-## Out Of Scope
+### Executable bin links (`node_modules/.bin`)
 
-`.bin` generation is not defined by this contract. It should be specified and
-implemented separately.
+After dependency links are created, RPM generates executable links for every
+package that declares a `bin` field. The `bin` field source and shape are owned
+by `docs/specs/core/manifest/SPEC.md` (root package) and
+`docs/specs/core/registry/SPEC.md` (per-version packument entry); the linker
+owns only the link layout those entries produce.
+
+For each resolved package that declares `bin`, RPM creates one link per exposed
+binary name under the project `node_modules/.bin/` directory. The link points
+at the package's declared target file inside the package's installed directory:
+
+```text
+node_modules/.bin/<binary-name> -> ../<package-dir>/<target-file>
+```
+
+Where `<package-dir>` is the package's installed directory (the same directory
+the dependency-link step uses) and `<target-file>` is the path the `bin` entry
+names, relative to the package root.
+
+Binary name mapping follows npm semantics:
+
+- An **unscoped** package with `bin` in string form (`"bin": "./cli.js"`)
+  exposes exactly one binary named after the package `name`, pointing at
+  `./cli.js`.
+- An **unscoped** package with `bin` in object form
+  (`"bin": { "my-cli": "./cli.js", "helper": "./bin/helper.js" }`) exposes one
+  binary per map key; each key is the binary name and each value is the target
+  file.
+- A **scoped** package (`@scope/name`) in string form exposes one binary named
+  after the package's unscoped name (`name`, without the `@scope/` prefix),
+  pointing at the target file. The scope is dropped from the binary name.
+- A **scoped** package (`@scope/name`) in object form exposes one binary per map
+  key, exactly as written. Object-form keys are used verbatim; the linker does
+  not prefix, strip, or otherwise rewrite them.
+
+Name collisions across packages are resolved last-writer-wins by link creation
+order. A single canonical link target exists per binary name after linking
+completes; RPM does not merge or union colliding binaries. The collision
+resolution order is owned by the linker implementation ticket (#140), not by
+this contract.
+
+The `.bin` directory and its links are part of the install output transaction:
+they are created during the link phase and must be present before the install
+is reported as successful. `rpm run` consumes the resulting `node_modules/.bin`
+by prepending it to `PATH` (`docs/specs/cli/run/SPEC.md`); the linker owns how
+`.bin` is populated, `rpm run` owns how it is consumed.
+
+Lifecycle script execution (`preinstall`, `install`, `postinstall`, `prepare`)
+is not part of this contract. Lifecycle policy is owned separately
+(`docs/specs/core/install/recovery/SPEC.md` will own the `scripts` phase; see
+issue #141). The `.bin` contract must not depend on lifecycle scripts running,
+and lifecycle scripts must not depend on `.bin` being populated.
+
+#### Platform considerations
+
+This contract defines the link layout only. Platform-specific executable
+wrappers are explicitly deferred:
+
+- On Unix-like platforms the link is a symlink and the target file is expected
+  to carry its own shebang line. RPM does not synthesize or rewrite shebangs.
+- Windows `.cmd` / `.ps1` shim generation, executable-bit handling, and any
+  platform-dependent permission normalization are **out of scope** for this
+  contract and are deferred until a platform-packaging strategy SPEC owns them
+  (M10 / issue #163). Until then, `.bin` generation produces the same symlink
+  layout on every platform; a Windows host that cannot create or follow a
+  symlink surfaces a filesystem error as defined under Error Cases.
 
 ## Error Cases
 
@@ -75,7 +139,29 @@ Linking fails if a dependency target package has not been extracted, if the
 destination directory cannot be created, or if the symlink cannot be created.
 Failed linking must not be reported as a successful install or script setup.
 
+A package that declares a `bin` entry whose target file does not exist inside
+the extracted package directory is a link failure, not a successful install.
+The linker must not create a `.bin` link that points at a missing target. A
+`node_modules/.bin` directory that cannot be created or written is a link
+failure.
+
+A package that declares no `bin` field contributes no `.bin` entries; this is
+normal and not an error.
+
 ## Test Fixtures
 
 Linker verification should cover unscoped and scoped dependency links plus
 destination-directory and symlink-creation failures.
+
+`.bin` generation verification should cover:
+
+- unscoped package, string-form `bin`, single binary named after the package;
+- unscoped package, object-form `bin`, one binary per map key;
+- scoped package, string-form `bin`, binary named after the unscoped name;
+- scoped package, object-form `bin`, binary names used verbatim;
+- package with no `bin` field producing no `.bin` entries;
+- a `bin` target file that is absent from the extracted package producing a
+  link failure rather than a dangling link.
+
+Fixtures must copy install projects to temporary directories before mutation
+and must not use live npm.

--- a/docs/specs/core/linker/SPEC.md
+++ b/docs/specs/core/linker/SPEC.md
@@ -68,10 +68,17 @@ packages from the root package set.
 ### Executable bin links (`node_modules/.bin`)
 
 After dependency links are created, RPM generates executable links for every
-package that declares a `bin` field. The `bin` field source and shape are owned
-by `docs/specs/core/manifest/SPEC.md` (root package) and
+resolved package that declares a `bin` field. The `bin` field source and shape
+are owned by `docs/specs/core/manifest/SPEC.md` (root package) and
 `docs/specs/core/registry/SPEC.md` (per-version packument entry); the linker
 owns only the link layout those entries produce.
+
+Only resolved packages with an installed directory under `node_modules/`
+receive `.bin` links. The root project manifest is a `bin` source for
+preservation only: it has no installed directory and the linker does not create
+a `.bin` link for the root package itself. Reaching the root project's own
+binaries through `rpm run` is handled by the run contract and the PATH prepend
+(`docs/specs/cli/run/SPEC.md`, issue #143), not by `.bin` generation.
 
 For each resolved package that declares `bin`, RPM creates one link per exposed
 binary name under the project `node_modules/.bin/` directory. The link points
@@ -84,6 +91,17 @@ node_modules/.bin/<binary-name> -> ../<package-dir>/<target-file>
 Where `<package-dir>` is the package's installed directory (the same directory
 the dependency-link step uses) and `<target-file>` is the path the `bin` entry
 names, relative to the package root.
+
+Binary name confinement. The binary name must be a single path component: it
+must not be empty, must not contain a path separator (`/` or `\`), must not be
+absolute, and must not contain a parent-reference (`..`) component. An
+object-form `bin` key that violates any of these (for example
+`{"../../outside": "./cli.js"}`, `{"": "./cli.js"}`, or `{"a/b": "./cli.js"}`)
+is rejected as a link input error before any `.bin` link is created; it is not
+written verbatim into `node_modules/.bin`. Package-controlled metadata must not
+be able to place a `.bin` entry outside the `node_modules/.bin/` directory. The
+package name used for string-form binaries is already a single component by the
+resolver name contract, so this guard primarily constrains object-form keys.
 
 Binary name mapping follows npm semantics:
 
@@ -145,6 +163,10 @@ The linker must not create a `.bin` link that points at a missing target. A
 `node_modules/.bin` directory that cannot be created or written is a link
 failure.
 
+A `bin` binary name that violates the single-component confinement guard
+(absolute, separator-containing, parent-referencing, or empty) is a link input
+error, not a successful install; no `.bin` link is created for that entry.
+
 A package that declares no `bin` field contributes no `.bin` entries; this is
 normal and not an error.
 
@@ -161,7 +183,15 @@ destination-directory and symlink-creation failures.
 - scoped package, object-form `bin`, binary names used verbatim;
 - package with no `bin` field producing no `.bin` entries;
 - a `bin` target file that is absent from the extracted package producing a
-  link failure rather than a dangling link.
+  link failure rather than a dangling link;
+- a `bin` target that traverses outside the extracted package directory after
+  symlink and `..` normalization (for example a `target` of `../outside.js` or
+  an in-package symlink that resolves outside the package root) producing a
+  link failure rather than an escaping link;
+- an object-form `bin` key that is not a single path component (absolute,
+  separator-containing, parent-referencing, or empty, for example
+  `{"../../etc/foo": "./cli.js"}`) producing a link input error rather than a
+  link written outside `node_modules/.bin/`.
 
 Fixtures must copy install projects to temporary directories before mutation
 and must not use live npm.

--- a/docs/specs/core/manifest/SPEC.md
+++ b/docs/specs/core/manifest/SPEC.md
@@ -17,13 +17,14 @@ related_issues:
   - 127
   - 130
   - 133
+  - 139
 ---
 
 # Spec: Package Manifest
 
 Status: Draft
 Owner: core/manifest
-Last reviewed: 2026-08-10
+Last reviewed: 2026-08-11
 
 ## Purpose
 
@@ -109,6 +110,35 @@ a non-failure: platform metadata must not block resolution, download,
 verification, extraction, linking, lockfile, or manifest output. Per-version
 `engines`, `os`, and `cpu` on registry packuments remain ignored at the registry
 boundary (`docs/specs/core/registry/SPEC.md`).
+
+### Bin field
+
+RPM reads the root `bin` field when it is present and accepts both npm-defined
+forms:
+
+- **String form:** `"bin": "./cli.js"` exposes a single binary. For an unscoped
+  package the binary name is the package `name`; for a scoped package
+  (`@scope/name`) the binary name is the unscoped name (`name`).
+- **Object form:** `"bin": { "<name>": "<target>", ... }` exposes one binary
+  per map key. The keys are used verbatim as binary names; the scope prefix is
+  neither added nor stripped from object-form keys.
+
+A present-but-wrong-type `bin` value (for example a number or an array) is
+discarded as absent during deserialization rather than failing the manifest,
+mirroring the lenient handling used for other preserved fields. A well-typed
+value round-trips into `Some(...)`.
+
+The read `bin` entries do not influence resolution, version selection, the
+resolved graph, or the lockfile. They are consumed by exactly one downstream
+behavior: the linker's `node_modules/.bin` generation
+(`docs/specs/core/linker/SPEC.md`). Until that generation runs, a `bin` entry
+has no install side effect. A manifest that omits `bin` behaves identically to
+one without it: no `.bin` entries are produced for that package.
+
+A `bin` target that names a path outside the package directory (after symlink
+and `..` normalization) is rejected as a link input error by the linker, not
+silently followed. This keeps `.bin` generation from becoming a traversal
+vector; the traversal guard is owned by the linker contract.
 
 ## Error Cases
 

--- a/docs/specs/core/manifest/SPEC.md
+++ b/docs/specs/core/manifest/SPEC.md
@@ -135,10 +135,21 @@ behavior: the linker's `node_modules/.bin` generation
 has no install side effect. A manifest that omits `bin` behaves identically to
 one without it: no `.bin` entries are produced for that package.
 
+The root package `bin` field is preservation-only at this boundary: the root
+package is not a resolved package and has no installed directory under
+`node_modules/`, so the linker does not generate a `.bin` link for the root
+project itself. The linker consumes `bin` only from resolved (installed)
+packages. Reaching the root project's own declared binaries at runtime is owned
+by `rpm run` and its PATH policy (`docs/specs/cli/run/SPEC.md`, issue #143),
+not by `.bin` generation.
+
 A `bin` target that names a path outside the package directory (after symlink
 and `..` normalization) is rejected as a link input error by the linker, not
 silently followed. This keeps `.bin` generation from becoming a traversal
-vector; the traversal guard is owned by the linker contract.
+vector; the traversal guard is owned by the linker contract. An object-form
+`bin` key that is not a single path component (absolute, separator-containing,
+parent-referencing, or empty) is likewise rejected by the linker before any
+`.bin` entry is written; see `docs/specs/core/linker/SPEC.md`.
 
 ## Error Cases
 

--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -23,6 +23,7 @@ related_issues:
   - 130
   - 133
   - 136
+  - 139
   - 170
 ---
 
@@ -129,6 +130,20 @@ Distribution record (`Dist`):
   absent or empty. Used for tarball verification when no supported SRI value
   exists.
 
+Package bin metadata. Per-version `bin` is read and preserved in both npm
+forms — string (`"bin": "./cli.js"`) and object
+(`"bin": { "name": "./target" }`) — so the linker can generate
+`node_modules/.bin` entries for resolved packages. The binary name mapping
+(unscoped string form uses the package name; scoped string form uses the
+unscoped name; object form uses the keys verbatim) and the link layout are
+owned by `docs/specs/core/linker/SPEC.md`. The registry boundary owns only
+reading and preserving `bin`; it does not influence version selection,
+dependency edges, cache writes, or integrity verification. A
+present-but-wrong-type `bin` value is discarded as absent during deserialization
+rather than failing the packument, consistent with the lenient handling of
+other preserved fields. A version that omits `bin` simply contributes no
+`.bin` entries.
+
 ### Ignored metadata fields
 
 The following fields are deserialized for document fidelity but are not consumed
@@ -161,11 +176,13 @@ verification:
   for `engines`/`os`/`cpu` is owned by
   `docs/specs/core/manifest/SPEC.md`; per-version values on registry packuments
   remain ignored here until that strategy consumes them.
-- `main`, `types`, `scripts`, `bin`/package bin metadata, `private`,
+- `main`, `types`, `scripts`, `private`,
   `repository`, `description`, `maintainers`, `author`, `homepage`, `keywords`,
   `license`, `readme`, `readmeFilename`, `time`, `_id`, `_rev`, and `sequence`.
   These do not influence resolution, download, verification, extraction,
-  linking, lockfile, or manifest output.
+  linking, lockfile, or manifest output. Package `bin` metadata was previously
+  listed here; it is now read for `.bin` generation (see "Package bin metadata"
+  under Consumed metadata fields).
 
 Ignored means RPM may accept documents that carry these fields, but no active
 behavior depends on them. An ignored field that is invalid or missing must not
@@ -374,11 +391,12 @@ not duplicate the contract text above.
 ## Open Questions
 
 - When and how RPM begins consuming `peerDependencies`, `optionalDependencies`,
-  `engines`, `os`, `cpu`, and package `bin` metadata as active behavior. These
-  remain ignored at the registry boundary until a peer-aware resolution
-  strategy, an optional-aware strategy, platform gating, or `.bin` generation
-  SPEC owns the active behavior. The linker SPEC already notes `.bin` generation
-  is out of scope. The root manifest `optionalDependencies` read-and-preserve
+  `engines`, `os`, and `cpu` as active behavior. These remain ignored at the
+  registry boundary until a peer-aware resolution strategy, an optional-aware
+  strategy, or platform gating owns the active behavior. Package `bin` metadata
+  is now consumed for `.bin` generation
+  (`docs/specs/core/linker/SPEC.md`, #139) and is no longer an open question.
+  The root manifest `optionalDependencies` read-and-preserve
   baseline is now owned by `docs/specs/core/manifest/SPEC.md`; per-version
   `optionalDependencies` on registry packuments remain ignored here until an
   optional-aware strategy consumes them as dependency edges. The reserved


### PR DESCRIPTION
## Contract

Closes #139.

This brings `.bin` generation and the package `bin` field under SPEC contract before any linker implementation (#140). It is docs-only: no source, fixture, lockfile, or CLI surface change.

The M6 audit (#138, landed via #175) identified five related `.bin` gaps and assigned them to #139 as one unit so the link layout, the manifest field form, and the binary-name mapping are decided together.

## Changes

Four SPEC documents updated; no code change.

- **`docs/specs/core/linker/SPEC.md`** — adds the `### Executable bin links (node_modules/.bin)` section:
  - link layout: one `node_modules/.bin/<name>` entry per exposed binary, pointing at the target file inside the installed package directory
  - binary-name mapping for all four cases: unscoped string (binary = package name), unscoped object (keys verbatim), scoped string (binary = unscoped name), scoped object (keys verbatim)
  - last-writer-wins collision policy; resolution order deferred to #140
  - `.bin` is part of the install output transaction (link phase), consumed by `rpm run`
  - lifecycle scripts kept separable from this contract (owned by #141)
  - platform considerations: symlink layout defined for every platform; Windows `.cmd`/`.ps1` shim generation, executable-bit handling, and permission normalization explicitly deferred to M10 / #163
  - removes the old Out Of Scope sentence (`.bin` generation is no longer out of scope)
- **`docs/specs/core/manifest/SPEC.md`** — adds the `### Bin field` section owning string vs object form, scope-based name derivation, lenient wrong-type handling, the linker as sole downstream consumer, and the traversal guard reference.
- **`docs/specs/core/registry/SPEC.md`** — moves per-version `bin` from the ignored list to consumed metadata (\"Package bin metadata\"), documents both npm forms and lenient wrong-type handling, and removes `bin` from the Open Questions list.
- **`docs/specs/core/README.md`** — marks the five `.bin` M6 audit rows and the M5 bin row as delivered by #139; updates the M6 Findings bullets to past tense.

## Validation

\`\`\`
just format-check   # ok (cargo fmt --check)
just check          # ok (cargo check --locked --all-targets)
just lint           # ok (clippy strict, -D warnings)
just test           # ok — 181 passed (180 lib + 1 integration), 0 failed
\`\`\`

No source changed, so no new test applies; the contracts are reviewed against the existing linker (`src/lib/node_linker/mod.rs`), manifest (`src/lib/package_manifest/mod.rs`), registry (`src/lib/registry/mod.rs`), and `rpm run` PATH (`src/lib/command/working_process/run.rs`) implementations.

## Checklist

- [x] Link target layout is specified (linker SPEC).
- [x] Platform considerations are documented (symlink layout now; Windows shims deferred to M10/#163).
- [x] Error behavior is defined for missing package targets and filesystem failures.
- [x] Fixture cases are listed (unscoped/scoped string and object forms, no-bin package, missing-target failure).
- [x] `bin` field interpretation (string vs object) is owned (manifest + registry SPECs).
- [x] Scoped vs unscoped binary-name mapping is defined (linker SPEC).
- [x] Lifecycle scripts kept separable from this contract (#141 owns them).