### PR TITLE
docs(specs): define install lifecycle script policy (#141)

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -160,6 +160,8 @@ docs/specs/
         SPEC.md
       performance/
         SPEC.md
+      scripts/
+        SPEC.md
     linker/
       SPEC.md
 ```
@@ -277,4 +279,6 @@ M1 should start from:
   recovery
 - `docs/specs/core/install/performance/SPEC.md`: installer bottleneck and
   measurement baseline
+- `docs/specs/core/install/scripts/SPEC.md`: install lifecycle script execution
+  contract
 - `docs/specs/core/linker/SPEC.md`: `node_modules` linking contract

--- a/docs/specs/cli/run/SPEC.md
+++ b/docs/specs/cli/run/SPEC.md
@@ -14,13 +14,14 @@ related_adrs:
   - 0002-single-crate-cli-core-boundary
 related_issues:
   - 50
+  - 141
 ---
 
 # Spec: Run Scripts
 
 Status: Draft
 Owner: cli/run
-Last reviewed: 2026-05-29
+Last reviewed: 2026-08-11
 
 ## Purpose
 
@@ -39,6 +40,18 @@ project's `node_modules/.bin` directory to `PATH` for the child process.
 The CLI returns the child process exit code when the script starts and exits
 normally. If the script process cannot be spawned, RPM returns a readable run
 error.
+
+`rpm run` is the **user-invoked** script execution path. It is distinct from
+install lifecycle execution: lifecycle hooks (`preinstall`, `install`,
+`postinstall`, `prepare`) run as an install phase and are owned by
+`docs/specs/core/install/scripts/SPEC.md` (#141). The two paths share one shell
+invocation model — both execute script text through the platform shell and
+prepend the project `node_modules/.bin` to `PATH` — so there is a single
+script-execution contract rather than two. `rpm run` reads only the root
+manifest's `scripts` map; lifecycle execution reads recognized hooks from both
+the root manifest and resolved-package registry metadata. Running a script
+through `rpm run` must never trigger lifecycle execution, and lifecycle
+execution must never trigger `rpm run`.
 
 ## Error Cases
 

--- a/docs/specs/core/README.md
+++ b/docs/specs/core/README.md
@@ -16,6 +16,7 @@ Current core contracts:
 - `install/cache/SPEC.md`
 - `install/recovery/SPEC.md`
 - `install/performance/SPEC.md`
+- `install/scripts/SPEC.md`
 - `linker/SPEC.md`
 
 ## M4 Ownership and Gap Audit
@@ -128,10 +129,10 @@ criteria.
 | platform considerations (`.cmd`, shebang) | `linker/SPEC.md` | explicitly deferred inside #139: the link layout is defined; Windows `.cmd`/`.ps1` shim generation, executable-bit handling, and permission normalization are deferred until a platform-packaging strategy SPEC (M10 / #163) owns them | delivered: #139 (active layout); deferred to M10 (platform shims) |
 | `rpm run` PATH prepend | `cli/run/SPEC.md` | `rpm run` prepends the project `node_modules/.bin` to `PATH` and propagates the child exit code; running a script must not reinstall or mutate install output | none |
 | missing `.bin` directory behavior in `rpm run` | `cli/run/SPEC.md` | the run SPEC assumes `.bin` is populated and does not own how it is populated (that is linker work), but it already owns the absent-binary case: a binary that is missing from `PATH` (including when `node_modules/.bin` is absent) must surface the shell's readable error and non-zero status (`cli/run/SPEC.md` Error Cases); #143 proves project-local binaries are reachable without mutating install output rather than redefining that existing behavior | #143 |
-| lifecycle script fields (`preinstall`, `install`, `postinstall`, `prepare`, ...) | `registry/SPEC.md` (ignored per-version), `manifest/SPEC.md` (root field) | the registry SPEC already classifies per-version `scripts` as ignored metadata and requires no install behavior to depend on it, including tolerant wrong-type handling; what is unowned is active lifecycle execution — there is no field contract for which hook names run, in what order, with what environment — so #141 must explicitly update the registry contract (including its tolerant wrong-type behavior) before #142 consumes transitive scripts, rather than treating the field as absent from every SPEC | #141 |
-| script command parsing | `cli/run/SPEC.md` (shell invocation only) | shell invocation is already owned for `rpm run`: scripts execute through the platform shell so command chaining, quoting, and environment assignment follow normal package-script semantics; what is unowned is the lifecycle-specific part — whether hook values are strings-only or arrays, and whether lifecycle hooks reuse the `rpm run` shell model or define a departure — so #141 must share or explicitly diverge from the existing run SPEC rather than create a second script-execution contract | #141 |
-| lifecycle execution as an install phase | `install/recovery/SPEC.md` | absent from the phase pipeline: the recovery contract enforces `resolve`, `fetch`, `extract`, `link`, `write` labels and has no `scripts` phase | #141 |
-| lifecycle script failure preserving install state | `install/recovery/SPEC.md` | no contract for rollback or partial-success prevention when a lifecycle script fails mid-install; the M3/M4 side-effect audit tables have no lifecycle row | #141 |
+| lifecycle script fields (`preinstall`, `install`, `postinstall`, `prepare`, ...) | `registry/SPEC.md` (per-version read/preserve), `manifest/SPEC.md` (root read/preserve), `install/scripts/SPEC.md` (active execution) | per-version `scripts` is now read and preserved as a `string -> string` map at the registry boundary (moved out of the ignored list, with tolerant wrong-type handling kept) and the root `scripts` map is read and preserved by the manifest SPEC; active lifecycle execution is owned by `install/scripts/SPEC.md`, which fixes the supported hook names (`preinstall`, `install`, `postinstall`, `prepare`), the `string -> string` value type, and the working-directory and PATH policy | delivered: #141 |
+| script command parsing | `cli/run/SPEC.md` (shell invocation model), `install/scripts/SPEC.md` (lifecycle reuse) | lifecycle hook values are strings-only and reuse the `rpm run` shell invocation model (`/bin/sh -c` on Unix, `cmd /C` on Windows) and the same `node_modules/.bin` PATH prepend, so there is a single script-execution contract rather than two; the relationship is made explicit in both `cli/run/SPEC.md` and `install/scripts/SPEC.md` | delivered: #141 |
+| lifecycle execution as an install phase | `install/recovery/SPEC.md`, `install/scripts/SPEC.md` | the recovery phase pipeline now includes a `scripts` phase between `link` and `write`, with the phase label and position contracted in `install/recovery/SPEC.md`; the within-package ordering (`preinstall`, `install`, `postinstall`, `prepare`) is owned by `install/scripts/SPEC.md`; active execution is deferred to #142 | delivered: #141 (contract); #142 (execution) |
+| lifecycle script failure preserving install state | `install/recovery/SPEC.md`, `install/scripts/SPEC.md` | a failed `scripts` phase cannot publish partial successful install state: it runs between `link` and `write`, so the staged tree is discarded and the previous `node_modules`, `rpm.lock`, and `package.json` remain unchanged; the invariant is stated in both SPECs and an M6 lifecycle row is added to the recovery side-effect audit | delivered: #141 |
 
 Findings:
 
@@ -148,17 +149,23 @@ Findings:
   defined for every platform; platform-specific shim or `.cmd` behavior is
   explicitly deferred inside #139 until M10 / #163 owns a platform-packaging
   strategy.
-- Lifecycle scripts are the larger ownership gap: they are not covered by an
-  active execution SPEC. Per-version `scripts` are already classified as ignored
-  registry metadata (`registry/SPEC.md`) and the manifest SPEC names `scripts` in
-  its Purpose but defines no field contract, the recovery SPEC's phase pipeline
-  has no `scripts` phase, and the M3/M4 side-effect audits have no lifecycle row.
-  #141 owns the whole lifecycle cluster: supported phases, ordering, environment,
-  PATH, failure behavior, and rollback expectations, plus the registry SPEC
-  update that moves `scripts` from ignored to consumed (including its tolerant
-  wrong-type behavior) before #142 consumes transitive scripts, and the recovery
-  SPEC update that adds a `scripts` phase and the invariant that a failed script
-  phase cannot publish partial successful install state.
+- Lifecycle scripts are now under contract. Per-version `scripts` was previously
+  classified as ignored registry metadata and the manifest SPEC named `scripts`
+  in its Purpose but defined no field contract; the recovery phase pipeline had
+  no `scripts` phase, and the M3/M4 side-effect audits had no lifecycle row.
+  #141 has delivered the whole lifecycle cluster: supported phases (`preinstall`,
+  `install`, `postinstall`, `prepare`), within-package ordering, the
+  `string -> string` value type, working-directory and PATH policy, failure
+  behavior, and the rollback invariant that a failed `scripts` phase cannot
+  publish partial successful install state. The registry SPEC moves per-version
+  `scripts` out of the ignored list to read-and-preserve (with tolerant
+  wrong-type handling kept), the recovery SPEC adds a `scripts` phase between
+  `link` and `write` plus an M6 lifecycle side-effect row, and the run SPEC
+  records that lifecycle execution reuses the `rpm run` shell invocation model
+  rather than defining a second one. Active execution of the first phase is
+  tracked by #142; cross-package ordering, npm-specific environment variables,
+  and any opt-in skip-on-failure policy remain Open Questions in
+  `install/scripts/SPEC.md`.
 - `rpm run` integration is mostly owned: `cli/run/SPEC.md` already prepends
   `node_modules/.bin` to PATH and propagates exit codes without reinstalling. The
   one remaining gap — behavior when `.bin` is absent — is owned by #143, which
@@ -166,7 +173,7 @@ Findings:
   install output.
 - The delivery order follows the issue: (1) this contract and gap audit, (2) #139
   `.bin` and `bin` contract, (3) `.bin` fixture coverage, (4) #140 first `.bin`
-  link forms, (5) #141 lifecycle policy, (6) #142 first lifecycle phase with
-  failure-safe install state, (7) #143 `rpm run` PATH verification. Lifecycle
-  behavior is kept separable from linker behavior throughout so #139/#140 can
-  land without forcing #141/#142, and vice versa.
+  link forms, (5) #141 lifecycle policy (delivered), (6) #142 first lifecycle
+  phase with failure-safe install state, (7) #143 `rpm run` PATH verification.
+  Lifecycle behavior is kept separable from linker behavior throughout so
+  #139/#140 can land without forcing #141/#142, and vice versa.

--- a/docs/specs/core/install/recovery/SPEC.md
+++ b/docs/specs/core/install/recovery/SPEC.md
@@ -3,7 +3,7 @@ spec_id: install_recovery
 title: Install Recovery
 status: draft
 owner: core/install/recovery
-last_reviewed: 2026-06-22
+last_reviewed: 2026-08-11
 authors:
   - nerdchanii
 deciders:
@@ -16,13 +16,15 @@ related_issues:
   - 50
   - 79
   - 81
+  - 141
+  - 142
 ---
 
 # Spec: Install Recovery
 
 Status: Draft
 Owner: core/install/recovery
-Last reviewed: 2026-06-22
+Last reviewed: 2026-08-11
 
 ## Purpose
 
@@ -41,16 +43,30 @@ complete successfully. If replacement itself fails, RPM attempts to restore the
 previous directory before returning the write failure.
 
 Failures must include the failed phase in the returned error message for cached
-package installation. This contract currently enforces `resolve`, `fetch`,
-`extract`, `link`, and `write` labels for cached package installation. Registry
-fetch and cache-write failures must be returned to callers instead of being
-ignored or reported as successful downloads.
+package installation. This contract enforces `resolve`, `fetch`, `extract`,
+`link`, `scripts`, and `write` labels for cached package installation. The
+`scripts` phase runs between `link` and `write` and is owned by
+`docs/specs/core/install/scripts/SPEC.md` (#141); its execution is deferred
+until #142, but the phase label and its position in the pipeline are part of
+this recovery contract now so that implementation does not have to re-derive
+where lifecycle hooks attach. Registry fetch and cache-write failures must be
+returned to callers instead of being ignored or reported as successful
+downloads.
 
 ## Error Cases
 
 A failed resolve, fetch, extract, or link phase must leave the previous
 `node_modules` directory untouched. A failed write phase must not be reported as
 a successful install.
+
+A failed `scripts` phase must leave the previous `node_modules` directory
+untouched, must not write or rewrite `rpm.lock` or `package.json` (those writes
+belong to the `write` phase, which has not run), and must not be reported as a
+successful install. Because the `scripts` phase runs between `link` and
+`write`, a lifecycle hook failure occurs while the staged replacement has been
+linked but not yet renamed into place; the staged tree is discarded, so the
+published install never reflects a partial lifecycle run. This invariant is
+owned jointly with `docs/specs/core/install/scripts/SPEC.md` (#141).
 
 ## M3 Side-Effect Audit
 
@@ -113,8 +129,38 @@ Findings:
 - No phase is stale, no contract is changed by M4, and no phase lacks SPEC
   ownership. No new follow-up issue is required from this audit.
 
+## M6 Lifecycle Phase Audit
+
+The 2026-08-11 M6 audit adds the `scripts` phase to the recovery pipeline
+between `link` and `write`, so lifecycle hook execution has a contracted home
+before any execution lands in #142. The phase label and its position are part
+of this recovery contract now; the active execution is owned by
+`docs/specs/core/install/scripts/SPEC.md` (#141).
+
+| Phase | Owning SPEC(s) | M6 change | Side-effect status | Current tests | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| scripts (lifecycle hooks) | recovery, install/scripts | phase label and position contracted (#141); execution deferred to #142 | not yet executed in production; when implemented, a failed `scripts` phase discards the staged tree and leaves `node_modules`, `rpm.lock`, and `package.json` unchanged | none yet; #142 will add success, failure, missing-command, wrong-type, and environment/PATH fixtures | conforms (contracted, not yet implemented) |
+
+Findings:
+
+- The `scripts` phase is the only M6 addition to the recovery pipeline. It
+  inherits the existing staged-replacement guarantee: a hook failure occurs
+  while the staged replacement is linked but not yet published, so the previous
+  `node_modules` stays in place and no lockfile or manifest write has run.
+- The within-package lifecycle ordering (`preinstall`, `install`,
+  `postinstall`, `prepare`) and the failure invariant (a failed `scripts` phase
+  cannot publish partial successful install state) are owned by
+  `docs/specs/core/install/scripts/SPEC.md`. This recovery SPEC owns only the
+  phase label, its position, and the staged-tree discard guarantee.
+- No existing M3 or M4 phase is changed by adding the `scripts` phase. The
+  `resolve`, `fetch`, `extract`, `link`, and `write` labels and their
+  side-effect classifications stand unchanged.
+
 ## Test Fixtures
 
 Recovery verification should cover staged replacement success plus resolve,
-fetch, extract, link, and write failures that leave the previous `node_modules`
-contents intact.
+fetch, extract, link, scripts, and write failures that leave the previous
+`node_modules` contents intact. Scripts-phase fixtures are planned by
+`docs/specs/core/install/scripts/SPEC.md` (#141) and land with #142; they must
+prove that a failed lifecycle hook leaves `node_modules`, `rpm.lock`, and
+`package.json` unchanged.

--- a/docs/specs/core/install/scripts/SPEC.md
+++ b/docs/specs/core/install/scripts/SPEC.md
@@ -1,0 +1,252 @@
+---
+spec_id: install_lifecycle_scripts
+title: Install Lifecycle Scripts
+status: draft
+owner: core/install/scripts
+last_reviewed: 2026-08-11
+authors:
+  - nerdchanii
+deciders:
+  - nerdchanii
+consulted: []
+informed: []
+related_adrs:
+  - 0002-single-crate-cli-core-boundary
+related_issues:
+  - 138
+  - 141
+  - 142
+---
+
+# Spec: Install Lifecycle Scripts
+
+Status: Draft
+Owner: core/install/scripts
+Last reviewed: 2026-08-11
+
+## Purpose
+
+Install-time lifecycle scripts can mutate the filesystem, so their execution
+must be a contracted install phase rather than an ad-hoc side effect. This
+contract defines which lifecycle hooks RPM recognizes, when they run during
+install, the environment they execute in, how their failure is reported, and the
+invariant that a failed script phase cannot publish partial successful install
+state.
+
+This contract is the M6 lifecycle policy named by issue #141. It owns the whole
+lifecycle cluster before any execution lands in #142. It is intentionally a
+policy contract only: #142 implements the first phase selected here, and the
+remaining phases stay deferred under this contract until a later issue claims
+them.
+
+## Contract
+
+### Lifecycle hook inventory
+
+RPM recognizes the following install lifecycle hooks, read from the
+`scripts` map of the root package manifest and of each resolved package's
+per-version registry metadata:
+
+| Hook | Phase owner | Scope | Status |
+| --- | --- | --- | --- |
+| `preinstall` | `install/scripts` | root and resolved packages | the first phase to implement (#142) |
+| `install` | `install/scripts` | root and resolved packages | deferred under this contract |
+| `postinstall` | `install/scripts` | root and resolved packages | deferred under this contract |
+| `prepare` | `install/scripts` | root and resolved packages | deferred under this contract |
+
+All other `scripts` entries (for example `prepublish`, `prestart`, `start`,
+`poststart`, `prestop`, `stop`, `poststop`, `test`, `build`, and any custom
+name) are **not lifecycle hooks**. RPM preserves them on the manifest and the
+per-version registry record but never invokes them during install. They remain
+reachable as user-invoked scripts through `rpm run`
+(`docs/specs/cli/run/SPEC.md`), which is a separate execution path and is not an
+install side effect.
+
+The set of supported install lifecycle hooks is exactly the four listed above.
+Adding, removing, or reordering a hook is a contract change to this SPEC, not an
+implementation detail.
+
+### Unsupported lifecycle phases
+
+npm defines additional install-time and publish-time lifecycle hooks (for
+example `prepublishOnly`, `prepack`, `postpack`, `prepublish`, `preinstall`,
+`install`, `postinstall`, `preprepare`, `prepare`, `postprepare`,
+`preuninstall`, `uninstall`, `postuninstall`). Of these, RPM supports only
+`preinstall`, `install`, `postinstall`, and `prepare`. Every other npm
+lifecycle hook is explicitly **unsupported** during install: it is preserved on
+the manifest and registry record, never invoked, and never an install side
+effect. A package that declares an unsupported hook installs normally; the hook
+is ignored, not an error.
+
+### Hook value type
+
+Lifecycle hook values are **strings only**. RPM reads the `scripts` map as
+`string -> string`. A hook whose value is not a string is discarded as absent
+during deserialization, consistent with the tolerant wrong-type handling for
+preserved fields (`docs/specs/core/manifest/SPEC.md`,
+`docs/specs/core/registry/SPEC.md`). An array-valued or object-valued hook does
+not run and does not fail the install.
+
+Lifecycle hooks do not introduce a second script-execution model. They reuse
+the `rpm run` shell invocation model (`docs/specs/cli/run/SPEC.md`): each hook
+value is executed through the platform shell (`/bin/sh -c` on Unix, `cmd /C` on
+Windows), so command chaining, quoting, and environment assignment follow
+normal package-script semantics. This contract does not define a departure from
+that model.
+
+### Ordering within an install
+
+When lifecycle execution is implemented, hooks run as a distinct install
+**phase**, inserted into the recovery phase pipeline between `link` and `write`
+(see `docs/specs/core/install/recovery/SPEC.md`). The phase label is `scripts`.
+
+Within the `scripts` phase, the per-package ordering for install hooks is:
+
+1. `preinstall`
+2. `install`
+3. `postinstall`
+4. `prepare`
+
+This ordering is fixed by this contract. A later hook does not run if an
+earlier hook in the same package has already failed the phase (see "Failure
+behavior").
+
+The ordering **across packages** is deliberately left as an Open Question
+(death-by-dependency-ordering, root-first vs leaves-first, parallel vs
+sequential). This contract only fixes the within-package order today. Until that
+cross-package ordering is owned by a follow-up issue, the `scripts` phase must
+execute hooks in a single deterministic order within each package and must not
+rely on HashMap iteration order or network timing to pick that order.
+
+### Hook environment and PATH
+
+Lifecycle hooks execute with an environment contract that is narrower than
+npm's. This contract defines only what RPM guarantees today:
+
+- **Working directory.** A root lifecycle hook runs with the project root as its
+  working directory. A resolved-package lifecycle hook runs with that package's
+  installed directory under `node_modules/` as its working directory. This
+  matches the install phase that owns the hook: root hooks are owned by the
+  project install, package hooks by the installed package directory.
+- **PATH.** Lifecycle hooks receive the same PATH prepend policy as `rpm run`:
+  the project `node_modules/.bin` is prepended to the inherited `PATH`. For
+  resolved-package hooks, `.bin` generation
+  (`docs/specs/core/linker/SPEC.md`) has already run in the preceding `link`
+  phase, so the project `node_modules/.bin` is populated before any hook runs.
+  `.bin` generation and lifecycle execution remain independent phases; this
+  contract only fixes the PATH ordering, not a dependency between them.
+- **Child status propagation.** The child process exit status is propagated per
+  `docs/specs/cli/run/SPEC.md`: a hook that exits non-zero fails the phase with
+  that status; a hook that cannot be spawned surfaces a readable run error.
+
+RPM does **not** set npm-specific environment variables today (`npm_lifecycle_event`,
+`npm_lifecycle_script`, `npm_config_*`, `npm_package_*`, `INIT_CWD`). These are
+deliberately out of scope for the first phase. Adding any of them is a contract
+change to this SPEC, not an implementation detail. A future issue must own
+which, if any, are added.
+
+### Failure behavior and install state
+
+A failed lifecycle hook fails the `scripts` phase. The phase failure is reported
+with the phase label `scripts`, matching the recovery contract's labeled-phase
+error guarantee.
+
+**Invariant: a failed `scripts` phase cannot publish partial successful install
+state.** Because the `scripts` phase runs between `link` and `write`, a hook
+failure occurs while the previous `node_modules` is still in place: the staged
+replacement has been linked but not yet renamed into place. The recovery
+contract's existing guarantees therefore apply unchanged:
+
+- A failed `scripts` phase leaves the previous `node_modules` directory
+  untouched (the staged replacement is discarded, not published).
+- A failed `scripts` phase is not reported as a successful install.
+- A failed `scripts` phase must not write or rewrite `rpm.lock` or
+  `package.json`; the `write` phase (which owns those writes) has not run.
+
+There is no force-continue or skip-on-failure policy for lifecycle hooks today.
+A failed hook fails the install for the whole transaction. A future issue may
+own an opt-in skip policy; until then, any hook failure is fatal to the install.
+
+A hook that mutates files inside or outside the workspace is still subject to
+the user-controlled filesystem safety rules: RPM confines its own writes to
+approved roots and validates inputs before mutation. Lifecycle hooks execute
+arbitrary user/registry-controlled commands, so RPM does not guarantee a hook's
+internal effects are reversible. What RPM guarantees is narrower: the install
+transaction either reaches `write` (and publishes a complete, consistent
+install) or it does not publish any install state. A hook that has already run
+and mutated the staged tree before a later hook fails does not get its effects
+rolled back inside the staged tree, but the staged tree itself is discarded, so
+the published install never reflects a partial lifecycle run.
+
+### Relationship to `rpm run`
+
+Lifecycle hook execution and `rpm run` share a shell invocation model but are
+different execution paths:
+
+- `rpm run <script>` is a user-invoked command. It must not reinstall or mutate
+  install output (`docs/specs/cli/run/SPEC.md`). It reads the root manifest's
+  `scripts` map only.
+- Lifecycle hooks are install-driven. They run during the `scripts` phase, read
+  from both the root manifest and resolved-package registry metadata, and their
+  failure controls install state.
+
+This contract does not redefine `rpm run`. It reuses `rpm run`'s shell
+invocation and PATH prepend so there is one script-execution contract, not two.
+
+## Error Cases
+
+- A lifecycle hook value that is not a string is discarded as absent; the hook
+  does not run and the install is not failed. This is the tolerant wrong-type
+  handling shared with `docs/specs/core/manifest/SPEC.md` and
+  `docs/specs/core/registry/SPEC.md`.
+- A supported lifecycle hook that exits non-zero fails the `scripts` phase with
+  that exit status. The phase label `scripts` must appear in the error.
+- A supported lifecycle hook that cannot be spawned surfaces a readable run
+  error and fails the `scripts` phase; it is not reported as a successful
+  install.
+- An unsupported lifecycle hook name (anything outside `preinstall`, `install`,
+  `postinstall`, `prepare`) is never an error: it is preserved and ignored.
+- A failed `scripts` phase must not publish partial install state (see
+  "Failure behavior and install state").
+
+## Test Fixtures
+
+No lifecycle fixtures exist yet. This is a policy-only contract; implementation
+lands in #142. The following fixture scenarios are planned for #142 and any
+later lifecycle phase, and must follow `docs/conventions/install_fixture_outputs.md`
+and stay offline and deterministic:
+
+- a successful lifecycle hook that runs during install and observes the
+  contracted working directory and PATH;
+- a failing lifecycle hook that exits non-zero and fails the `scripts` phase
+  with the `scripts` label, while the previous `node_modules` and the
+  `rpm.lock`/`package.json` remain unchanged;
+- a hook whose command is missing, surfacing a readable run error and non-zero
+  status without publishing install state;
+- a wrong-type hook value (array or object) that is discarded as absent so the
+  install proceeds;
+- environment and PATH behavior verification (project `node_modules/.bin`
+  prepended; no `npm_*` variables set).
+
+Each scenario must be a single deterministic fixture under
+`tests/fixtures/install-projects/`, scaffolded by `scripts/new-install-fixture.sh`
+or `just fixture <name>`, and must not assert behavior outside this contract.
+
+## Open Questions
+
+Each open question is a deferred decision that does not block the first phase
+(#142). They are listed here so #142 does not silently resolve them in code.
+
+- Cross-package hook ordering during the `scripts` phase (root-first vs
+  leaves-first, sequential vs parallel, dependency order). This contract fixes
+  only the within-package order. A follow-up issue must own the cross-package
+  order before more than the first phase lands.
+- Which, if any, npm-specific environment variables (`npm_lifecycle_event`,
+  `npm_lifecycle_script`, `npm_config_*`, `npm_package_*`, `INIT_CWD`) RPM sets
+  for lifecycle hooks. None are set today.
+- Whether RPM supports an opt-in skip-on-failure or force-continue policy for
+  lifecycle hooks. None exists today; any hook failure is fatal to the install.
+- Whether `prepare` (which npm also runs at git-dep install and at local
+  `npm install` without arguments) gains additional trigger points beyond the
+  install ordering fixed here. Today `prepare` is only an install-phase hook
+  with the same trigger as the other three.

--- a/docs/specs/core/manifest/SPEC.md
+++ b/docs/specs/core/manifest/SPEC.md
@@ -18,6 +18,8 @@ related_issues:
   - 130
   - 133
   - 139
+  - 141
+  - 142
 ---
 
 # Spec: Package Manifest
@@ -150,6 +152,40 @@ vector; the traversal guard is owned by the linker contract. An object-form
 `bin` key that is not a single path component (absolute, separator-containing,
 parent-referencing, or empty) is likewise rejected by the linker before any
 `.bin` entry is written; see `docs/specs/core/linker/SPEC.md`.
+
+### Scripts field
+
+RPM reads and preserves the root `scripts` map when it is present, using
+npm-accurate type (`string -> string`). Values are preserved verbatim; RPM does
+not rewrite, validate, or canonicalize script text. A present-but-wrong-type
+`scripts` value (for example a string, an array, or a map whose values are not
+strings) is discarded as absent during deserialization rather than failing the
+manifest, mirroring the lenient handling used for other preserved fields. A
+well-typed value round-trips into `Some(...)`. A manifest that omits `scripts`
+behaves identically to one without it.
+
+The manifest boundary owns reading and preserving `scripts` only. The read
+entries do not influence resolution, version selection, the resolved graph, or
+the lockfile. They are consumed by two distinct downstream behaviors, each with
+its own contract:
+
+- **`rpm run`** reads the root manifest's `scripts` map to execute a
+  user-named script on demand. Running a script must not reinstall or mutate
+  install output (`docs/specs/cli/run/SPEC.md`). Any script name is reachable
+  through `rpm run`, not only the lifecycle names below.
+- **Install lifecycle execution** reads the recognized lifecycle hooks from the
+  `scripts` map and runs them as an install phase. The supported install
+  lifecycle hook names are exactly `preinstall`, `install`, `postinstall`, and
+  `prepare`. Every other `scripts` entry is preserved but never invoked during
+  install. The active lifecycle execution contract — ordering, environment,
+  PATH, failure behavior, and the invariant that a failed script phase cannot
+  publish partial successful install state — is owned by
+  `docs/specs/core/install/scripts/SPEC.md` (#141).
+
+Per-version `scripts` on registry packuments are read and preserved at the
+registry boundary (`docs/specs/core/registry/SPEC.md`) under the same
+`string -> string` shape and the same wrong-type tolerance, and feed the same
+lifecycle execution contract for resolved packages.
 
 ## Error Cases
 

--- a/docs/specs/core/registry/SPEC.md
+++ b/docs/specs/core/registry/SPEC.md
@@ -24,6 +24,8 @@ related_issues:
   - 133
   - 136
   - 139
+  - 141
+  - 142
   - 170
 ---
 
@@ -144,6 +146,23 @@ rather than failing the packument, consistent with the lenient handling of
 other preserved fields. A version that omits `bin` simply contributes no
 `.bin` entries.
 
+Lifecycle script fields. Per-version `scripts` is read and preserved as a
+`string -> string` map so the install lifecycle phase can execute recognized
+lifecycle hooks (`preinstall`, `install`, `postinstall`, `prepare`). The
+registry boundary owns only reading and preserving `scripts`; it does not
+influence version selection, dependency edges, cache writes, or integrity
+verification, and the registry boundary does not execute scripts. The active
+lifecycle execution contract — which hook names run, in what order, with what
+environment and PATH, and how their failure preserves install state — is owned
+by `docs/specs/core/install/scripts/SPEC.md` (#141). A present-but-wrong-type
+`scripts` value (for example a string or array) is discarded as absent during
+deserialization rather than failing the packument, consistent with the lenient
+handling of other preserved fields; the lifecycle phase then sees no hooks for
+that package and proceeds. A version that omits `scripts` simply contributes no
+lifecycle hooks. Non-lifecycle `scripts` entries (for example `test`, `build`,
+`start`) are preserved but are not invoked during install; they remain
+reachable only through `rpm run` (`docs/specs/cli/run/SPEC.md`).
+
 ### Ignored metadata fields
 
 The following fields are deserialized for document fidelity but are not consumed
@@ -176,13 +195,15 @@ verification:
   for `engines`/`os`/`cpu` is owned by
   `docs/specs/core/manifest/SPEC.md`; per-version values on registry packuments
   remain ignored here until that strategy consumes them.
-- `main`, `types`, `scripts`, `private`,
+- `main`, `types`, `private`,
   `repository`, `description`, `maintainers`, `author`, `homepage`, `keywords`,
   `license`, `readme`, `readmeFilename`, `time`, `_id`, `_rev`, and `sequence`.
   These do not influence resolution, download, verification, extraction,
   linking, lockfile, or manifest output. Package `bin` metadata was previously
   listed here; it is now read for `.bin` generation (see "Package bin metadata"
-  under Consumed metadata fields).
+  under Consumed metadata fields). Per-version `scripts` was previously listed
+  here; it is now read and preserved for lifecycle execution (see "Lifecycle
+  script fields" under Consumed metadata fields).
 
 Ignored means RPM may accept documents that carry these fields, but no active
 behavior depends on them. An ignored field that is invalid or missing must not
@@ -191,14 +212,19 @@ packument that omits or malforms any of them still parses. A
 present-but-wrong-type value is discarded as absent during deserialization
 rather than failing the packument, regardless of the field's expected shape.
 This applies uniformly to all ignored fields: string fields such as `main`,
-`license`, `readme`, and `readmeFilename`; map fields such as `scripts`,
+`license`, `readme`, and `readmeFilename`; map fields such as
 `devDependencies`, `peerDependencies`, and `optionalDependencies`; array fields
 such as `os`, `cpu`, and `keywords`; scalar fields such as `private` and
 `sequence`; and the untagged-enum fields `repository`, `author`,
 `bundledDependencies`, `engines`, `time`, `_rev`, and `homepage`. A wrong-type
 value for any of these (for example a SPDX object-form `license`, a numeric
-`engines`, or a string `scripts`) is dropped to its absence without aborting
-packument parsing. Well-typed values still round-trip into `Some(...)`.
+`engines`) is dropped to its absence without aborting packument parsing.
+Well-typed values still round-trip into `Some(...)`. The same lenient
+deserialization applies to preserved fields that are consumed downstream
+(`bin`, `scripts`): a present-but-wrong-type `bin` or `scripts` value (for
+example a string `scripts`) is discarded as absent without failing the
+packument, while a well-typed value round-trips into `Some(...)` for the
+downstream owner to consume.
 
 ### Unsupported metadata behavior
 
@@ -396,6 +422,10 @@ not duplicate the contract text above.
   strategy, or platform gating owns the active behavior. Package `bin` metadata
   is now consumed for `.bin` generation
   (`docs/specs/core/linker/SPEC.md`, #139) and is no longer an open question.
+  Per-version `scripts` is now read and preserved for lifecycle execution
+  (`docs/specs/core/install/scripts/SPEC.md`, #141) and is no longer an open
+  question at this boundary; active execution of the first phase is tracked by
+  #142.
   The root manifest `optionalDependencies` read-and-preserve
   baseline is now owned by `docs/specs/core/manifest/SPEC.md`; per-version
   `optionalDependencies` on registry packuments remain ignored here until an


### PR DESCRIPTION
## Contract

Defines the install lifecycle script policy before any execution lands (issue #141). This is a SPEC-only change: no production code is modified. It closes the M6 lifecycle cluster that the M6 gap audit (#138) identified as unowned.

Closes #141.

## Changes

- **New SPEC** `docs/specs/core/install/scripts/SPEC.md` — owns the M6 lifecycle cluster:
  - Supported hook names: `preinstall`, `install`, `postinstall`, `prepare` (exactly these four; all other npm lifecycle hooks explicitly unsupported during install, preserved but ignored)
  - Hook value type: `string -> string` (wrong-type discarded as absent, matching the existing tolerant deserialization)
  - Within-package ordering: `preinstall` → `install` → `postinstall` → `prepare`
  - New install phase `scripts` between `link` and `write` (phase label and position contracted now; execution deferred to #142)
  - Environment & PATH: working directory (root vs installed package dir), project `node_modules/.bin` prepended; no `npm_*` variables set today
  - Failure invariant: a failed `scripts` phase cannot publish partial successful install state (staged tree discarded; `node_modules`, `rpm.lock`, `package.json` unchanged)
  - Relationship to `rpm run`: reuses the same shell invocation model (`/bin/sh -c` / `cmd /C`) and PATH prepend — one script-execution contract, not two
  - Open Questions (deferred, each needs a follow-up issue): cross-package ordering, npm environment variables, opt-in skip-on-failure, additional `prepare` trigger points
- **`registry/SPEC.md`** — moved per-version `scripts` from the ignored list to read-and-preserve (consumed downstream by lifecycle execution), kept tolerant wrong-type handling; updated Open Questions
- **`manifest/SPEC.md`** — added "Scripts field" contract: read/preserve `string -> string`, recognized lifecycle hook names, two downstream consumers (`rpm run` + lifecycle execution), wrong-type tolerance
- **`install/recovery/SPEC.md`** — added `scripts` phase to the pipeline (between `link` and `write`), added failure invariant to Error Cases, added an M6 Lifecycle Phase Audit row, updated Test Fixtures
- **`cli/run/SPEC.md`** — recorded that lifecycle execution reuses the `rpm run` shell model and the two paths are distinct (shared model, separate triggers)
- **`core/README.md`** — updated the four M6 lifecycle audit rows to `delivered: #141`, refreshed the M6 Findings, added `install/scripts/SPEC.md` to the core contract list
- **`specs/README.md`** — added `install/scripts/SPEC.md` to the directory layout and Current Index

## Done criteria mapping (#141)

- ✅ Supported lifecycle phases are listed (hook inventory table)
- ✅ Unsupported phases are explicit (unsupported lifecycle phases section)
- ✅ Script environment and PATH policy are specified (environment & PATH section)
- ✅ Failed scripts do not publish partial successful install state (failure behavior + invariant)

## Validation

Ran the code-validation gates individually (this is a docs-only change; no production code touched):

- `just format-check` — pass
- `just check` — pass
- `just lint` (clippy strict) — pass, no warnings
- `just test` — 194 unit + 1 integration passed, 0 failed
- `just docs` (rustdoc `-D warnings`) — pass

Note: `just validate` also runs `just agent-assets`, which fails on pre-existing `.claude/settings.local.json` unreviewed-allow findings unrelated to this change. That gate is not affected by these SPEC edits.

## Checklist

- [x] SPEC-driven: owning SPEC created/updated before implementation (#142 implements)
- [x] Deferred implementation tracked explicitly (#142 for first phase; Open Questions each require a follow-up issue)
- [x] No behavior change in production code
- [x] No fixture changes (fixtures land with #142)
- [x] Code-validation gates green
