### PR TITLE
docs(agent): define Codex-centered repository operating model

### DIFF
--- a/.agents/docs/backlog-agent-workflow.md
+++ b/.agents/docs/backlog-agent-workflow.md
@@ -5,6 +5,34 @@ ticket. Runtime routing authority lives in `.codex/agents/`. Mechanical Project,
 label, batch, transition, and automation policy lives in
 `.agents/workflows/backlog-policy.json`.
 
+Codex is the current primary and default repository operating path. Codex Cloud
+scheduled execution and repository-configured Codex Automatic review are current
+mechanisms. The lifecycle, state, validation, and mutation contracts below are
+provider-neutral; provider-specific details remain in adapters, environments,
+and role instructions. This document records the existing execution model and
+does not add an executor-routing architecture.
+
+## Durable Handoff and Discovered Work
+
+A GitHub issue is the durable handoff for a fresh worker. Its current body must
+preserve the goal, scope, non-goals, acceptance criteria, dependencies,
+validation plan, and necessary context. Issue #207 remains the open
+implementation that will persist and validate the executable-issue contract and
+its schema/mutations. Current manual guidance does not claim automatic template
+enforcement.
+
+Work discovered during execution or review receives exactly one disposition:
+an in-scope fix, a narrowly justified blocker or hotfix, or a durable linked
+follow-up issue. Actionable findings cannot remain hidden output or expand an
+unrelated PR. Follow-up creation requires policy authorization,
+`may_create_followup_issues=true`, a duplicate check, and a bounded writer;
+without approval, retain a draft disposition or link an existing issue. Issue
+#208 owns the implementation of this disposition contract.
+
+Structured model proposals provide classification or planning evidence.
+Authorized workflows apply bounded deterministic writes separately, using the
+contract and current GitHub state as their mutation boundary.
+
 ## Harness Boundary and Execution Record
 
 The local orchestration plan owns decomposition, dependency ordering, and
@@ -157,23 +185,30 @@ must record its lease and idempotency key while preserving ordinary labels.
 
 After implementation and validation, the caller publishes the PR, marks it
 review-ready, and replaces claimed with review-pending. Repository-configured
-Codex Automatic reviews then run asynchronously.
+Codex Automatic reviews then run asynchronously under issue #199's
+repository-external review-creation mechanism.
 
 `$take-ticket explicit <issue>` executes a user-selected issue without running
 the scheduled candidate claim flow.
 
-Scheduled runs do not post, request, or wait for `@codex review`. Repository
-code-review settings run independently after a pull request is published.
+Ticket execution does not create or request an Automatic review or post `@codex review`;
+its arrival is asynchronous evidence, not a synchronous
+completion dependency or blocking condition. Repository code-review settings
+run independently after a pull request is published. Review reconciliation
+returns `no-work` without mutation when feedback is absent and rechecks on a
+later scheduled run. Explicit review-only workflows retain their documented
+non-blocking COMMENT review-posting scope.
 
 ## Review-Reconciliation Contract
 
 `$pr-review-resolution` scheduled mode selects at most one open PR linked to an
 open review-pending issue. It returns `no-work` when no candidate exists or the
-Codex review has not arrived. Accepted findings receive minimal changes,
+Codex review has not arrived, without mutating state; a later scheduled run
+rechecks the candidate. Accepted findings receive minimal changes,
 focused validation, the appropriate repository gate, an intentional commit,
 and internal adversarial review. Actionable P0/P1 findings keep the issue
 review-pending. Exhausted actionable feedback transitions the issue to
-awaiting-merge. This workflow never merges and never requests `@codex review`.
+awaiting-merge. This workflow never merges and does not request `@codex review`.
 
 ## Merge-Gate Contract
 
@@ -186,9 +221,13 @@ through the GitHub plugin and lets GitHub close the linked issue; lifecycle
 labels on closed issues are inert. Pending checks or unknown mergeability
 return `no-work`. Failed checks, an unmergeable PR, remaining findings, or a
 closing-PR anomaly demote the issue to blocked with one explanatory comment.
-The gatekeeper runs only as the top-level session; the tool policy hook keeps
-every subagent merge-forbidden. The workflow automation flag
-`automation.merge_pull_requests` stays `false`: subagent workflows never merge.
+Issue #195 owns the planned deterministic blocking CI aggregate contract. Until
+that implementation exists, current `merge_gate.required_checks` consumes the
+policy's `metadata` and `verify` conclusions as individual evidence. The scheduled
+`merge-gatekeeper` is the actual merge owner, with issue #202 preserving and
+organizing that lifecycle ownership. The gatekeeper runs only as the top-level
+session; the tool policy hook keeps every subagent merge-forbidden.
+The workflow automation flag `automation.merge_pull_requests` stays `false`: subagent workflows never merge.
 
 ## Suggested Automation Split
 

