### PR TITLE
chore(output): quiet routine validation output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,8 +119,14 @@ executable. It does not change tracked files outside the hook setup.
 Default hooks:
 
 - `pre-commit`: `cargo fmt --check`
-- `pre-push`: `cargo clippy --all-targets --all-features -- -D warnings`
-- `pre-push`: `cargo test`
+- `pre-push`: `cargo clippy --quiet --all-targets --all-features -- -D warnings`
+- `pre-push`: `cargo test --quiet`
+
+The pre-push checks use Cargo's quiet mode to hide intermediate build progress.
+Compiler diagnostics, test failures, summaries, and exit statuses remain visible.
+The `just build`, `just check`, `just lint`, `just test`, `just docs`, and
+`just validate` recipes follow the same output policy. Agent-asset validation
+prints one success summary and expands individual output only when a check fails.
 
 If you need to bypass the local guardrail for a one-off case, use normal Git hook
 escape hatches such as `--no-verify`. Do not treat that as a replacement for the

--- a/justfile
+++ b/justfile
@@ -8,8 +8,8 @@ default:
 
 # Build the local debug binary.
 build:
-    @echo "::rpm::begin build cargo build --locked"
-    cargo build --locked
+    @echo "::rpm::begin build cargo build --quiet --locked"
+    @cargo build --quiet --locked
     @echo "::rpm::end build"
 
 # Run the strict local validation gate.
@@ -19,78 +19,78 @@ alias verify := validate
 
 # Check Rust compilation without producing the final binary.
 check:
-    @echo "::rpm::begin check cargo check --locked --all-targets"
-    cargo check --locked --all-targets
+    @echo "::rpm::begin check cargo check --quiet --locked --all-targets"
+    @cargo check --quiet --locked --all-targets
     @echo "::rpm::end check"
 
 # Format Rust sources in place.
 format:
     @echo "::rpm::begin format cargo fmt --all"
-    cargo fmt --all
+    @cargo fmt --all
     @echo "::rpm::end format"
 
 # Verify Rust formatting without changing files.
 format-check:
     @echo "::rpm::begin format-check cargo fmt --all --check"
-    cargo fmt --all --check
+    @cargo fmt --all --check
     @echo "::rpm::end format-check"
 
 # Run Rust lints with repository guardrails that the current codebase satisfies.
 lint:
     @echo "::rpm::begin lint cargo clippy strict"
-    cargo clippy --locked --all-targets --all-features -- -D warnings -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_imports -D clippy::disallowed_methods -D clippy::disallowed_types -D clippy::disallowed_macros
+    @cargo clippy --quiet --locked --all-targets --all-features -- -D warnings -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented -D clippy::wildcard_imports -D clippy::disallowed_methods -D clippy::disallowed_types -D clippy::disallowed_macros
     @echo "::rpm::end lint"
 
 # Run tests. Extra cargo test args may be passed after the recipe name.
 test *args:
-    @echo "::rpm::begin test cargo test --locked --lib --bins --tests {{args}}"
-    cargo test --locked --lib --bins --tests {{args}}
+    @echo "::rpm::begin test cargo test --quiet --locked --lib --bins --tests {{args}}"
+    @cargo test --quiet --locked --lib --bins --tests {{args}}
     @echo "::rpm::end test"
 
 # Enforce the repository line coverage floor.
 coverage:
     @echo "::rpm::begin coverage rustup run stable cargo llvm-cov --fail-under-lines 90"
-    rustup run stable cargo llvm-cov --locked --lib --bins --all-features --fail-under-lines 90
+    @rustup run stable cargo llvm-cov --locked --lib --bins --all-features --fail-under-lines 90
     @echo "::rpm::end coverage"
 
 # Build documentation and fail on rustdoc warnings.
 docs:
