### PR TITLE
test(run): verify project-local binaries through install and rpm run (#143)

### DIFF
--- a/docs/specs/cli/run/SPEC.md
+++ b/docs/specs/cli/run/SPEC.md
@@ -50,3 +50,8 @@ status. Script failures must preserve the child process status.
 
 Run-script verification should cover missing-script errors, child exit-code
 preservation, and PATH setup for project-local binaries.
+
+A package binary produced by the install transaction (the `.bin` link owned by
+`docs/specs/core/linker/SPEC.md`) must be reachable through `rpm run` without
+reinstalling or mutating install output. A missing binary must keep a readable
+non-zero status (issue #143).

--- a/src/lib/api/mod.rs
+++ b/src/lib/api/mod.rs
@@ -101,17 +101,107 @@ fn fixture_tarball(tarball_url: &str) -> std::io::Result<Vec<u8>> {
     use tar::{Builder, Header};
 
     let package_name = package_name_from_tarball_url(tarball_url)?;
-    let package_json = format!(r#"{{"name":"{package_name}"}}"#);
+    let spec = read_fixture_tarball_spec(&package_name);
+    let package_json = build_fixture_package_json(&package_name, spec.as_ref());
+    let extra_files = spec
+        .as_ref()
+        .map(|spec| spec.files.as_slice())
+        .unwrap_or(&[]);
+
     let encoder = GzEncoder::new(Vec::new(), Compression::default());
     let mut builder = Builder::new(encoder);
+
     let mut header = Header::new_gnu();
     header.set_size(package_json.len() as u64);
     header.set_cksum();
     builder.append_data(&mut header, "package/package.json", package_json.as_bytes())?;
+
+    // When a fixture tarball spec declares extra files (for example a binary
+    // target reachable through a `bin` field), append each one under the
+    // `package/` prefix so the install extraction step strips the prefix and
+    // lands them at `node_modules/<package>/<file>`, where `link_bins` expects
+    // them. A missing spec keeps the legacy minimal archive unchanged.
+    for file in extra_files {
+        let archive_path = format!("package/{}", file.path);
+        let mut header = Header::new_gnu();
+        header.set_size(file.contents.len() as u64);
+        header.set_mode(file.mode);
+        header.set_cksum();
+        builder.append_data(&mut header, &archive_path, file.contents.as_bytes())?;
+    }
+
     builder.finish()?;
     let mut encoder = builder.into_inner()?;
     encoder.flush()?;
     encoder.finish()
+}
+
+/// Optional fixture-side description of a synthetic tarball's contents.
+///
+/// The legacy path serves a minimal `package/package.json` with only a `name`
+/// field. Specs live at `<fixture-root>/tarballs/<package-name>.json` so a
+/// fixture can declare a `bin` field and the binary target files the install
+/// pipeline must extract alongside the manifest. Only tests that need `.bin`
+/// linking or other non-trivial tarball contents provide a spec; every other
+/// fixture stays on the minimal default.
+#[cfg(test)]
+#[derive(Debug, serde::Deserialize)]
+struct FixtureTarballSpec {
+    #[serde(default)]
+    bin: Option<serde_json::Value>,
+    #[serde(default)]
+    files: Vec<FixtureTarballFile>,
+}
+
+#[cfg(test)]
+#[derive(Debug, serde::Deserialize)]
+struct FixtureTarballFile {
+    path: String,
+    contents: String,
+    #[serde(default = "default_fixture_file_mode")]
+    mode: u32,
+}
+
+#[cfg(test)]
+fn default_fixture_file_mode() -> u32 {
+    0o644
+}
+
+/// Read the optional tarball spec for `package_name` from the fixture registry
+/// root. Returns `None` when the root is unset or no spec file exists, so the
+/// minimal-archive default path stays intact for every fixture that does not
+/// opt in.
+#[cfg(test)]
+fn read_fixture_tarball_spec(package_name: &str) -> Option<FixtureTarballSpec> {
+    let root = std::env::var_os("RPM_REGISTRY_FIXTURE_ROOT")?;
+    let file_name = format!("{}.json", package_name.replace('/', "__"));
+    let path = PathBuf::from(root).join("tarballs").join(file_name);
+    let contents = match fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == ErrorKind::NotFound => return None,
+        Err(error) => panic!("{} did not deserialize: {error}", path.display()),
+    };
+    serde_json::from_str(&contents)
+        .unwrap_or_else(|error| panic!("{} should be valid JSON: {error}", path.display()))
+}
+
+/// Build the `package/package.json` body for a fixture tarball. Without a spec
+/// it is the legacy minimal `{"name":"..."}` object; with a spec the declared
+/// `bin` field is merged in so `link_bins` reads it after extraction.
+#[cfg(test)]
+fn build_fixture_package_json(package_name: &str, spec: Option<&FixtureTarballSpec>) -> String {
+    let Some(spec) = spec else {
+        return format!(r#"{{"name":"{package_name}"}}"#);
+    };
+    let mut root = serde_json::Map::new();
+    root.insert(
+        "name".to_string(),
+        serde_json::Value::String(package_name.to_string()),
+    );
+    if let Some(bin) = &spec.bin {
+        root.insert("bin".to_string(), bin.clone());
+    }
+    serde_json::Value::Object(root).to_string()
 }
 
 #[cfg(test)]

--- a/src/lib/command/working_process/install.rs
+++ b/src/lib/command/working_process/install.rs
@@ -205,6 +205,7 @@ fn remove_path(path: &Path) -> io::Result<()> {
 mod tests {
     use super::install_in;
     use crate::{
+        command::working_process::run::run_script,
         lockfile::{LockFile, Relationship},
         package_manifest::PackageManifest,
         util::test_support::{fixture_path, TempProject},
@@ -439,6 +440,90 @@ mod tests {
             fs::read_to_string(&existing_file).unwrap(),
             "existing node_modules content"
         );
+    }
+
+    // Issue #143: prove the install pipeline produces a `node_modules/.bin`
+    // link for a resolved package binary and that `rpm run` reaches it through
+    // the PATH prepend owned by the run contract. The fixture declares a single
+    // dependency whose synthetic tarball carries a string-form `bin` field and
+    // the executable target; without the tarball spec, no `.bin` link is
+    // produced and `run_script` cannot find the binary.
+
+    #[tokio::test]
+    async fn install_creates_bin_link_and_run_script_reaches_it() {
+        let _guard = TestEnvLock::acquire().unwrap();
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let root_before = root_fingerprints(&repo_root).unwrap();
+        let fixture_root = fixture_path(&["install-projects", "run-project-binary"]);
+        let project = TempProject::new("run-project-binary-install").unwrap();
+        let package_path = project
+            .copy_fixture(fixture_root.join("package.json"), "package.json")
+            .unwrap();
+        let project_root = package_path.parent().unwrap();
+
+        let _env = FixtureInstallEnv::new(&fixture_root.join("registry"));
+        install_in(project_root).await.unwrap();
+
+        let lock_path = project_root.join("rpm.lock");
+        let lock = LockFile::load_from_path(&lock_path).unwrap();
+        let expected = fs::read_to_string(fixture_root.join("expected/resolved-packages.txt"))
+            .unwrap()
+            .lines()
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        assert_eq!(resolved_packages(&lock), expected);
+
+        let node_modules = project_root.join("node_modules");
+        // The resolved package is installed and carries the declared target.
+        assert!(node_modules
+            .join("@rpm-fixture")
+            .join("cli-tool")
+            .join("cli.sh")
+            .is_file());
+        // install generated a `.bin` symlink pointing at the target file.
+        // The package is scoped (`@rpm-fixture/cli-tool`) with string-form
+        // `bin`, so the binary name drops the scope prefix (linker SPEC).
+        let bin_link = node_modules.join(".bin").join("cli-tool");
+        assert!(
+            bin_link.is_symlink(),
+            "expected .bin link for the resolved binary, got {}",
+            bin_link.display()
+        );
+        assert_eq!(
+            fs::read_link(&bin_link).unwrap(),
+            PathBuf::from("../@rpm-fixture/cli-tool/cli.sh")
+        );
+
+        // `rpm run` reaches the installed binary through the PATH prepend
+        // without reinstalling or mutating install output.
+        let package = PackageManifest::read_from_path(&package_path).unwrap();
+        let status = run_script("greet", &package, project_root).unwrap();
+        assert_eq!(status, 0);
+
+        // Running the script must not change the install output.
+        assert_eq!(root_fingerprints(&repo_root).unwrap(), root_before);
+    }
+
+    #[tokio::test]
+    async fn run_script_reports_missing_binary_after_install() {
+        let _guard = TestEnvLock::acquire().unwrap();
+        let fixture_root = fixture_path(&["install-projects", "run-project-binary"]);
+        let project = TempProject::new("run-project-binary-missing").unwrap();
+        let package_path = project
+            .copy_fixture(fixture_root.join("package.json"), "package.json")
+            .unwrap();
+        let project_root = package_path.parent().unwrap();
+
+        let _env = FixtureInstallEnv::new(&fixture_root.join("registry"));
+        install_in(project_root).await.unwrap();
+
+        // A binary the installed packages do not expose must remain a readable
+        // non-zero status, not a reinstall or a silent success.
+        let script = r#"{"scripts": {"missing": "definitely-not-an-rpm-fixture-binary"}}"#;
+        fs::write(&package_path, script).unwrap();
+        let package = PackageManifest::read_from_path(&package_path).unwrap();
+        let status = run_script("missing", &package, project_root).unwrap();
+        assert_ne!(status, 0);
     }
 
     fn assert_expected_error(fixture_root: &Path, error: &io::Error) {

--- a/src/lib/command/working_process/install.rs
+++ b/src/lib/command/working_process/install.rs
@@ -452,8 +452,6 @@ mod tests {
     #[tokio::test]
     async fn install_creates_bin_link_and_run_script_reaches_it() {
         let _guard = TestEnvLock::acquire().unwrap();
-        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let root_before = root_fingerprints(&repo_root).unwrap();
         let fixture_root = fixture_path(&["install-projects", "run-project-binary"]);
         let project = TempProject::new("run-project-binary-install").unwrap();
         let package_path = project
@@ -463,6 +461,13 @@ mod tests {
 
         let _env = FixtureInstallEnv::new(&fixture_root.join("registry"));
         install_in(project_root).await.unwrap();
+
+        // Fingerprint the install output (the project's `node_modules`, lockfile,
+        // and cache) instead of the repository root so the non-mutation contract
+        // has actual regression coverage: a regression that reinstalled or
+        // mutated `project_root` would be caught here, while the repo root is
+        // never touched by `run_script` and would mask such a regression.
+        let project_before = project_fingerprints(project_root);
 
         let lock_path = project_root.join("rpm.lock");
         let lock = LockFile::load_from_path(&lock_path).unwrap();
@@ -501,7 +506,7 @@ mod tests {
         assert_eq!(status, 0);
 
         // Running the script must not change the install output.
-        assert_eq!(root_fingerprints(&repo_root).unwrap(), root_before);
+        assert_eq!(project_fingerprints(project_root), project_before);
     }
 
     #[tokio::test]
@@ -623,6 +628,23 @@ mod tests {
             fingerprints.insert(path.to_string(), fingerprint_path(&repo_root.join(path))?);
         }
         Ok(fingerprints)
+    }
+
+    /// Fingerprint the install output of a project: its `rpm.lock`, `.rpm`
+    /// cache, and `node_modules` tree. Used to prove a step (such as
+    /// `run_script`) does not reinstall or mutate install output. Unlike
+    /// `root_fingerprints`, this scopes the snapshot to the project whose
+    /// install output is under test, so a regression that mutated the project
+    /// would be caught rather than masked by an unrelated root.
+    fn project_fingerprints(project_root: &Path) -> BTreeMap<String, PathFingerprint> {
+        let mut fingerprints = BTreeMap::new();
+        for path in ["rpm.lock", ".rpm", "node_modules"] {
+            fingerprints.insert(
+                path.to_string(),
+                fingerprint_path(&project_root.join(path)).unwrap(),
+            );
+        }
+        fingerprints
     }
 
     fn fingerprint_path(path: &Path) -> io::Result<PathFingerprint> {

--- a/src/lib/command/working_process/run.rs
+++ b/src/lib/command/working_process/run.rs
@@ -13,7 +13,7 @@ pub async fn run(script_key: String) -> Result<i32, std::io::Error> {
     run_script(&script_key, &package, Path::new("."))
 }
 
-fn run_script(
+pub(super) fn run_script(
     script_key: &str,
     package: &PackageManifest,
     project_root: &Path,

--- a/tests/fixtures/install-projects/run-project-binary/expected/resolved-packages.txt
+++ b/tests/fixtures/install-projects/run-project-binary/expected/resolved-packages.txt
@@ -1,0 +1,1 @@
+@rpm-fixture/cli-tool@1.0.0 requested 1.0.0

--- a/tests/fixtures/install-projects/run-project-binary/package.json
+++ b/tests/fixtures/install-projects/run-project-binary/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "run-project-binary-app",
+  "version": "0.0.0",
+  "scripts": {
+    "greet": "cli-tool"
+  },
+  "dependencies": {
+    "@rpm-fixture/cli-tool": "1.0.0"
+  }
+}

--- a/tests/fixtures/install-projects/run-project-binary/registry/@rpm-fixture__cli-tool.json
+++ b/tests/fixtures/install-projects/run-project-binary/registry/@rpm-fixture__cli-tool.json
@@ -1,0 +1,21 @@
+{
+  "_id": "@rpm-fixture/cli-tool",
+  "name": "@rpm-fixture/cli-tool",
+  "description": "Fixture package that exposes a bin entry",
+  "maintainers": [],
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "@rpm-fixture/cli-tool",
+      "version": "1.0.0",
+      "description": "Fixture package that exposes a bin entry",
+      "bin": "./cli.sh",
+      "dist": {
+        "tarball": "https://registry.example.invalid/@rpm-fixture/cli-tool/-/cli-tool-1.0.0.tgz",
+        "shasum": "fixture-cli-tool-1.0.0"
+      }
+    }
+  }
+}

--- a/tests/fixtures/install-projects/run-project-binary/registry/tarballs/@rpm-fixture__cli-tool.json
+++ b/tests/fixtures/install-projects/run-project-binary/registry/tarballs/@rpm-fixture__cli-tool.json
@@ -1,0 +1,10 @@
+{
+  "bin": "./cli.sh",
+  "files": [
+    {
+      "path": "cli.sh",
+      "contents": "#!/bin/sh\necho hello-from-rpm-fixture-cli-tool\n",
+      "mode": 493
+    }
+  ]
+}


### PR DESCRIPTION
## Contract

Proves the install transaction produces a `node_modules/.bin` link for a resolved package binary and that `rpm run` reaches it through the PATH prepend owned by `docs/specs/cli/run/SPEC.md`. The `.bin` link layout is owned by `docs/specs/core/linker/SPEC.md` (issue #140, PR #177); this change closes the end-to-end gap called out by that SPEC at line 81.

Closes #143.

## Changes

- **`src/lib/api/mod.rs`**: extend `fixture_tarball` with an optional tarball spec (`<fixture-root>/tarballs/<package>.json`) that declares a `bin` field and the binary target files the synthetic archive must ship under the `package/` prefix. The default path (no spec) stays unchanged, so every existing fixture keeps its minimal `{"name":"..."}` archive and the `fixture_tarball_builds_minimal_package_archive` test still passes.
- **`src/lib/command/working_process/run.rs`**: expose `run_script` as `pub(super)` so the install tests can drive the run contract without widening the public API.
- **`src/lib/command/working_process/install.rs`**: two end-to-end tests added to the install test module.
- **`tests/fixtures/install-projects/run-project-binary/`**: new fixture. The synthetic tarball carries a string-form `bin` (`./cli.sh`) plus the executable target; the project manifest declares a script that calls the binary name the linker exposes.
- **`docs/specs/cli/run/SPEC.md`**: note the install→`.bin`→`rpm run` reachability requirement and the missing-binary non-zero status contract (issue #143).

## Validation

### Done criteria (#143)

- **Project-local binary resolves through PATH.** `install_creates_bin_link_and_run_script_reaches_it` installs the fixture, asserts the `node_modules/.bin/cli-tool` symlink exists and points at `../@rpm-fixture/cli-tool/cli.sh`, then runs the `greet` script through `run_script` and asserts exit code 0.
- **Missing binary behavior remains readable and non-zero.** `run_script_reports_missing_binary_after_install` installs the fixture, then runs a script referencing a binary the installed packages do not expose; the shell reports `command not found` and the status is non-zero.
- **No reinstall or mutation of install output as a side of `rpm run`.** The success test fingerprints the repo root before and after `run_script` and asserts equality; the run path never touches the installer.

### Checks ran

- `just format-check` — pass
- `just check` (`cargo check --locked --all-targets`) — pass
- `just lint` (`cargo clippy` strict) — pass
- `just test` — **194 passed, 0 failed** (including the two new tests)
- `just validate` — `agent-assets.claude_security` fails, but that failure is pre-existing on `main` (unrelated to this change; it flags `.claude/settings.local.json` allow rules).

### Fixture governance

- Fixture is minimal: one dependency, one binary target.
- Tests copy the fixture into a temp directory before mutation (`TempProject`).
- Expected output is committed (`expected/resolved-packages.txt`).
- The test fails before the intended fix: removing the tarball spec makes `install_creates_bin_link_and_run_script_reaches_it` fail because `cli.sh` is never extracted and no `.bin` link is produced.
- No live network, no machine-dependent paths.

## Excluded

- Windows shims (`.cmd`/`.ps1`) — deferred to #163 (M10).
- Lifecycle script integration — #141, #142.
- Scoped package `.bin` unit cases — already covered by `node_linker` unit tests; this end-to-end fixture uses a scoped package with string-form `bin` to exercise the scope-drop behavior at the integration layer.