--- a/.agents/docs/backlog-agent-workflow.md
+++ b/.agents/docs/backlog-agent-workflow.md
@@ -26,7 +26,10 @@ an in-scope fix, a narrowly justified blocker or hotfix, or a durable linked
 follow-up issue. Actionable findings cannot remain hidden output or expand an
 unrelated PR. Follow-up creation requires policy authorization,
 `may_create_followup_issues=true`, a duplicate check, and a bounded writer;
-without approval, retain a draft disposition or link an existing issue. Issue
+without approval, link an existing issue or post the draft disposition and its
+evidence to the source issue or PR as a durable comment. A session-local draft
+is only preparation, not a terminal disposition. If the workflow cannot persist
+either record, it must stop as blocked and report the missing permission. Issue
 #208 owns the implementation of this disposition contract.
 
 Structured model proposals provide classification or planning evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ This file is a navigation and judgment guide, not the enforcement layer. Determi
 - If scope must be narrowed, say what is included, what is excluded, and why.
 - Do not treat a representative file, planning issue, milestone anchor, or draft issue as the whole target set unless the user explicitly asks for only that item.
 - If a guardrail can be checked mechanically, prefer adding or using a check over adding more prompt text.
+- Codex is the current primary and default repository operating path. Codex Cloud execution and repository-configured Codex Automatic review are current mechanisms; provider-specific details belong in adapters, environments, or role instructions.
+- Shared lifecycle, state, validation, and mutation contracts apply provider-neutrally. They describe required outcomes and evidence while preserving the existing provider-specific execution records.
 
 ## Source of Truth
 
@@ -21,6 +23,8 @@ This file is a navigation and judgment guide, not the enforcement layer. Determi
 - Open issue lifecycle labels are the Cloud scheduled execution queue.
 - Draft issues can explain implementation intent, ordering, dependencies, and acceptance context, but they do not override SPECs or ADRs.
 - If code, SPEC, ADR, and issue text disagree, classify the mismatch before editing behavior.
+- A GitHub issue is the durable handoff for fresh workers. Its current body preserves the goal, scope, non-goals, acceptance criteria, dependencies, validation plan, and necessary context.
+- Issue #207 remains the open implementation that will persist and validate the executable-issue contract and its schema/mutations; current manual guidance does not claim automatic template enforcement. Issue #208 owns discovered-work disposition.
 
 ## GitHub Project and Roadmap Work
 
@@ -41,14 +45,22 @@ execution eligibility condition. Respect the policy batch limits and allowed
 state transitions.
 
 Repository agents consume review feedback after it appears on a pull request.
-Codex review creation is configured outside this repository workflow; agents
-must not post an `@codex review` request.
+Issue #199 owns repository-external Codex Automatic review creation. Lifecycle
+ticket execution does not create or request an Automatic review or post `@codex review`;
+its arrival is asynchronous evidence, not a synchronous
+completion dependency or blocking condition. Review reconciliation returns
+`no-work` without mutation when feedback is absent and rechecks on a later
+scheduled run. Explicit review-only workflows retain their documented
+non-blocking COMMENT review-posting scope. Issue #195 owns the planned
+deterministic blocking CI aggregate contract; current `merge_gate.required_checks`
+consumes policy `metadata` and `verify` conclusions as individual evidence.
 
-Merging is owned exclusively by the scheduled merge gatekeeper defined in
-`.agents/skills/merge-gatekeeper/`. It merges at most one awaiting-merge pull
-request per run and only when the deterministic policy `merge_gate` passes:
-required checks concluded, the PR is mergeable, and no unresolved P0/P1
-finding remains. Subagents never merge; the tool policy hook enforces this.
+The scheduled `merge-gatekeeper` is the actual merge owner, with issue #202
+preserving and organizing that lifecycle ownership. It is defined in
+`.agents/skills/merge-gatekeeper/`, merges at most one awaiting-merge pull
+request per run, and only when the deterministic policy `merge_gate` passes:
+required checks concluded, the PR is mergeable, and no unresolved P0/P1 finding
+remains. Subagents never merge; the tool policy hook enforces this.
 
 ## Change Discipline
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,10 @@ an in-scope fix, a narrowly justified blocker or hotfix, or a durable linked
 follow-up issue. Actionable findings cannot remain hidden output or expand an
 unrelated PR. Follow-up creation requires policy authorization,
 `may_create_followup_issues=true`, a duplicate check, and a bounded writer;