-    @echo "::rpm::begin docs RUSTDOCFLAGS=-Dwarnings cargo doc --locked --no-deps"
-    RUSTDOCFLAGS="-Dwarnings" cargo doc --locked --no-deps
+    @echo "::rpm::begin docs RUSTDOCFLAGS=-Dwarnings cargo doc --quiet --locked --no-deps"
+    @RUSTDOCFLAGS="-Dwarnings" cargo doc --quiet --locked --no-deps
     @echo "::rpm::end docs"
 
 # Audit fixture structure before running behavior tests.
 audit-fixtures:
     @echo "::rpm::begin audit-fixtures"
-    ./scripts/audit-fixtures.sh
+    @./scripts/audit-fixtures.sh
     @echo "::rpm::end audit-fixtures"
 
 # Verify fixture creation helpers produce auditable fixtures.
 fixture-smoke:
     @echo "::rpm::begin fixture-smoke"
-    ./scripts/test-fixture-tools.sh
+    @./scripts/test-fixture-tools.sh
     @echo "::rpm::end fixture-smoke"
 
 # Validate project-scoped skills, agents, hooks, and deterministic workflow helpers.
 agent-assets:
     @echo "::rpm::begin agent-assets"
-    ./scripts/validate-agent-workflow-assets.sh --format=text
+    @./scripts/validate-agent-workflow-assets.sh --format=summary
     @echo "::rpm::end agent-assets"
 
 # Run benchmarks when benchmark targets exist. Extra cargo bench args are forwarded.
 bench *args:
     @echo "::rpm::begin bench cargo bench --locked {{args}}"
-    cargo bench --locked {{args}}
+    @cargo bench --locked {{args}}
     @echo "::rpm::end bench"
 
 # Create a new install-project fixture skeleton under tests/fixtures/install-projects.
 fixture name:
     @echo "::rpm::begin fixture {{name}}"
-    ./scripts/new-install-fixture.sh "{{name}}"
+    @./scripts/new-install-fixture.sh "{{name}}"
     @echo "::rpm::end fixture {{name}}"
 
 # Create a new performance fixture by copying the current benchmark baseline.
 bench-fixture name:
     @echo "::rpm::begin bench-fixture {{name}}"
-    ./scripts/new-bench-fixture.sh "{{name}}"
+    @./scripts/new-bench-fixture.sh "{{name}}"
     @echo "::rpm::end bench-fixture {{name}}"

--- a/justfile
+++ b/justfile
@@ -45,6 +45,7 @@ lint:
 test *args:
     @test_args=({{args}}); \
     verbose=0; \
+    quiet=0; \
     for arg in "${test_args[@]}"; do \
       case "${arg}" in \
         --verbose) verbose=1 ;; \
@@ -55,10 +56,11 @@ test *args:
             *) verbose=1 ;; \
           esac \
           ;; \
+        -q|--quiet) quiet=1 ;; \
       esac; \
     done; \
     cargo_command=(cargo test); \
-    if [ "${verbose}" -eq 0 ]; then cargo_command+=(--quiet); fi; \
+    if [ "${verbose}" -eq 0 ] && [ "${quiet}" -eq 0 ]; then cargo_command+=(--quiet); fi; \
     echo "::rpm::begin test ${cargo_command[*]} --locked --lib --bins --tests ${test_args[*]}"; \
     "${cargo_command[@]}" --locked --lib --bins --tests "${test_args[@]}"
     @echo "::rpm::end test"

--- a/justfile
+++ b/justfile
@@ -43,8 +43,17 @@ lint:
 
 # Run tests. Extra cargo test args may be passed after the recipe name.
 test *args:
-    @echo "::rpm::begin test cargo test --quiet --locked --lib --bins --tests {{args}}"
-    @cargo test --quiet --locked --lib --bins --tests {{args}}
+    @test_args=({{args}}); \
+    verbose=0; \
+    for arg in "${test_args[@]}"; do \
+      case "${arg}" in \
+        -v|-vv|--verbose) verbose=1 ;; \
+      esac; \
+    done; \
+    cargo_command=(cargo test); \
+    if [ "${verbose}" -eq 0 ]; then cargo_command+=(--quiet); fi; \
+    echo "::rpm::begin test ${cargo_command[*]} --locked --lib --bins --tests ${test_args[*]}"; \
+    "${cargo_command[@]}" --locked --lib --bins --tests "${test_args[@]}"
     @echo "::rpm::end test"
 
 # Enforce the repository line coverage floor.

