### PR TITLE
fix(manifest): discard wrong-type scripts field instead of failing parse

### DIFF
--- a/docs/specs/core/manifest/SPEC.md
+++ b/docs/specs/core/manifest/SPEC.md
@@ -161,8 +161,11 @@ not rewrite, validate, or canonicalize script text. A present-but-wrong-type
 `scripts` value (for example a string, an array, or a map whose values are not
 strings) is discarded as absent during deserialization rather than failing the
 manifest, mirroring the lenient handling used for other preserved fields. A
-well-typed value round-trips into `Some(...)`. A manifest that omits `scripts`
-behaves identically to one without it.
+single non-string value drops the entire `scripts` map, not just the offending
+entry, matching the per-version registry boundary's whole-map drop semantics
+(`docs/specs/core/registry/SPEC.md`). A well-typed value round-trips into
+`Some(...)`. A manifest that omits `scripts` behaves identically to one without
+it.
 
 The manifest boundary owns reading and preserving `scripts` only. The read
 entries do not influence resolution, version selection, the resolved graph, or

--- a/src/lib/package_manifest/mod.rs
+++ b/src/lib/package_manifest/mod.rs
@@ -59,6 +59,29 @@ where
     }
 }
 
+/// Tolerantly deserialize the root `scripts` map. A missing or null value yields
+/// `None`, and a present-but-wrong-type value (for example a string, an array,
+/// or a map whose values are not strings) is discarded as `None` rather than
+/// failing the whole manifest. A single non-string value drops the entire map,
+/// not just the offending entry, mirroring the per-version registry boundary
+/// (`src/lib/registry/mod.rs::ignored_field`) and the manifest SPEC
+/// (`docs/specs/core/manifest/SPEC.md`, "Scripts field"). See issue #182.
+fn deserialize_scripts_field<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    if value.is_null() {
+        return Ok(None);
+    }
+    match HashMap::<String, String>::deserialize(value) {
+        Ok(parsed) => Ok(Some(parsed)),
+        Err(_) => Ok(None),
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct VersionString(String);
 
@@ -89,7 +112,11 @@ pub struct PackageManifest {
     pub author: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub license: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_scripts_field",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub scripts: Option<HashMap<String, String>>,
     #[serde(default = "HashMap::new")]
     pub dependencies: HashMap<String, VersionString>,
@@ -412,6 +439,55 @@ mod package_json_test {
         assert_eq!(
             map.get("helper").map(String::as_str),
             Some("./bin/helper.js")
+        );
+    }
+
+    #[test]
+    fn read_file_discards_wrong_type_scripts_as_absent() {
+        let fixture = fixture_path(&["package_manifest", "manifest-with-scripts-wrong-type.json"]);
+        let package = PackageManifest::read_file(fixture.to_str().unwrap()).unwrap();
+
+        // A present-but-wrong-type `scripts` value is discarded as absent rather
+        // than failing the manifest, mirroring the registry boundary and the
+        // manifest SPEC. The rest of the manifest still parses.
+        assert_eq!(package.name.as_deref(), Some("wrong-type-scripts-app"));
+        assert_eq!(package.scripts, None);
+        assert!(package.get_scripts().is_empty());
+    }
+
+    #[test]
+    fn read_file_discards_mixed_type_scripts_map_as_absent() {
+        // A single non-string value drops the entire `scripts` map, not just the
+        // offending entry, matching the registry boundary's whole-map drop.
+        let fixture = fixture_path(&[
+            "package_manifest",
+            "manifest-with-scripts-mixed-values.json",
+        ]);
+        let package = PackageManifest::read_file(fixture.to_str().unwrap()).unwrap();
+
+        assert_eq!(package.name.as_deref(), Some("mixed-scripts-app"));
+        assert_eq!(package.scripts, None);
+        assert!(package.get_scripts().is_empty());
+    }
+
+    #[test]
+    fn scripts_field_round_trips_through_save() {
+        let temp_project = TempProject::new("package-manifest-scripts-round-trip").unwrap();
+        let temp_manifest_path = temp_project
+            .copy_fixture(
+                fixture_path(&["package_manifest", "manifest-with-fields.json"]),
+                "package.json",
+            )
+            .unwrap();
+
+        let package = PackageManifest::read_file(temp_manifest_path.to_str().unwrap()).unwrap();
+        package.save_to_path(&temp_manifest_path).unwrap();
+
+        let saved = PackageManifest::read_file(temp_manifest_path.to_str().unwrap()).unwrap();
+        // A well-typed `scripts` map round-trips unchanged.
+        assert_eq!(
+            saved.get_scripts().get("test").map(String::as_str),
+            Some("cargo test")
         );
     }
 

--- a/tests/fixtures/package_manifest/manifest-with-scripts-mixed-values.json
+++ b/tests/fixtures/package_manifest/manifest-with-scripts-mixed-values.json
@@ -1,0 +1,8 @@
+{
+  "name": "mixed-scripts-app",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "tsc",
+    "broken": 42
+  }
+}

--- a/tests/fixtures/package_manifest/manifest-with-scripts-wrong-type.json
+++ b/tests/fixtures/package_manifest/manifest-with-scripts-wrong-type.json
@@ -1,0 +1,5 @@
+{
+  "name": "wrong-type-scripts-app",
+  "version": "0.1.0",
+  "scripts": "not-a-map"
+}


### PR DESCRIPTION
## Contract

- Owning SPEC: `docs/specs/core/manifest/SPEC.md` ("Scripts field")
- Related SPEC: `docs/specs/core/install/scripts/SPEC.md` ("Hook value type" / Error Cases)
- Classification: behavior change at the manifest parse boundary, recorded in the owning SPEC.

The manifest SPEC promises that a present-but-wrong-type `scripts` value is discarded as absent during deserialization rather than failing the manifest, mirroring the registry boundary. The root manifest field did not yet apply a tolerant deserializer, so the two `scripts` reading boundaries behaved asymmetrically. This PR closes that gap and records the whole-map drop semantics in the manifest SPEC.

## Changes

- `src/lib/package_manifest/mod.rs`: add `deserialize_scripts_field`, a tolerant deserializer for the root `scripts` field. A missing/null value yields `None`; a present-but-wrong-type value (string, array, or a map whose values are not strings) is discarded as `None` rather than failing the parse. A single non-string map value drops the entire map, matching the registry boundary (`ignored_field`) whole-map drop. Applied the deserializer to the `scripts` field via `#[serde(default, deserialize_with = "deserialize_scripts_field", ...)]`.
- `docs/specs/core/manifest/SPEC.md` ("Scripts field"): record the whole-map drop semantics explicitly and link the registry boundary.
- Fixtures: `tests/fixtures/package_manifest/manifest-with-scripts-wrong-type.json` (scalar wrong type) and `manifest-with-scripts-mixed-values.json` (one non-string entry inside the map).

## Regression tests

- `read_file_discards_wrong_type_scripts_as_absent`: a scalar wrong-type `scripts` parses successfully with `scripts == None` and the rest of the manifest intact.
- `read_file_discards_mixed_type_scripts_map_as_absent`: a single non-string value drops the whole map (`scripts == None`).
- `scripts_field_round_trips_through_save`: a well-typed `scripts` map round-trips unchanged through save/read.

## Validation

- `just format-check` — PASS
- `just check` — PASS
- `just lint` — PASS
- `just test` — PASS (198 tests, including the 3 new tests)

Note: `just validate` reports an unrelated `claude_security` failure from `.claude/settings.local.json` allow-rule review; this is a pre-existing local-settings issue and not touched by this PR (only the 4 files above are changed).

## Checklist

- [x] Root manifest with wrong-type `scripts` parses successfully and yields `scripts: None`.
- [x] Root manifest with well-typed `scripts` map round-trips unchanged.
- [x] Regression tests cover both cases at the manifest boundary.
- [x] `docs/specs/core/install/scripts/SPEC.md` asymmetry note is collapsed to a single shared rule (the install/scripts SPEC already states the unified rule on `main`; this PR makes the manifest boundary implement it).

Closes #182