-without approval, retain a draft disposition or link an existing issue. Issue
+without approval, link an existing issue or post the draft disposition and its
+evidence to the source issue or PR as a durable comment. A session-local draft
+is only preparation, not a terminal disposition. If the workflow cannot persist
+either record, it must stop as blocked and report the missing permission. Issue
 #208 owns the discovered-work disposition implementation.
 
 Structured model proposals and bounded deterministic writes have separate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,25 @@ Use the closest issue template and include:
 
 Issue text explains intent, but it does not override an owning SPEC.
 
+A GitHub issue is the durable handoff for a fresh worker. Keep the current body
+self-contained with the goal, scope, non-goals, acceptance criteria,
+dependencies, validation plan, and necessary context. Issue #207 remains the
+open implementation that will persist and validate the executable-issue
+contract and its schema/mutations; current manual guidance does not claim
+automatic template enforcement.
+
+When work is discovered during execution or review, record one disposition:
+an in-scope fix, a narrowly justified blocker or hotfix, or a durable linked
+follow-up issue. Actionable findings cannot remain hidden output or expand an
+unrelated PR. Follow-up creation requires policy authorization,
+`may_create_followup_issues=true`, a duplicate check, and a bounded writer;
+without approval, retain a draft disposition or link an existing issue. Issue
+#208 owns the discovered-work disposition implementation.
+
+Structured model proposals and bounded deterministic writes have separate
+responsibilities. A proposal supplies classification or planning evidence; an
+authorized workflow applies only the bounded mutation allowed by its contract.
+
 ### Agent-backed backlog
 
 Unrefined product ideas use the Idea issue template and enter GitHub Project #7
@@ -26,14 +45,29 @@ transitions are defined in
 - `agent:ready`: the readiness gate passed and scheduled execution may select the issue
 - `agent:claimed`: one scheduled execution owns the issue
 - `agent:review-pending`: the implementation PR is review-ready and awaits review reconciliation
-- `agent:awaiting-merge`: review reconciliation is complete and a human may decide whether to merge
+- `agent:awaiting-merge`: review reconciliation is complete and the issue is eligible for the scheduled merge gatekeeper
 - `agent:blocked`: a user, product, permission, or dependency decision is required
 
 Scheduled research and ticket execution process at most the configured batch
 size. An issue reaches `agent:ready` only after its owning SPEC impact, scope,
 dependencies, observable done criteria, and validation plan are explicit.
-Repository automation does not request Codex review. Review feedback generated
-by the configured GitHub integration is handled after it appears.
+Codex is the current primary and default repository operating path. Codex Cloud
+scheduled execution and repository-configured Codex Automatic review are current
+mechanisms. Shared lifecycle, state, validation, and mutation contracts are
+provider-neutral, with provider-specific details kept in adapters, environments,
+and role instructions.
+
+Issue #199 owns repository-external Codex Automatic review creation. Lifecycle
+ticket execution does not create or request an Automatic review or post `@codex review`;
+its arrival is asynchronous evidence, not a synchronous
+completion dependency or blocking condition. Review reconciliation returns
+`no-work` without mutation when feedback is absent and rechecks on a later
+scheduled run. Explicit review-only workflows retain their documented
+non-blocking COMMENT review-posting scope. Issue #195 owns the planned
+deterministic blocking CI aggregate contract; current `merge_gate.required_checks`
+consumes policy `metadata` and `verify` conclusions as individual evidence. The
+scheduled `merge-gatekeeper` is the actual merge owner, with issue #202
+preserving and organizing that lifecycle ownership.
 
 ## Milestones
 


### PR DESCRIPTION
## Summary
- document Codex as the current primary/default path while keeping shared lifecycle contracts provider-neutral
- define durable GitHub handoff and discovered-work disposition ownership without claiming open #207/#208 work is implemented
- separate external Automatic review creation, explicit COMMENT-only review workflows, reconciliation polling, CI evidence, and scheduled merge ownership

## Validation
- `bash scripts/validate-agent-workflow-assets.sh --format=summary`
- `just validate`
- `git diff --check`
- independent contract review with P0/P1/P2 all clear

Closes #189