--- a/justfile
+++ b/justfile
@@ -47,7 +47,14 @@ test *args:
     verbose=0; \
     for arg in "${test_args[@]}"; do \
       case "${arg}" in \
-        -v|-vv|--verbose) verbose=1 ;; \
+        --verbose) verbose=1 ;; \
+        -v*) \
+          shorthand="${arg#-}"; \
+          case "${shorthand}" in \
+            ''|*[!v]*) ;; \
+            *) verbose=1 ;; \
+          esac \
+          ;; \
       esac; \
     done; \
     cargo_command=(cargo test); \

--- a/scripts/codex-rust-analyzer.sh
+++ b/scripts/codex-rust-analyzer.sh
@@ -50,7 +50,7 @@ analyze() {
 cargo_check() {
   printf 'rust_analyzer.mode=cargo-fallback\n'
   cd -- "${repo_root}"
-  exec cargo check --locked --all-targets
+  exec cargo check --quiet --locked --all-targets
 }
 
 diagnose() {

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -18,5 +18,5 @@ git config --local core.hooksPath .githooks
 
 echo "Installed repo-local git hooks at .githooks"
 echo "pre-commit: cargo fmt --check"
-echo "pre-push: cargo clippy --all-targets --all-features -- -D warnings"
-echo "pre-push: cargo test"
+echo "pre-push: cargo clippy --quiet --all-targets --all-features -- -D warnings"
+echo "pre-push: cargo test --quiet"

--- a/scripts/run-local-git-hook-gate.sh
+++ b/scripts/run-local-git-hook-gate.sh
@@ -42,9 +42,9 @@ case "$hook_name" in
       echo "[local-hook] pre-push: ref-deletion-only push, skipping clippy/test gate"
       exit 0
     fi
-    run_gate "cargo clippy --all-targets --all-features -- -D warnings" \
-      cargo clippy --all-targets --all-features -- -D warnings
-    run_gate "cargo test" cargo test
+    run_gate "cargo clippy --quiet --all-targets --all-features -- -D warnings" \
+      cargo clippy --quiet --all-targets --all-features -- -D warnings
+    run_gate "cargo test --quiet" cargo test --quiet
     ;;
   *)
     echo "unsupported hook: $hook_name" >&2

--- a/scripts/test-codex-rust-analyzer.sh
+++ b/scripts/test-codex-rust-analyzer.sh
@@ -70,6 +70,6 @@ assert_contains "${output}" "rust_analyzer.reason=test rustup shim has no compon
 output="$(PATH="${temp_dir}:${PATH}" bash "${wrapper}" diagnose)"
 assert_contains "${output}" "rust_analyzer.fallback=cargo-check"
 assert_contains "${output}" "rust_analyzer.mode=cargo-fallback"
-assert_contains "${output}" "fake-cargo-args=check --locked --all-targets"
+assert_contains "${output}" "fake-cargo-args=check --quiet --locked --all-targets"
 
 printf 'codex_rust_analyzer_tests=ok\n'

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -546,13 +546,7 @@ check_summary_suppresses_skips() {
       RPM_VALIDATE_AGENT_WORKFLOW_ASSETS_REGRESSION=1 \
       bash scripts/validate-agent-workflow-assets.sh --format=summary
   )"
-  printf '%s\n' "${output}" | rg -q '^agent_assets.status=ok$'
-  if printf '%s\n' "${output}" | rg -q '^agent_assets\.skill_.*=skip$'; then
-    return 1
-  fi
-  if printf '%s\n' "${output}" | rg -q '^agent_assets\.skill_.*\.output\.(begin|end)$'; then
-    return 1
-  fi
+  [ "${output}" = "agent_assets.status=ok" ]
 }
 
 for skill in .agents/skills/*; do

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -69,6 +69,28 @@ check() {
   fi
 }
 
+if [ "${RPM_VALIDATE_AGENT_WORKFLOW_ASSETS_REGRESSION:-}" = "1" ]; then
+  check_summary_formatter() {
+    local output
+    local expected
+    expected=$'agent_assets.summary_failure=fail\nagent_assets.summary_failure.output.begin\nsummary failure diagnostics\nagent_assets.summary_failure.output.end'
+    output="$(
+      emit_check "summary_skip" "skip" "skipped checks stay hidden"
+      emit_check "summary_failure" "fail" "summary failure diagnostics"
+    )"
+    if [ "${output}" != "${expected}" ]; then
+      printf 'summary formatter output mismatch\nexpected:\n%s\nactual:\n%s\n' \
+        "${expected}" "${output}" >&2
+      return 1
+    fi
+  }
+
+  check "summary_formatter" check_summary_formatter
+  printf 'agent_assets.status=%s\n' "${status}"
+  [ "${status}" = "ok" ] || exit 1
+  exit 0
+fi
+
 with_fake_collect_gh() {
   local fixture="$1"
   shift
@@ -549,6 +571,26 @@ check_summary_suppresses_skips() {
   [ "${output}" = "agent_assets.status=ok" ]
 }
 
+check_just_test_verbosity() {
+  local temp_dir
+  local output
+  temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/rpm-just-test-verbosity.XXXXXX")"
+  trap 'rm -f "${temp_dir}/cargo"; rmdir "${temp_dir}"' RETURN
+  ln -s /bin/echo "${temp_dir}/cargo"
+
+  output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test -v)"
+  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests -v$'
+
+  output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test -vv)"
+  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests -vv$'
+
+  output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test --verbose)"
+  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests --verbose$'
+
+  output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test package_filter --nocapture)"
+  printf '%s\n' "${output}" | rg -q '^test --quiet --locked --lib --bins --tests package_filter --nocapture$'
+}
+
 for skill in .agents/skills/*; do
   [ -d "${skill}" ] || continue
   name="$(basename "${skill}")"
@@ -674,9 +716,8 @@ check "script_check_claude_security_syntax" \
 check "script_validate_agent_workflow_assets_syntax" \
   bash -n scripts/validate-agent-workflow-assets.sh
 
-if [ "${RPM_VALIDATE_AGENT_WORKFLOW_ASSETS_REGRESSION:-}" != "1" ]; then
-  check "summary_suppresses_skips" check_summary_suppresses_skips
-fi
+check "summary_suppresses_skips" check_summary_suppresses_skips
+check "just_test_verbosity" check_just_test_verbosity
 
 check "collect_pr_review_context_paginates" check_collect_paginates_comments_and_reviews
 check "collect_pr_review_context_no_duplicates" check_collect_does_not_duplicate_exhausted_connections

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -26,7 +26,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-if [ "${format}" != "jsonl" ] && [ "${format}" != "text" ]; then
+if [ "${format}" != "jsonl" ] && [ "${format}" != "text" ] && [ "${format}" != "summary" ]; then
   printf 'agent_assets.error=invalid-format:%s\n' "${format}" >&2
   exit 2
 fi
@@ -48,7 +48,7 @@ emit_check() {
       --arg status "${result}" \
       --arg output "${output}" \
       '{type:"agent_asset_check",data:{name:$name,status:$status,output:(if $output == "" then null else $output end)}}'
-  else
+  elif [ "${format}" = "text" ] || [ "${result}" != "ok" ]; then
     printf 'agent_assets.%s=%s\n' "${name}" "${result}"
     if [ -n "${output}" ]; then
       printf 'agent_assets.%s.output.begin\n%s\nagent_assets.%s.output.end\n' \

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -579,19 +579,25 @@ check_just_test_verbosity() {
   ln -s /bin/echo "${temp_dir}/cargo"
 
   output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test -v)"
-  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests -v$'
+  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests -v$' || return 1
 
   output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test -vv)"
-  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests -vv$'
+  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests -vv$' || return 1
 
   output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test -vvv)"
-  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests -vvv$'
+  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests -vvv$' || return 1
 
   output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test --verbose)"
-  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests --verbose$'
+  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests --verbose$' || return 1
 
   output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test package_filter --nocapture)"
-  printf '%s\n' "${output}" | rg -q '^test --quiet --locked --lib --bins --tests package_filter --nocapture$'
+  printf '%s\n' "${output}" | rg -q '^test --quiet --locked --lib --bins --tests package_filter --nocapture$' || return 1
+
+  output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test -q)"
+  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests -q$' || return 1
+
+  output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test --quiet)"
+  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests --quiet$' || return 1
 }
 
 for skill in .agents/skills/*; do

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -584,6 +584,9 @@ check_just_test_verbosity() {
   output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test -vv)"
   printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests -vv$'
 
+  output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test -vvv)"
+  printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests -vvv$'
+
   output="$(PATH="${temp_dir}:${PATH}" just --justfile justfile test --verbose)"
   printf '%s\n' "${output}" | rg -q '^test --locked --lib --bins --tests --verbose$'
 

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -48,7 +48,7 @@ emit_check() {
       --arg status "${result}" \
       --arg output "${output}" \
       '{type:"agent_asset_check",data:{name:$name,status:$status,output:(if $output == "" then null else $output end)}}'
-  elif [ "${format}" = "text" ] || [ "${result}" != "ok" ]; then
+  elif [ "${format}" = "text" ] || [ "${result}" = "fail" ]; then
     printf 'agent_assets.%s=%s\n' "${name}" "${result}"
     if [ -n "${output}" ]; then
       printf 'agent_assets.%s.output.begin\n%s\nagent_assets.%s.output.end\n' \
@@ -535,6 +535,26 @@ check_backlog_access_preflight() {
   ' >/dev/null
 }
 
+check_summary_suppresses_skips() {
+  local temp_home
+  local output
+  temp_home="$(mktemp -d "${TMPDIR:-/tmp}/rpm-agent-assets-no-validator-home.XXXXXX")"
+  trap 'rm -rf "${temp_home}"' RETURN
+  output="$(
+    HOME="${temp_home}" \
+      RPM_SKILL_VALIDATOR= \
+      RPM_VALIDATE_AGENT_WORKFLOW_ASSETS_REGRESSION=1 \
+      bash scripts/validate-agent-workflow-assets.sh --format=summary
+  )"
+  printf '%s\n' "${output}" | rg -q '^agent_assets.status=ok$'
+  if printf '%s\n' "${output}" | rg -q '^agent_assets\.skill_.*=skip$'; then
+    return 1
+  fi
+  if printf '%s\n' "${output}" | rg -q '^agent_assets\.skill_.*\.output\.(begin|end)$'; then
+    return 1
+  fi
+}
+
 for skill in .agents/skills/*; do
   [ -d "${skill}" ] || continue
   name="$(basename "${skill}")"
@@ -659,6 +679,10 @@ check "script_check_claude_security_syntax" \
   bash -n scripts/check-claude-security.sh
 check "script_validate_agent_workflow_assets_syntax" \
   bash -n scripts/validate-agent-workflow-assets.sh
+
+if [ "${RPM_VALIDATE_AGENT_WORKFLOW_ASSETS_REGRESSION:-}" != "1" ]; then
+  check "summary_suppresses_skips" check_summary_suppresses_skips
+fi
 
 check "collect_pr_review_context_paginates" check_collect_paginates_comments_and_reviews
 check "collect_pr_review_context_no_duplicates" check_collect_does_not_duplicate_exhausted_connections

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -38,7 +38,7 @@ for command_name in jq node python3; do
   fi
 done
 
-cargo fetch --locked
-cargo check --locked --all-targets
+cargo fetch --quiet --locked
+cargo check --quiet --locked --all-targets
 
 printf 'worktree-setup: ready (%s)\n' "${repo_root}"

--- a/src/lib/node_linker/mod.rs
+++ b/src/lib/node_linker/mod.rs
@@ -858,9 +858,15 @@ mod tests {
     use flate2::{write::GzEncoder, Compression};
     use std::{
         fs,
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            Arc, Barrier,
+        },
         time::{SystemTime, UNIX_EPOCH},
     };
     use tar::{Builder, Header};
+
+    static TEMP_NODE_MODULES_ID: AtomicU64 = AtomicU64::new(0);
 
     struct TempNodeModules {
         path: PathBuf,
@@ -872,10 +878,21 @@ mod tests {
                 .duration_since(UNIX_EPOCH)
                 .map(|duration| duration.as_nanos())
                 .unwrap_or(0);
-            let path = std::env::temp_dir()
-                .join(format!("rpm-node-linker-{}-{nanos}", std::process::id()));
-            fs::create_dir_all(path.join("node_modules")).unwrap();
-            Self { path }
+            loop {
+                let id = TEMP_NODE_MODULES_ID.fetch_add(1, Ordering::Relaxed);
+                let path = std::env::temp_dir().join(format!(
+                    "rpm-node-linker-{}-{nanos}-{id}",
+                    std::process::id()
+                ));
+                match fs::create_dir(&path) {
+                    Ok(()) => {
+                        fs::create_dir(path.join("node_modules")).unwrap();
+                        return Self { path };
+                    }
+                    Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+                    Err(error) => panic!("failed to create temp node_modules root: {error}"),
+                }
+            }
         }
 
         fn node_modules(&self) -> PathBuf {
@@ -895,6 +912,32 @@ mod tests {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.path);
         }
+    }
+
+    #[test]
+    fn temp_node_modules_are_isolated_when_created_in_parallel() {
+        const WORKER_COUNT: usize = 32;
+        let barrier = Arc::new(Barrier::new(WORKER_COUNT));
+        let handles = (0..WORKER_COUNT)
+            .map(|_| {
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    TempNodeModules::new()
+                })
+            })
+            .collect::<Vec<_>>();
+        let temps = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect::<Vec<_>>();
+
+        let unique_paths = temps
+            .iter()
+            .map(|temp| temp.path.clone())
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(unique_paths.len(), WORKER_COUNT);
+        assert!(temps.iter().all(|temp| temp.node_modules().is_dir()));
     }
 
     fn dependency(version: &str, dependencies: &[&str]) -> Dependency {


### PR DESCRIPTION
## Contract

Routine repository validation output is quiet while compiler diagnostics, test failures, summaries, and exit statuses remain visible.

## Changes

- Pass Cargo's quiet flag through build, check, lint, test, docs, worktree setup, Rust Analyzer fallback, and local pre-push validation.
- Suppress routine Just command echoing while retaining begin/end markers.
- Add summary output for agent-asset validation and keep detailed output for failures.
- Update contributor guidance and the Rust Analyzer fallback assertion.

## Validation

- `git diff --check`
- Shell syntax checks for all changed shell scripts
- `bash scripts/test-codex-rust-analyzer.sh`
- `RUST_TEST_THREADS=1 just validate`
  - format-check, fixture audit/smoke, agent-assets, check, lint, 227 library tests, 2 binary tests, and docs passed
- Pre-push gate passed with `RUST_TEST_THREADS=1`: clippy and tests passed

The initial parallel test run exposed two existing `node_linker` temporary-directory collisions. Both tests passed individually, and the full validation passed with one test thread.

## Checklist

- [x] Scope is focused on repository validation output.
- [x] Relevant test assertion and script validation were run.
- [x] SPEC impact is none; this changes repository tooling output only.
- [x] PR metadata label will be applied after creation.
- [x] No closing issue: this is repository validation-output tooling without a linked GitHub issue.
- [x] PR is ready for review.

No closing issue: this is repository validation-output tooling without a linked GitHub issue.