### PR TITLE
chore(codex): tighten Cloud environment setup

### DIFF
--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -38,6 +38,11 @@ is an existing absolute canonical directory at
 prepended to the default trusted PATH, so a platform-managed Node binary is
 discovered before the fixed system directories. An exported empty value, a
 malformed or nonexistent directory, or an out-of-bound `NVM_BIN` fails setup.
+Every directory from `${HOME}/.nvm` through the selected `bin` must be a
+non-symlink directory owned consistently by either the setup UID or the pinned
+universal-container NVM owner UID 1001, and must not be writable by group or
+other users. Executables selected from that `bin` must have the same pinned
+owner and mode protection. Mixed or arbitrary owners fail setup.
 When `NVM_BIN` is unset, the fixed system directories remain the supported
 Node lookup path; ambient PATH entries are never used as a fallback. An
 explicit trusted PATH override is used exactly as supplied and does not
@@ -73,9 +78,12 @@ The setup performs these steps in order:
    `.cargo/` directory from the repository root through its filesystem-root
    ancestors. Public locked setup does not accept source replacement or
    private credentials.
-3. Require `rustup`, resolve the unique active/default concrete installed
-   `stable-<host>` toolchain with local `rustup toolchain list --verbose`
-   inspection, and reject custom, multiple, or host-mismatched entries. Inspect
+3. Require `rustup`, resolve the unique active/default concrete installed host
+   toolchain with local `rustup toolchain list --verbose` inspection, and
+   accept either `stable-<host>` or a versioned release such as
+   `1.89.0-<host>` for the supported `x86_64-unknown-linux-gnu` and
+   `aarch64-unknown-linux-gnu` Cloud hosts. Reject tracking, custom,
+   unsupported-host, multiple active/default, or path/name-mismatched entries. Inspect
    its `rustfmt` and `clippy` components without channel synchronization. Install
    missing components through the vetted online transport, then resolve its
    installed binaries with `rustup which --toolchain <concrete-toolchain> cargo`
@@ -106,12 +114,20 @@ code, so their socket and file access is governed by the platform sandbox,
 network, and secret policies.
 Setup never runs the full test suite or `just validate`.
 
-Every executable discovered on the trusted PATH must be a regular non-symlink
-file without traversal components. Executables under immutable platform paths
-must be platform-owned and non-writable by group or other users. Other trusted
-executables, including `${HOME}/.cargo/bin`, must be owned by the setup user and
-must also be non-writable by group or other users. This prevents a Cargo-bin
-shadow executable from replacing a platform command.
+Every executable discovered on the trusted PATH must be an executable regular
+file without traversal components, with one narrow exception for standard
+Rustup proxies. `${HOME}/.cargo/bin/cargo`, `rustfmt`, and `cargo-clippy` may be
+symlinks only when each resolves to the executable, regular, non-symlink
+`${HOME}/.cargo/bin/rustup` file. The Cargo-bin trusted root is confined to the
+canonical `${HOME}/.cargo/bin` path, and neither `${HOME}` nor its `.cargo/bin`
+path may contain a symlink for proxy or regular executables. Other symlinks
+fail setup. Executables under
+immutable platform paths must be platform-owned and non-writable by group or
+other users. Other trusted executables, including `${HOME}/.cargo/bin`, must be
+owned by the setup user and must also be non-writable by group or other users.
+The validated NVM subtree follows its pinned owner rule described above. These
+checks prevent a Cargo-bin shadow executable or mixed-owner NVM entry from
+replacing a platform command.
 
 The checked-in environment also exposes a manual `Clean worktree artifacts`
 action. It runs `scripts/worktree-cleanup.sh`, which requires a clean worktree,

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -1,7 +1,8 @@
 # Codex Cloud environment
 
-RPM can run in the Codex universal container with a repository-specific setup
-script.
+RPM runs in the Codex universal container with a repository-specific setup
+script. The setup script prepares tools and warms the Rust dependency/build
+cache; task prompts do not need to repeat those installation steps.
 
 ## Configure the environment
 
@@ -13,15 +14,55 @@ script.
    ./scripts/codex-cloud-setup.sh
    ```
 
-4. Keep agent internet access disabled for repository validation. Enable only
-   the domains required by a task that must access a live registry or GitHub.
-5. Save the environment and reset its cache after changing toolchain settings.
+   Run the file directly as an executable. This preserves the `/bin/bash -p`
+   startup boundary; invoking it through an ambient shell can change that
+   boundary.
 
-The setup installs the Rust formatting and lint components, installs `just`
-when the universal image does not provide it, verifies the auxiliary tools used
-by repository checks, fetches locked Cargo dependencies, and checks all Rust
-targets. The Cloud compatibility wrapper delegates to the shared
-`scripts/worktree-setup.sh` entrypoint.
+4. Keep agent internet access disabled after setup. Enable only the minimum
+   domains required by a task that must access a live registry or GitHub.
+5. Save the environment and use its `Reset cache` action after changing
+   toolchain or setup settings. Confirm whether setup reran and which caches
+   were cleared in the Cloud UI logs; those effects are platform behavior.
+
+The Cloud setup is intentionally independent from the shared desktop
+`scripts/worktree-setup.sh` entrypoint. It uses this trusted PATH by default:
+
+```text
+${HOME}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+```
+
+`RPM_CODEX_CLOUD_TRUSTED_PATH` is an explicit trust assertion by the
+environment owner for a trusted Cloud environment setting. Every entry must be
+an absolute, non-empty path. Ambient PATH entries are ignored and the override
+must not be supplied by task input. The default `${HOME}/.cargo/bin` entry
+trusts the platform-managed fresh/reset environment cache. If a task writes
+and then reuses `${HOME}`, repository code cannot guarantee binary integrity;
+that is a platform/cache residual.
+The public setup assumes direct access to public package sources; it does not
+forward proxy, registry-authentication, compiler-wrapper, or task-secret
+variables.
+
+The setup performs these steps in order:
+
+1. Reject Cargo config and credentials files in the Cargo home and in every
+   `.cargo/` directory from the repository root through its filesystem-root
+   ancestors. Public locked setup does not accept source replacement or
+   private credentials.
+2. Require `rustup`, inspect stable `rustfmt` and `clippy` components, and
+   install missing components.
+3. Install `just` with `cargo install just --locked` when it is missing, then
+   verify `rustfmt`, `cargo-clippy`, and `just` are discoverable.
+4. Verify that `jq`, `node`, and `python3` are available.
+5. Fetch the lockfile-resolved dependencies with `cargo fetch --quiet --locked`.
+6. Warm the compiler cache with
+   `cargo check --quiet --offline --locked --all-targets`.
+
+Tool installation and locked dependency fetch are the setup operations that
+may require network access. The warm-up check is explicitly offline and uses
+the dependencies fetched in the preceding step. `--offline` constrains Cargo's
+network behavior; build scripts and procedural macros remain executable code,
+so their socket and file access is governed by the platform sandbox, network,
+and secret policies. Setup never runs the full test suite or `just validate`.
 
 The checked-in environment also exposes a manual `Clean worktree artifacts`
 action. It runs `scripts/worktree-cleanup.sh`, which requires a clean worktree,
@@ -31,7 +72,8 @@ does not remove a worktree or modify shared Git worktree metadata. Use
 
 ## Validate a cloud task
 
-Use the repository recipes documented in `AGENTS.md`:
+With agent internet access disabled, use the repository recipes documented in
+`AGENTS.md`:
 
 ```bash
 just check
@@ -39,10 +81,25 @@ just test
 just validate
 ```
 
-`just validate` is the full repository gate. Package operations that contact a
-live registry require agent internet access; deterministic fixture tests run
-offline.
+`just validate` is the full repository gate and includes the test suite. The
+repository's deterministic fixture checks are designed to run offline. A task
+that contacts a live package registry or GitHub must request internet access
+for only the required domains, then disable it again for ordinary validation.
+
+The setup phase may need network access for tool installation and
+`cargo fetch --locked`; this is separate from task-time agent internet access.
+The setup runs external tools with a minimal environment containing only the
+temporary setup `HOME`, the trusted PATH, the actual Cargo/Rustup homes, the
+stable toolchain, and disabled Git global/system config. It is therefore
+unsuitable for environments whose setup requires a proxy or private registry
+credentials.
 
 The checked-in `.codex/environments/environment.toml` configures Codex desktop
 worktrees. Codex Cloud environment setup is stored in Codex environment
-settings.
+settings. The `Clean worktree artifacts` action only removes this worktree's
+Cargo `target/` contents after its clean-worktree check; it does not clear the
+Cargo registry cache or shared Git worktree metadata. Use the environment's
+`Reset cache` action when those setup caches need to be rebuilt, then confirm
+the result in the Cloud UI logs. The exact Cloud allowlist, secret isolation,
+and Reset cache behavior are platform boundaries and cannot be verified from
+this repository.

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -25,11 +25,23 @@ cache; task prompts do not need to repeat those installation steps.
    were cleared in the Cloud UI logs; those effects are platform behavior.
 
 The Cloud setup is intentionally independent from the shared desktop
-`scripts/worktree-setup.sh` entrypoint. It uses this trusted PATH by default:
+`scripts/worktree-setup.sh` entrypoint. The default trusted PATH starts with
+the platform-managed Cargo bin and the fixed system directories:
 
 ```text
 ${HOME}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ```
+
+When the universal container exports `NVM_BIN`, setup accepts it only when it
+is an existing absolute canonical directory at
+`${HOME}/.nvm/versions/node/<version>/bin`. The canonical directory is
+prepended to the default trusted PATH, so a platform-managed Node binary is
+discovered before the fixed system directories. An exported empty value, a
+malformed or nonexistent directory, or an out-of-bound `NVM_BIN` fails setup.
+When `NVM_BIN` is unset, the fixed system directories remain the supported
+Node lookup path; ambient PATH entries are never used as a fallback. An
+explicit trusted PATH override is used exactly as supplied and does not
+receive an automatic NVM entry.
 
 `RPM_CODEX_CLOUD_TRUSTED_PATH` is an explicit trust assertion by the
 environment owner for a trusted Cloud environment setting. Every entry must be
@@ -37,24 +49,30 @@ an absolute, non-empty path. Ambient PATH entries are ignored and the override
 must not be supplied by task input. The default `${HOME}/.cargo/bin` entry
 trusts the platform-managed fresh/reset environment cache. If a task writes
 and then reuses `${HOME}`, repository code cannot guarantee binary integrity;
-that is a platform/cache residual.
+that is a platform/cache residual. When `just` is absent, an explicit trusted
+PATH override must include the exact `${HOME}/.cargo/bin` entry before setup
+will run `cargo install`. The install and subsequent lookup use the same
+`CARGO_HOME/bin` directory. An override that omits that directory fails before
+Rustup component installation or any Cargo network operation starts.
 The public setup assumes direct access to public package sources; it does not
 forward proxy, registry-authentication, compiler-wrapper, or task-secret
 variables.
 
 The setup performs these steps in order:
 
-1. Reject Cargo config and credentials files in the Cargo home and in every
+1. Validate the trusted PATH and, when `just` is missing, require its Cargo bin
+   installation destination before any tool installation or network operation.
+2. Reject Cargo config and credentials files in the Cargo home and in every
    `.cargo/` directory from the repository root through its filesystem-root
    ancestors. Public locked setup does not accept source replacement or
    private credentials.
-2. Require `rustup`, inspect stable `rustfmt` and `clippy` components, and
+3. Require `rustup`, inspect stable `rustfmt` and `clippy` components, and
    install missing components.
-3. Install `just` with `cargo install just --locked` when it is missing, then
+4. Install `just` with `cargo install just --locked` when it is missing, then
    verify `rustfmt`, `cargo-clippy`, and `just` are discoverable.
-4. Verify that `jq`, `node`, and `python3` are available.
-5. Fetch the lockfile-resolved dependencies with `cargo fetch --quiet --locked`.
-6. Warm the compiler cache with
+5. Verify that `jq`, `node`, and `python3` are available.
+6. Fetch the lockfile-resolved dependencies with `cargo fetch --quiet --locked`.
+7. Warm the compiler cache with
    `cargo check --quiet --offline --locked --all-targets`.
 
 Tool installation and locked dependency fetch are the setup operations that

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -54,9 +54,16 @@ PATH override must include the exact `${HOME}/.cargo/bin` entry before setup
 will run `cargo install`. The install and subsequent lookup use the same
 `CARGO_HOME/bin` directory. An override that omits that directory fails before
 Rustup component installation or any Cargo network operation starts.
-The public setup assumes direct access to public package sources; it does not
-forward proxy, registry-authentication, compiler-wrapper, or task-secret
-variables.
+The public setup forwards only vetted HTTP(S)/SOCKS proxy and CA variables for
+the online component-install, Cargo-install, and locked-fetch steps. Unsupported
+proxy schemes, relative CA paths, registry-authentication, compiler-wrapper, and
+task-secret variables are rejected or omitted.
+The Cloud owner contract supplies the transport variables listed by the setup;
+task code cannot add transport variables to the clean environment. Proxy values
+cannot contain userinfo or newlines, and `NO_PROXY` accepts only host, address,
+port, and comma-list characters. CA file and directory values are canonical
+regular non-symlink paths under the platform roots `/etc/ssl`, `/etc/pki/tls`,
+or `/usr/local/share/ca-certificates`.
 
 The setup performs these steps in order:
 
@@ -66,10 +73,13 @@ The setup performs these steps in order:
    `.cargo/` directory from the repository root through its filesystem-root
    ancestors. Public locked setup does not accept source replacement or
    private credentials.
-3. Require `rustup`, inspect stable `rustfmt` and `clippy` components, and
-   install missing components. After the toolchain is available, resolve its
-   installed binaries with `rustup which --toolchain stable cargo` and
-   `rustup which --toolchain stable rustc`.
+3. Require `rustup`, resolve the unique active/default concrete installed
+   `stable-<host>` toolchain with local `rustup toolchain list --verbose`
+   inspection, and reject custom, multiple, or host-mismatched entries. Inspect
+   its `rustfmt` and `clippy` components without channel synchronization. Install
+   missing components through the vetted online transport, then resolve its
+   installed binaries with `rustup which --toolchain <concrete-toolchain> cargo`
+   and `rustup which --toolchain <concrete-toolchain> rustc`.
 4. Install `just` with `cargo install just --locked` when it is missing, then
    verify `rustfmt`, `cargo-clippy`, and `just` are discoverable.
 5. Verify that `jq`, `node`, and `python3` are available.
@@ -80,19 +90,28 @@ The setup performs these steps in order:
 
 Tool installation and locked dependency fetch are the setup operations that
 may require network access. Cargo setup commands use the already installed
-stable toolchain paths returned by those two `rustup which` calls, with
+concrete toolchain paths returned by those two `rustup which` calls, with
 `RUSTUP_HOME` and both results resolved through the trusted system `realpath`
 utility. The canonical `cargo` and `rustc` files must be executable regular
-files under the same canonical toolchain `bin` directory; traversal components
-and symlinked parents or files fail setup. Exact Cargo runs omit
-`RUSTUP_TOOLCHAIN` and supply the matching `RUSTC` path. This avoids invoking a
-Rustup Cargo proxy that could synchronize the stable channel before an offline
-check.
-The warm-up check is explicitly offline and uses the dependencies fetched in
-the preceding step. `--offline` constrains Cargo's network behavior; build
-scripts and procedural macros remain executable code, so their socket and file
-access is governed by the platform sandbox, network, and secret policies.
+files under the selected concrete toolchain's canonical `bin` directory;
+traversal components and symlinked parents or files fail setup. Exact Cargo
+runs omit `RUSTUP_TOOLCHAIN` and supply the matching `RUSTC` path. Stable channel
+inspection and the offline warm-up omit proxy and CA transport variables, so
+Rustup cannot synchronize a tracking channel during cached setup.
+The online component-install, Cargo-install, and locked-fetch steps receive
+only the vetted transport allowlist. The warm-up check is explicitly offline
+and uses the dependencies fetched in the preceding step. `--offline` constrains
+Cargo's network behavior; build scripts and procedural macros remain executable
+code, so their socket and file access is governed by the platform sandbox,
+network, and secret policies.
 Setup never runs the full test suite or `just validate`.
+
+Every executable discovered on the trusted PATH must be a regular non-symlink
+file without traversal components. Executables under immutable platform paths
+must be platform-owned and non-writable by group or other users. Other trusted
+executables, including `${HOME}/.cargo/bin`, must be owned by the setup user and
+must also be non-writable by group or other users. This prevents a Cargo-bin
+shadow executable from replacing a platform command.
 
 The checked-in environment also exposes a manual `Clean worktree artifacts`
 action. It runs `scripts/worktree-cleanup.sh`, which requires a clean worktree,
@@ -118,11 +137,11 @@ for only the required domains, then disable it again for ordinary validation.
 
 The setup phase may need network access for tool installation and
 `cargo fetch --locked`; this is separate from task-time agent internet access.
-The setup runs external tools with a minimal environment containing only the
+The setup runs external tools with a minimal environment containing the
 temporary setup `HOME`, the trusted PATH, the actual Cargo/Rustup homes, the
-stable toolchain, and disabled Git global/system config. It is therefore
-unsuitable for environments whose setup requires a proxy or private registry
-credentials.
+concrete installed toolchain, disabled Git global/system config, and the
+allowlisted proxy/CA transport only for online steps. It does not forward
+private registry credentials.
 
 The checked-in `.codex/environments/environment.toml` configures Codex desktop
 worktrees. Codex Cloud environment setup is stored in Codex environment

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -38,11 +38,13 @@ is an existing absolute canonical directory at
 prepended to the default trusted PATH, so a platform-managed Node binary is
 discovered before the fixed system directories. An exported empty value, a
 malformed or nonexistent directory, or an out-of-bound `NVM_BIN` fails setup.
-Every directory from `${HOME}/.nvm` through the selected `bin` must be a
-non-symlink directory owned consistently by either the setup UID or the pinned
-universal-container NVM owner UID 1001, and must not be writable by group or
-other users. Executables selected from that `bin` must have the same pinned
-owner and mode protection. Mixed or arbitrary owners fail setup.
+Every directory from `${HOME}/.nvm` through the selected version directory
+must be a non-symlink directory with one consistent setup-UID or root owner.
+The `bin` directory may retain that owner or make the single supported forward
+transition to the pinned universal-container NVM owner UID 1001. Executables
+selected from `bin` must match its pinned owner. Every checked component must
+be protected from group and other writes. Arbitrary owners, earlier or repeated
+transitions, and a transition back after `bin` fail setup.
 When `NVM_BIN` is unset, the fixed system directories remain the supported
 Node lookup path; ambient PATH entries are never used as a fallback. An
 explicit trusted PATH override is used exactly as supplied and does not
@@ -50,7 +52,8 @@ receive an automatic NVM entry.
 
 `RPM_CODEX_CLOUD_TRUSTED_PATH` is an explicit trust assertion by the
 environment owner for a trusted Cloud environment setting. Every entry must be
-an absolute, non-empty path. Ambient PATH entries are ignored and the override
+an absolute, non-empty path without repeated slashes or traversal components.
+Ambient PATH entries are ignored and the override
 must not be supplied by task input. The default `${HOME}/.cargo/bin` entry
 trusts the platform-managed fresh/reset environment cache. If a task writes
 and then reuses `${HOME}`, repository code cannot guarantee binary integrity;
@@ -120,11 +123,17 @@ Rustup proxies. `${HOME}/.cargo/bin/cargo`, `rustfmt`, and `cargo-clippy` may be
 symlinks only when each resolves to the executable, regular, non-symlink
 `${HOME}/.cargo/bin/rustup` file. The Cargo-bin trusted root is confined to the
 canonical `${HOME}/.cargo/bin` path, and neither `${HOME}` nor its `.cargo/bin`
-path may contain a symlink for proxy or regular executables. Other symlinks
-fail setup. Executables under
-immutable platform paths must be platform-owned and non-writable by group or
-other users. Other trusted executables, including `${HOME}/.cargo/bin`, must be
-owned by the setup user and must also be non-writable by group or other users.
+path may contain a symlink for proxy or regular executables. `${HOME}`,
+`${HOME}/.cargo`, and `${HOME}/.cargo/bin` must all be owned by the setup user
+and protected from group and other writes. Other symlinks fail setup, except
+for the platform `/usr/bin/python3` symlink. That exact link
+must resolve to an executable, regular, non-symlink direct child named
+`/usr/bin/python3.<digits>`;
+the filesystem root, `/usr`, `/usr/bin`, and the target must all be root-owned
+and protected from group and other writes. Executables under immutable platform
+paths must meet the same platform ownership and mode requirements. Other
+trusted executables, including `${HOME}/.cargo/bin`, must be owned by the setup
+user and must also be non-writable by group or other users.
 The validated NVM subtree follows its pinned owner rule described above. These
 checks prevent a Cargo-bin shadow executable or mixed-owner NVM entry from
 replacing a platform command.

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -67,20 +67,32 @@ The setup performs these steps in order:
    ancestors. Public locked setup does not accept source replacement or
    private credentials.
 3. Require `rustup`, inspect stable `rustfmt` and `clippy` components, and
-   install missing components.
+   install missing components. After the toolchain is available, resolve its
+   installed binaries with `rustup which --toolchain stable cargo` and
+   `rustup which --toolchain stable rustc`.
 4. Install `just` with `cargo install just --locked` when it is missing, then
    verify `rustfmt`, `cargo-clippy`, and `just` are discoverable.
 5. Verify that `jq`, `node`, and `python3` are available.
-6. Fetch the lockfile-resolved dependencies with `cargo fetch --quiet --locked`.
-7. Warm the compiler cache with
-   `cargo check --quiet --offline --locked --all-targets`.
+6. Fetch the lockfile-resolved dependencies with the resolved stable Cargo
+   binary using `cargo fetch --quiet --locked`.
+7. Warm the compiler cache with that same binary and its exact sibling Rustc
+   using `cargo check --quiet --offline --locked --all-targets`.
 
 Tool installation and locked dependency fetch are the setup operations that
-may require network access. The warm-up check is explicitly offline and uses
-the dependencies fetched in the preceding step. `--offline` constrains Cargo's
-network behavior; build scripts and procedural macros remain executable code,
-so their socket and file access is governed by the platform sandbox, network,
-and secret policies. Setup never runs the full test suite or `just validate`.
+may require network access. Cargo setup commands use the already installed
+stable toolchain paths returned by those two `rustup which` calls, with
+`RUSTUP_HOME` and both results resolved through the trusted system `realpath`
+utility. The canonical `cargo` and `rustc` files must be executable regular
+files under the same canonical toolchain `bin` directory; traversal components
+and symlinked parents or files fail setup. Exact Cargo runs omit
+`RUSTUP_TOOLCHAIN` and supply the matching `RUSTC` path. This avoids invoking a
+Rustup Cargo proxy that could synchronize the stable channel before an offline
+check.
+The warm-up check is explicitly offline and uses the dependencies fetched in
+the preceding step. `--offline` constrains Cargo's network behavior; build
+scripts and procedural macros remain executable code, so their socket and file
+access is governed by the platform sandbox, network, and secret policies.
+Setup never runs the full test suite or `just validate`.
 
 The checked-in environment also exposes a manual `Clean worktree artifacts`
 action. It runs `scripts/worktree-cleanup.sh`, which requires a clean worktree,

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -186,6 +186,89 @@ validate_trusted_path() {
 validate_trusted_path "${trusted_path}"
 export PATH="${trusted_path}"
 
+trusted_path_root_for() {
+  local requested_path="$1"
+  local path_value="${trusted_path}"
+  local entry
+
+  while :; do
+    case "${path_value}" in
+      *:*)
+        entry="${path_value%%:*}"
+        path_value="${path_value#*:}"
+        ;;
+      *)
+        entry="${path_value}"
+        path_value=
+        ;;
+    esac
+    case "${requested_path}" in
+      "${entry}"|"${entry}"/*)
+        printf '%s\n' "${entry}"
+        return 0
+        ;;
+    esac
+    [ -n "${path_value}" ] || break
+  done
+  die "executable is outside the trusted PATH roots: ${requested_path}"
+}
+
+file_metadata() {
+  local path="$1"
+  local metadata
+
+  if metadata="$(/usr/bin/stat -c '%a %u' -- "${path}" 2>/dev/null)"; then
+    printf '%s\n' "${metadata}"
+  elif metadata="$(/usr/bin/stat -f '%Lp %u' "${path}" 2>/dev/null)"; then
+    printf '%s\n' "${metadata}"
+  else
+    die "cannot inspect executable ownership and mode: ${path}"
+  fi
+}
+
+validate_owner_and_mode() {
+  local label="$1"
+  local path="$2"
+  local metadata
+  local mode
+  local owner
+
+  metadata="$(file_metadata "${path}")"
+  mode="${metadata%% *}"
+  owner="${metadata#* }"
+  case "${path}" in
+    /bin/*|/usr/bin/*|/sbin/*|/usr/sbin/*|/usr/local/bin/*|/usr/local/sbin/*)
+      [ "${owner}" = 0 ] || die "${label} is not owned by the platform owner: ${path}"
+      ;;
+    *)
+      [ "${owner}" = "${EUID}" ] || die "${label} is not owned by the setup user: ${path}"
+      ;;
+  esac
+  if (( 8#${mode} & 022 )); then
+    die "${label} is writable by a group or other user: ${path}"
+  fi
+}
+
+validate_executable_path() {
+  local label="$1"
+  local executable_path="$2"
+  local trusted_root
+
+  reject_unsafe_path "${label}" "${executable_path}"
+  case "${executable_path}" in
+    *:*|*$'\n'*) die "${label} contains an unsafe separator: ${executable_path}" ;;
+  esac
+  trusted_root="$(trusted_path_root_for "${executable_path}")"
+  reject_symlink_components "${label}" "${trusted_root}" "${executable_path}"
+  [ -d "${trusted_root}" ] || die "trusted PATH root is not a directory: ${trusted_root}"
+  validate_owner_and_mode "trusted PATH root" "${trusted_root}"
+  [ -f "${executable_path}" ] && [ ! -L "${executable_path}" ] && \
+    [ -x "${executable_path}" ] || \
+    die "${label} must be an executable regular file: ${executable_path}"
+
+  validate_owner_and_mode "${label}" "${executable_path}"
+}
+
 has_trusted_path_entry() {
   local expected="$1"
   local path_value="${trusted_path}"
@@ -215,13 +298,24 @@ find_command() {
   command_path="$(command -v "${command_name}" 2>/dev/null || true)"
   [ -n "${command_path}" ] || die "${command_name} is required on the trusted PATH"
   case "${command_path}" in
-    /*) printf '%s\n' "${command_path}" ;;
+    /*) validate_executable_path "${command_name}" "${command_path}" ;;
     *) die "${command_name} resolved outside the trusted PATH: ${command_path}" ;;
   esac
+  printf '%s\n' "${command_path}"
 }
 
 find_optional_command() {
-  command -v "$1" 2>/dev/null || true
+  local command_name="$1"
+  local command_path
+
+  command_path="$(command -v "${command_name}" 2>/dev/null || true)"
+  if [ -n "${command_path}" ]; then
+    case "${command_path}" in
+      /*) validate_executable_path "${command_name}" "${command_path}" ;;
+      *) die "${command_name} resolved outside the trusted PATH: ${command_path}" ;;
+    esac
+    printf '%s\n' "${command_path}"
+  fi
 }
 
 git_command="$(find_command git)"
@@ -248,10 +342,100 @@ canonical_rustup_home="$(canonicalize_path RUSTUP_HOME "${rustup_home}")"
 [ -d "${canonical_rustup_home}" ] || die "RUSTUP_HOME is not a directory: ${rustup_home}"
 [ ! -L "${canonical_rustup_home}" ] || die "canonical RUSTUP_HOME must not be a symlink: ${canonical_rustup_home}"
 
+online_transport_env=()
+# Cloud owner contract: only these platform-managed transport variables may
+# cross the clean environment boundary, and only for online setup commands.
+trusted_ca_roots=(/etc/ssl /etc/pki/tls /usr/local/share/ca-certificates)
+
+canonicalize_ca_transport() {
+  local variable="$1"
+  local value="$2"
+  local canonical_value
+  local root
+  local canonical_root
+  local is_directory=0
+
+  case "${variable}" in
+    SSL_CERT_DIR) is_directory=1 ;;
+  esac
+  reject_unsafe_path "${variable}" "${value}"
+  if [ "${is_directory}" -eq 1 ]; then
+    [ -d "${value}" ] && [ ! -L "${value}" ] || \
+      die "${variable} must be a regular trusted CA directory: ${value}"
+  else
+    [ -f "${value}" ] && [ ! -L "${value}" ] || \
+      die "${variable} must be a regular trusted CA file: ${value}"
+  fi
+  canonical_value="$(canonicalize_path "${variable}" "${value}")"
+
+  for root in "${trusted_ca_roots[@]}"; do
+    [ -d "${root}" ] && [ ! -L "${root}" ] || continue
+    canonical_root="$(canonicalize_path "trusted CA root" "${root}")"
+    case "${canonical_value}" in
+      "${canonical_root}"|"${canonical_root}"/*)
+        case "${value}" in
+          "${root}"|"${root}"/*)
+            reject_symlink_components "${variable}" "${root}" "${value}"
+            ;;
+          *)
+            reject_symlink_components "${variable}" "${canonical_root}" "${canonical_value}"
+            ;;
+        esac
+        printf '%s\n' "${canonical_value}"
+        return 0
+        ;;
+    esac
+  done
+  die "${variable} is outside the trusted CA roots: ${value}"
+}
+
+capture_online_transport() {
+  local variable
+  local value
+
+  for variable in \
+    HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY \
+    http_proxy https_proxy all_proxy no_proxy \
+    SSL_CERT_FILE SSL_CERT_DIR CURL_CA_BUNDLE CARGO_HTTP_CAINFO
+  do
+    if [ "${!variable+x}" != x ]; then
+      continue
+    fi
+    value="${!variable}"
+    [ -n "${value}" ] || continue
+    case "${variable}" in
+      HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|http_proxy|https_proxy|all_proxy)
+        case "${value}" in
+          http://*|https://*|socks5://*|socks5h://*) ;;
+          *) die "unsupported ${variable} transport URL" ;;
+        esac
+        case "${value}" in
+          *@*) die "${variable} must not contain proxy userinfo" ;;
+        esac
+        ;;
+      NO_PROXY|no_proxy)
+        case "${value}" in
+          ,*|*,|*,,*|*[!A-Za-z0-9._,:\[\]-]*)
+            die "unsafe ${variable} value" ;;
+        esac
+        ;;
+      *)
+        value="$(canonicalize_ca_transport "${variable}" "${value}")"
+        ;;
+    esac
+    case "${value}" in
+      *$'\n'*) die "${variable} must not contain a newline" ;;
+    esac
+    online_transport_env+=("${variable}=${value}")
+  done
+}
+capture_online_transport
+
 run_clean_env() {
   local toolchain="$1"
   local rustc_command="$2"
-  shift 2
+  local transport_mode="$3"
+  shift 3
   local -a clean_env=(
     "HOME=${setup_home}"
     "PATH=${trusted_path}"
@@ -263,6 +447,11 @@ run_clean_env() {
     GIT_TERMINAL_PROMPT=0
   )
 
+  case "${transport_mode}" in
+    online) clean_env+=("${online_transport_env[@]}") ;;
+    offline) ;;
+    *) die "unknown setup transport mode: ${transport_mode}" ;;
+  esac
   if [ -n "${toolchain}" ]; then
     clean_env+=("RUSTUP_TOOLCHAIN=${toolchain}")
   fi
@@ -273,12 +462,72 @@ run_clean_env() {
 }
 
 run_clean() {
-  run_clean_env stable '' "$@"
+  run_clean_env "${stable_toolchain}" '' offline "$@"
 }
 
-run_clean_exact() {
-  run_clean_env '' "${stable_rustc_command}" "$@"
+run_clean_online() {
+  run_clean_env "${stable_toolchain}" '' online "$@"
 }
+
+run_clean_exact_online() {
+  run_clean_env '' "${stable_rustc_command}" online "$@"
+}
+
+run_clean_exact_offline() {
+  run_clean_env '' "${stable_rustc_command}" offline "$@"
+}
+
+resolve_installed_stable_toolchain() {
+  local installed_toolchains
+  local line
+  local candidate
+  local remainder
+  local canonical_toolchain_path
+  local expected_toolchain_path
+  local stable_count=0
+  local active_default_count=0
+  local selected_toolchain=
+  local selected_toolchain_path=
+
+  installed_toolchains="$(run_clean_env '' '' offline "${rustup_command}" toolchain list --verbose)"
+  while IFS= read -r line; do
+    candidate="${line%% *}"
+    case "${candidate}" in
+      stable) die 'rustup returned a tracking stable channel entry' ;;
+      stable-*)
+        case "${candidate}" in
+          *[!A-Za-z0-9._-]*) die "rustup returned an invalid stable toolchain name: ${candidate}" ;;
+          *) ;;
+        esac
+        stable_count=$((stable_count + 1))
+        remainder="${line#"${candidate}"}"
+        case "${remainder}" in
+          ' (active, default) '*|' (default, active) '*|' (active) '*|' (default) '*)
+            active_default_count=$((active_default_count + 1))
+            selected_toolchain="${candidate}"
+            selected_toolchain_path="${remainder##* }"
+            ;;
+        esac
+        ;;
+    esac
+  done <<<"${installed_toolchains}"
+  [ "${stable_count}" -eq 1 ] && [ "${active_default_count}" -eq 1 ] || \
+    die 'rustup must expose exactly one active/default stable host toolchain'
+  [ -n "${selected_toolchain_path}" ] || \
+    die 'rustup active/default stable toolchain has no installation path'
+  reject_unsafe_path 'stable toolchain path' "${selected_toolchain_path}"
+  reject_symlink_components 'stable toolchain path' "${canonical_rustup_home}" \
+    "${selected_toolchain_path}"
+  expected_toolchain_path="${canonical_rustup_home}/toolchains/${selected_toolchain}"
+  canonical_toolchain_path="$(canonicalize_path 'stable toolchain path' "${selected_toolchain_path}")"
+  [ "${canonical_toolchain_path}" = "${expected_toolchain_path}" ] || \
+    die 'rustup stable toolchain path does not match its active host name'
+  [ -d "${canonical_toolchain_path}" ] && [ ! -L "${canonical_toolchain_path}" ] || \
+    die 'active/default stable toolchain root is unsafe'
+  printf '%s\n' "${selected_toolchain}"
+}
+
+stable_toolchain="$(resolve_installed_stable_toolchain)"
 
 check_cargo_control_file() {
   local path="$1"
@@ -333,7 +582,7 @@ resolve_stable_binary() {
   local binary_path
   local canonical_binary_path
 
-  binary_path="$(run_clean "${rustup_command}" which --toolchain stable "${binary_name}")"
+  binary_path="$(run_clean "${rustup_command}" which --toolchain "${stable_toolchain}" "${binary_name}")"
   [ -n "${binary_path}" ] || die "rustup did not return the stable ${binary_name} path"
   reject_unsafe_path "stable ${binary_name}" "${binary_path}"
   reject_symlink_components "stable ${binary_name}" "${canonical_rustup_home}" "${binary_path}"
@@ -375,12 +624,12 @@ validate_stable_binary() {
   printf '%s\n' "${toolchain_root}"
 }
 
-installed_components="$(run_clean "${rustup_command}" component list --toolchain stable --installed)"
+installed_components="$(run_clean "${rustup_command}" component list --toolchain "${stable_toolchain}" --installed)"
 if ! has_component rustfmt "${installed_components}"; then
-  run_clean "${rustup_command}" component add --toolchain stable rustfmt
+  run_clean_online "${rustup_command}" component add --toolchain "${stable_toolchain}" rustfmt
 fi
 if ! has_component clippy "${installed_components}"; then
-  run_clean "${rustup_command}" component add --toolchain stable clippy
+  run_clean_online "${rustup_command}" component add --toolchain "${stable_toolchain}" clippy
 fi
 
 stable_cargo_command="$(resolve_stable_binary cargo)"
@@ -389,9 +638,14 @@ stable_cargo_toolchain_root="$(validate_stable_binary cargo "${stable_cargo_comm
 stable_rustc_toolchain_root="$(validate_stable_binary rustc "${stable_rustc_command}")"
 [ "${stable_cargo_toolchain_root}" = "${stable_rustc_toolchain_root}" ] || \
   die "stable cargo and rustc resolve to different toolchains"
+expected_stable_toolchain_root="${canonical_rustup_home}/toolchains/${stable_toolchain}"
+[ "${stable_cargo_toolchain_root}" = "${expected_stable_toolchain_root}" ] || \
+  die "stable cargo resolved to an unexpected toolchain: ${stable_cargo_toolchain_root}"
+[ "${stable_rustc_toolchain_root}" = "${expected_stable_toolchain_root}" ] || \
+  die "stable rustc resolved to an unexpected toolchain: ${stable_rustc_toolchain_root}"
 
 if [ -z "${just_command}" ]; then
-  run_clean_exact "${stable_cargo_command}" install just --locked
+  run_clean_exact_online "${stable_cargo_command}" install just --locked
 fi
 
 rustfmt_command="$(find_command rustfmt)"
@@ -401,7 +655,7 @@ find_command jq >/dev/null
 find_command node >/dev/null
 find_command python3 >/dev/null
 
-run_clean_exact "${stable_cargo_command}" fetch --quiet --locked
-run_clean_exact "${stable_cargo_command}" check --quiet --offline --locked --all-targets
+run_clean_exact_online "${stable_cargo_command}" fetch --quiet --locked
+run_clean_exact_offline "${stable_cargo_command}" check --quiet --offline --locked --all-targets
 
 printf 'codex-cloud-setup: ready (%s)\n' "${repo_root}"

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -22,6 +22,9 @@ case "${original_home}" in
   *:*|*$'\n'*) die 'HOME must not contain colon or newline' ;;
 esac
 
+cargo_home="${original_home}/.cargo"
+cargo_bin="${cargo_home}/bin"
+
 select_canonicalizer() {
   local candidate
 
@@ -111,6 +114,8 @@ reject_symlink_components() {
 }
 
 canonical_nvm_bin=
+trusted_nvm_owner=
+platform_nvm_owner_uid=1001
 if [ "${NVM_BIN+x}" = x ]; then
   nvm_bin="${NVM_BIN}"
   [ -n "${nvm_bin}" ] || die 'NVM_BIN must not be empty'
@@ -236,6 +241,18 @@ validate_owner_and_mode() {
   metadata="$(file_metadata "${path}")"
   mode="${metadata%% *}"
   owner="${metadata#* }"
+  if [ -n "${canonical_nvm_bin}" ]; then
+    case "${path}" in
+      "${canonical_nvm_bin}"|"${canonical_nvm_bin}"/*)
+        [ -n "${trusted_nvm_owner}" ] && [ "${owner}" = "${trusted_nvm_owner}" ] || \
+          die "${label} does not match the pinned NVM owner: ${path}"
+        if (( 8#${mode} & 022 )); then
+          die "${label} is writable by a group or other user: ${path}"
+        fi
+        return 0
+        ;;
+    esac
+  fi
   case "${path}" in
     /bin/*|/usr/bin/*|/sbin/*|/usr/sbin/*|/usr/local/bin/*|/usr/local/sbin/*)
       [ "${owner}" = 0 ] || die "${label} is not owned by the platform owner: ${path}"
@@ -249,6 +266,89 @@ validate_owner_and_mode() {
   fi
 }
 
+validate_nvm_provenance() {
+  local current
+  local remainder
+  local component
+  local metadata
+  local mode
+  local owner
+
+  [ -n "${canonical_nvm_bin}" ] || return 0
+  reject_symlink_components NVM_BIN "${original_home}" "${nvm_bin}"
+  current="${canonical_home}"
+  remainder="${canonical_nvm_bin#"${canonical_home}"/}"
+  while [ -n "${remainder}" ]; do
+    case "${remainder}" in
+      */*)
+        component="${remainder%%/*}"
+        remainder="${remainder#*/}"
+        ;;
+      *)
+        component="${remainder}"
+        remainder=
+        ;;
+    esac
+    current="${current}/${component}"
+    [ -d "${current}" ] && [ ! -L "${current}" ] || \
+      die "NVM_BIN contains an unsafe directory: ${current}"
+    metadata="$(file_metadata "${current}")"
+    mode="${metadata%% *}"
+    owner="${metadata#* }"
+    if [ -z "${trusted_nvm_owner}" ]; then
+      case "${owner}" in
+        "${EUID}"|"${platform_nvm_owner_uid}") trusted_nvm_owner="${owner}" ;;
+        *) die "NVM_BIN is not owned by the setup user or pinned platform owner: ${current}" ;;
+      esac
+    fi
+    [ "${owner}" = "${trusted_nvm_owner}" ] || \
+      die "NVM_BIN ownership changes within the trusted path: ${current}"
+    if (( 8#${mode} & 022 )); then
+      die "NVM_BIN is writable by a group or other user: ${current}"
+    fi
+  done
+}
+
+validate_nvm_provenance
+
+validate_cargo_bin_provenance() {
+  local canonical_cargo_bin
+  local cargo_canonical_home
+
+  reject_symlink_components 'Cargo bin' "${original_home}" "${cargo_bin}"
+  canonical_cargo_bin="$(canonicalize_path 'Cargo bin' "${cargo_bin}")"
+  cargo_canonical_home="$(canonicalize_path HOME "${original_home}")"
+  [ "${canonical_cargo_bin}" = "${cargo_canonical_home}/.cargo/bin" ] || \
+    die "Cargo bin resolves outside its trusted HOME path: ${cargo_bin}"
+}
+
+validate_rustup_proxy() {
+  local label="$1"
+  local executable_path="$2"
+  local trusted_root="$3"
+  local proxy_parent
+  local proxy_target
+  local rustup_target="${cargo_bin}/rustup"
+  local canonical_rustup_target
+
+  [ "${trusted_root}" = "${cargo_bin}" ] || return 1
+  case "${label}:${executable_path}" in
+    "cargo:${cargo_bin}/cargo"|"rustfmt:${cargo_bin}/rustfmt"|\
+      "cargo-clippy:${cargo_bin}/cargo-clippy") ;;
+    *) return 1 ;;
+  esac
+  proxy_parent="${executable_path%/*}"
+  reject_symlink_components "${label}" "${trusted_root}" "${proxy_parent}"
+  [ -f "${rustup_target}" ] && [ ! -L "${rustup_target}" ] && \
+    [ -x "${rustup_target}" ] || \
+    die "${label} rustup proxy target must be an executable regular file: ${rustup_target}"
+  proxy_target="$(canonicalize_path "${label} rustup proxy target" "${executable_path}")"
+  canonical_rustup_target="$(canonicalize_path rustup "${rustup_target}")"
+  [ "${proxy_target}" = "${canonical_rustup_target}" ] || \
+    die "${label} rustup proxy must resolve to ${rustup_target}"
+  validate_owner_and_mode "${label} rustup proxy target" "${rustup_target}"
+}
+
 validate_executable_path() {
   local label="$1"
   local executable_path="$2"
@@ -259,11 +359,18 @@ validate_executable_path() {
     *:*|*$'\n'*) die "${label} contains an unsafe separator: ${executable_path}" ;;
   esac
   trusted_root="$(trusted_path_root_for "${executable_path}")"
-  reject_symlink_components "${label}" "${trusted_root}" "${executable_path}"
+  if [ "${trusted_root}" = "${cargo_bin}" ]; then
+    validate_cargo_bin_provenance
+  fi
   [ -d "${trusted_root}" ] || die "trusted PATH root is not a directory: ${trusted_root}"
   validate_owner_and_mode "trusted PATH root" "${trusted_root}"
-  [ -f "${executable_path}" ] && [ ! -L "${executable_path}" ] && \
-    [ -x "${executable_path}" ] || \
+  if [ -L "${executable_path}" ]; then
+    validate_rustup_proxy "${label}" "${executable_path}" "${trusted_root}" || \
+      die "${label} is not an approved rustup proxy: ${executable_path}"
+    return 0
+  fi
+  reject_symlink_components "${label}" "${trusted_root}" "${executable_path}"
+  [ -f "${executable_path}" ] && [ -x "${executable_path}" ] || \
     die "${label} must be an executable regular file: ${executable_path}"
 
   validate_owner_and_mode "${label}" "${executable_path}"
@@ -322,8 +429,6 @@ git_command="$(find_command git)"
 cargo_command="$(find_command cargo)"
 rustup_command="$(find_command rustup)"
 
-cargo_home="${original_home}/.cargo"
-cargo_bin="${cargo_home}/bin"
 just_command="$(find_optional_command just)"
 if [ -z "${just_command}" ]; then
   has_trusted_path_entry "${cargo_bin}" || die "just is missing and trusted PATH must include ${cargo_bin} before tool installation"
@@ -484,35 +589,44 @@ resolve_installed_stable_toolchain() {
   local remainder
   local canonical_toolchain_path
   local expected_toolchain_path
-  local stable_count=0
   local active_default_count=0
   local selected_toolchain=
   local selected_toolchain_path=
+  local selected_host
 
   installed_toolchains="$(run_clean_env '' '' offline "${rustup_command}" toolchain list --verbose)"
   while IFS= read -r line; do
     candidate="${line%% *}"
+    remainder="${line#"${candidate}"}"
+    case "${remainder}" in
+      ' (active, default) '*|' (default, active) '*|' (active) '*|' (default) '*) ;;
+      *) continue ;;
+    esac
+    [ "${candidate}" != stable ] || die 'rustup returned a tracking stable channel entry'
     case "${candidate}" in
-      stable) die 'rustup returned a tracking stable channel entry' ;;
       stable-*)
-        case "${candidate}" in
-          *[!A-Za-z0-9._-]*) die "rustup returned an invalid stable toolchain name: ${candidate}" ;;
-          *) ;;
+        selected_host="${candidate#stable-}"
+        case "${selected_host}" in
+          x86_64-unknown-linux-gnu|aarch64-unknown-linux-gnu) ;;
+          *) die "rustup stable toolchain is not a supported Cloud host: ${candidate}" ;;
         esac
-        stable_count=$((stable_count + 1))
-        remainder="${line#"${candidate}"}"
-        case "${remainder}" in
-          ' (active, default) '*|' (default, active) '*|' (active) '*|' (default) '*)
-            active_default_count=$((active_default_count + 1))
-            selected_toolchain="${candidate}"
-            selected_toolchain_path="${remainder##* }"
-            ;;
+        ;;
+      *)
+        [[ "${candidate}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(.+)$ ]] || \
+          die "rustup active/default toolchain is not a concrete stable host toolchain: ${candidate}"
+        selected_host="${BASH_REMATCH[1]}"
+        case "${selected_host}" in
+          x86_64-unknown-linux-gnu|aarch64-unknown-linux-gnu) ;;
+          *) die "rustup versioned toolchain is not a supported Cloud host: ${candidate}" ;;
         esac
         ;;
     esac
+    active_default_count=$((active_default_count + 1))
+    selected_toolchain="${candidate}"
+    selected_toolchain_path="${remainder##* }"
   done <<<"${installed_toolchains}"
-  [ "${stable_count}" -eq 1 ] && [ "${active_default_count}" -eq 1 ] || \
-    die 'rustup must expose exactly one active/default stable host toolchain'
+  [ "${active_default_count}" -eq 1 ] || \
+    die 'rustup must expose exactly one active/default concrete stable host toolchain'
   [ -n "${selected_toolchain_path}" ] || \
     die 'rustup active/default stable toolchain has no installation path'
   reject_unsafe_path 'stable toolchain path' "${selected_toolchain_path}"

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -77,6 +77,7 @@ reject_unsafe_path() {
         ;;
     esac
     case "${component}" in
+      '') die "${label} contains an empty path component" ;;
       .|..) die "${label} contains a traversal component: ${component}" ;;
     esac
   done
@@ -115,6 +116,7 @@ reject_symlink_components() {
 
 canonical_nvm_bin=
 trusted_nvm_owner=
+trusted_nvm_ancestor_owner=
 platform_nvm_owner_uid=1001
 if [ "${NVM_BIN+x}" = x ]; then
   nvm_bin="${NVM_BIN}"
@@ -185,6 +187,7 @@ validate_trusted_path() {
       /*) ;;
       *) die "trusted PATH entry must be absolute: ${entry}" ;;
     esac
+    reject_unsafe_path 'trusted PATH entry' "${entry}"
   done
 }
 
@@ -231,6 +234,22 @@ file_metadata() {
   fi
 }
 
+validate_system_owner_and_mode() {
+  local label="$1"
+  local path="$2"
+  local metadata
+  local mode
+  local owner
+
+  metadata="$(file_metadata "${path}")"
+  mode="${metadata%% *}"
+  owner="${metadata#* }"
+  [ "${owner}" = 0 ] || die "${label} is not owned by the platform owner: ${path}"
+  if (( 8#${mode} & 022 )); then
+    die "${label} is writable by a group or other user: ${path}"
+  fi
+}
+
 validate_owner_and_mode() {
   local label="$1"
   local path="$2"
@@ -254,7 +273,8 @@ validate_owner_and_mode() {
     esac
   fi
   case "${path}" in
-    /bin/*|/usr/bin/*|/sbin/*|/usr/sbin/*|/usr/local/bin/*|/usr/local/sbin/*)
+    /bin|/bin/*|/usr/bin|/usr/bin/*|/sbin|/sbin/*|/usr/sbin|/usr/sbin/*|\
+      /usr/local/bin|/usr/local/bin/*|/usr/local/sbin|/usr/local/sbin/*)
       [ "${owner}" = 0 ] || die "${label} is not owned by the platform owner: ${path}"
       ;;
     *)
@@ -295,14 +315,22 @@ validate_nvm_provenance() {
     metadata="$(file_metadata "${current}")"
     mode="${metadata%% *}"
     owner="${metadata#* }"
-    if [ -z "${trusted_nvm_owner}" ]; then
+    if [ "${current}" = "${canonical_nvm_bin}" ]; then
       case "${owner}" in
-        "${EUID}"|"${platform_nvm_owner_uid}") trusted_nvm_owner="${owner}" ;;
-        *) die "NVM_BIN is not owned by the setup user or pinned platform owner: ${current}" ;;
+        "${trusted_nvm_ancestor_owner}"|"${platform_nvm_owner_uid}")
+          trusted_nvm_owner="${owner}"
+          ;;
+        *) die "NVM_BIN has an untrusted owner transition at bin: ${current}" ;;
       esac
+    elif [ -z "${trusted_nvm_ancestor_owner}" ]; then
+      case "${owner}" in
+        "${EUID}"|0) trusted_nvm_ancestor_owner="${owner}" ;;
+        *) die "NVM_BIN ancestors are not owned by the setup user or root: ${current}" ;;
+      esac
+    else
+      [ "${owner}" = "${trusted_nvm_ancestor_owner}" ] || \
+        die "NVM_BIN ownership changes before the trusted bin transition: ${current}"
     fi
-    [ "${owner}" = "${trusted_nvm_owner}" ] || \
-      die "NVM_BIN ownership changes within the trusted path: ${current}"
     if (( 8#${mode} & 022 )); then
       die "NVM_BIN is writable by a group or other user: ${current}"
     fi
@@ -320,6 +348,9 @@ validate_cargo_bin_provenance() {
   cargo_canonical_home="$(canonicalize_path HOME "${original_home}")"
   [ "${canonical_cargo_bin}" = "${cargo_canonical_home}/.cargo/bin" ] || \
     die "Cargo bin resolves outside its trusted HOME path: ${cargo_bin}"
+  validate_owner_and_mode "Cargo HOME" "${original_home}"
+  validate_owner_and_mode "Cargo home" "${cargo_home}"
+  validate_owner_and_mode "Cargo bin" "${cargo_bin}"
 }
 
 validate_rustup_proxy() {
@@ -349,24 +380,58 @@ validate_rustup_proxy() {
   validate_owner_and_mode "${label} rustup proxy target" "${rustup_target}"
 }
 
+validate_system_python_symlink() {
+  local label="$1"
+  local executable_path="$2"
+  local trusted_root="$3"
+  local component
+  local canonical_target
+
+  [ "${label}" = python3 ] && [ "${executable_path}" = /usr/bin/python3 ] && \
+    [ "${trusted_root}" = /usr/bin ] || return 1
+  for component in / /usr /usr/bin; do
+    [ -d "${component}" ] && [ ! -L "${component}" ] || \
+      die "python3 system path contains an unsafe parent: ${component}"
+    validate_system_owner_and_mode "python3 system parent" "${component}"
+  done
+  canonical_target="$(canonicalize_path python3 "${executable_path}")"
+  [[ "${canonical_target}" =~ ^/usr/bin/python3\.[0-9]+$ ]] || \
+    die "python3 system symlink does not resolve to a direct versioned system binary: ${canonical_target}"
+  [ -f "${canonical_target}" ] && [ ! -L "${canonical_target}" ] && \
+    [ -x "${canonical_target}" ] || \
+    die "python3 system target must be an executable regular file: ${canonical_target}"
+  validate_system_owner_and_mode "python3 system target" "${canonical_target}"
+}
+
 validate_executable_path() {
   local label="$1"
   local executable_path="$2"
   local trusted_root
+  local canonical_trusted_root
+  local canonical_cargo_bin_candidate
 
   reject_unsafe_path "${label}" "${executable_path}"
   case "${executable_path}" in
     *:*|*$'\n'*) die "${label} contains an unsafe separator: ${executable_path}" ;;
   esac
   trusted_root="$(trusted_path_root_for "${executable_path}")"
-  if [ "${trusted_root}" = "${cargo_bin}" ]; then
+  [ -d "${trusted_root}" ] || die "trusted PATH root is not a directory: ${trusted_root}"
+  canonical_trusted_root="$(canonicalize_path 'trusted PATH root' "${trusted_root}")"
+  canonical_cargo_bin_candidate=
+  if [ -d "${cargo_bin}" ]; then
+    canonical_cargo_bin_candidate="$(canonicalize_path 'Cargo bin candidate' "${cargo_bin}")"
+  fi
+  if [ "${trusted_root}" = "${cargo_bin}" ] || \
+    { [ -n "${canonical_cargo_bin_candidate}" ] && \
+      [ "${canonical_trusted_root}" = "${canonical_cargo_bin_candidate}" ]; }; then
     validate_cargo_bin_provenance
   fi
-  [ -d "${trusted_root}" ] || die "trusted PATH root is not a directory: ${trusted_root}"
   validate_owner_and_mode "trusted PATH root" "${trusted_root}"
   if [ -L "${executable_path}" ]; then
-    validate_rustup_proxy "${label}" "${executable_path}" "${trusted_root}" || \
-      die "${label} is not an approved rustup proxy: ${executable_path}"
+    if ! validate_rustup_proxy "${label}" "${executable_path}" "${trusted_root}"; then
+      validate_system_python_symlink "${label}" "${executable_path}" "${trusted_root}" || \
+        die "${label} is not an approved executable symlink: ${executable_path}"
+    fi
     return 0
   fi
   reject_symlink_components "${label}" "${trusted_root}" "${executable_path}"

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -22,10 +22,49 @@ case "${original_home}" in
   *:*|*$'\n'*) die 'HOME must not contain colon or newline' ;;
 esac
 
+canonical_nvm_bin=
+if [ "${NVM_BIN+x}" = x ]; then
+  nvm_bin="${NVM_BIN}"
+  [ -n "${nvm_bin}" ] || die 'NVM_BIN must not be empty'
+  case "${nvm_bin}" in
+    /*) ;;
+    *) die 'NVM_BIN must be an absolute path' ;;
+  esac
+  case "${nvm_bin}" in
+    *:*|*$'\n'*) die 'NVM_BIN must not contain colon or newline' ;;
+  esac
+  nvm_root="${original_home}/.nvm/versions/node/"
+  canonical_home="$(cd -- "${original_home}" && pwd -P)" || die 'cannot canonicalize HOME'
+  canonical_nvm_root="${canonical_home}/.nvm/versions/node/"
+  case "${nvm_bin}" in
+    "${nvm_root}"*/bin) ;;
+    *) die 'NVM_BIN must be under HOME/.nvm/versions/node/<version>/bin' ;;
+  esac
+  nvm_version="${nvm_bin#"${nvm_root}"}"
+  nvm_version="${nvm_version%/bin}"
+  case "${nvm_version}" in
+    ''|*/*) die 'NVM_BIN must name one NVM version directory' ;;
+  esac
+  [ -d "${nvm_bin}" ] || die "NVM_BIN directory does not exist: ${nvm_bin}"
+  canonical_nvm_bin="$(cd -- "${nvm_bin}" && pwd -P)" || die 'cannot canonicalize NVM_BIN'
+  case "${canonical_nvm_bin}" in
+    "${canonical_nvm_root}"*/bin) ;;
+    *) die 'NVM_BIN resolves outside HOME/.nvm/versions/node/<version>/bin' ;;
+  esac
+  canonical_version="${canonical_nvm_bin#"${canonical_nvm_root}"}"
+  canonical_version="${canonical_version%/bin}"
+  case "${canonical_version}" in
+    ''|*/*) die 'NVM_BIN resolves to an invalid NVM version directory' ;;
+  esac
+fi
+
 if [ "${RPM_CODEX_CLOUD_TRUSTED_PATH+x}" = x ]; then
   trusted_path="${RPM_CODEX_CLOUD_TRUSTED_PATH}"
 else
   trusted_path="${original_home}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  if [ -n "${canonical_nvm_bin}" ]; then
+    trusted_path="${canonical_nvm_bin}:${trusted_path}"
+  fi
 fi
 
 validate_trusted_path() {
@@ -59,6 +98,28 @@ validate_trusted_path() {
 validate_trusted_path "${trusted_path}"
 export PATH="${trusted_path}"
 
+has_trusted_path_entry() {
+  local expected="$1"
+  local path_value="${trusted_path}"
+  local entry
+
+  while :; do
+    case "${path_value}" in
+      *:*)
+        entry="${path_value%%:*}"
+        path_value="${path_value#*:}"
+        ;;
+      *)
+        entry="${path_value}"
+        path_value=
+        ;;
+    esac
+    [ "${entry}" = "${expected}" ] && return 0
+    [ -n "${path_value}" ] || break
+  done
+  return 1
+}
+
 find_command() {
   local command_name="$1"
   local command_path
@@ -79,13 +140,19 @@ git_command="$(find_command git)"
 cargo_command="$(find_command cargo)"
 rustup_command="$(find_command rustup)"
 
+cargo_home="${original_home}/.cargo"
+cargo_bin="${cargo_home}/bin"
+just_command="$(find_optional_command just)"
+if [ -z "${just_command}" ]; then
+  has_trusted_path_entry "${cargo_bin}" || die "just is missing and trusted PATH must include ${cargo_bin} before tool installation"
+fi
+
 setup_home="$(/usr/bin/mktemp -d /tmp/rpm-codex-cloud-home.XXXXXX)"
 cleanup() {
   /bin/rm -rf -- "${setup_home}"
 }
 trap cleanup EXIT
 
-cargo_home="${original_home}/.cargo"
 rustup_home="${original_home}/.rustup"
 
 run_clean() {
@@ -158,7 +225,6 @@ if ! has_component clippy "${installed_components}"; then
   run_clean "${rustup_command}" component add --toolchain stable clippy
 fi
 
-just_command="$(find_optional_command just)"
 if [ -z "${just_command}" ]; then
   run_clean "${cargo_command}" install just --locked
 fi

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -22,6 +22,94 @@ case "${original_home}" in
   *:*|*$'\n'*) die 'HOME must not contain colon or newline' ;;
 esac
 
+select_canonicalizer() {
+  local candidate
+
+  for candidate in /usr/bin/realpath /bin/realpath; do
+    if [ -f "${candidate}" ] && [ -x "${candidate}" ]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  die 'a trusted realpath canonicalizer is required'
+}
+
+canonicalizer="$(select_canonicalizer)"
+
+canonicalize_path() {
+  local label="$1"
+  local path="$2"
+  local canonical_path
+
+  canonical_path="$("${canonicalizer}" -- "${path}")" || \
+    die "cannot canonicalize ${label}: ${path}"
+  [ -n "${canonical_path}" ] || die "canonicalizer returned no ${label} path"
+  case "${canonical_path}" in
+    *$'\n'*) die "canonicalizer returned an invalid ${label} path" ;;
+  esac
+  printf '%s\n' "${canonical_path}"
+}
+
+reject_unsafe_path() {
+  local label="$1"
+  local path="$2"
+  local remainder
+  local component
+
+  case "${path}" in
+    /*) ;;
+    *) die "${label} must be an absolute path: ${path}" ;;
+  esac
+
+  remainder="${path#/}"
+  while [ -n "${remainder}" ]; do
+    case "${remainder}" in
+      */*)
+        component="${remainder%%/*}"
+        remainder="${remainder#*/}"
+        ;;
+      *)
+        component="${remainder}"
+        remainder=
+        ;;
+    esac
+    case "${component}" in
+      .|..) die "${label} contains a traversal component: ${component}" ;;
+    esac
+  done
+}
+
+reject_symlink_components() {
+  local label="$1"
+  local root="$2"
+  local path="$3"
+  local remainder
+  local component
+  local current="${root}"
+
+  case "${path}" in
+    "${root}") remainder= ;;
+    "${root}"/*) remainder="${path#"${root}"/}" ;;
+    *) die "${label} is outside its trusted root: ${path}" ;;
+  esac
+  [ ! -L "${current}" ] || die "${label} contains a symlink path component: ${current}"
+
+  while [ -n "${remainder}" ]; do
+    case "${remainder}" in
+      */*)
+        component="${remainder%%/*}"
+        remainder="${remainder#*/}"
+        ;;
+      *)
+        component="${remainder}"
+        remainder=
+        ;;
+    esac
+    current="${current}/${component}"
+    [ ! -L "${current}" ] || die "${label} contains a symlink path component: ${current}"
+  done
+}
+
 canonical_nvm_bin=
 if [ "${NVM_BIN+x}" = x ]; then
   nvm_bin="${NVM_BIN}"
@@ -154,19 +242,42 @@ cleanup() {
 trap cleanup EXIT
 
 rustup_home="${original_home}/.rustup"
+reject_unsafe_path RUSTUP_HOME "${rustup_home}"
+reject_symlink_components RUSTUP_HOME "${rustup_home}" "${rustup_home}"
+canonical_rustup_home="$(canonicalize_path RUSTUP_HOME "${rustup_home}")"
+[ -d "${canonical_rustup_home}" ] || die "RUSTUP_HOME is not a directory: ${rustup_home}"
+[ ! -L "${canonical_rustup_home}" ] || die "canonical RUSTUP_HOME must not be a symlink: ${canonical_rustup_home}"
+
+run_clean_env() {
+  local toolchain="$1"
+  local rustc_command="$2"
+  shift 2
+  local -a clean_env=(
+    "HOME=${setup_home}"
+    "PATH=${trusted_path}"
+    "CARGO_HOME=${cargo_home}"
+    "RUSTUP_HOME=${canonical_rustup_home}"
+    GIT_CONFIG_GLOBAL=/dev/null
+    GIT_CONFIG_SYSTEM=/dev/null
+    GIT_CONFIG_NOSYSTEM=1
+    GIT_TERMINAL_PROMPT=0
+  )
+
+  if [ -n "${toolchain}" ]; then
+    clean_env+=("RUSTUP_TOOLCHAIN=${toolchain}")
+  fi
+  if [ -n "${rustc_command}" ]; then
+    clean_env+=("RUSTC=${rustc_command}")
+  fi
+  /usr/bin/env -i "${clean_env[@]}" "$@"
+}
 
 run_clean() {
-  /usr/bin/env -i \
-    HOME="${setup_home}" \
-    PATH="${trusted_path}" \
-    CARGO_HOME="${cargo_home}" \
-    RUSTUP_HOME="${rustup_home}" \
-    RUSTUP_TOOLCHAIN=stable \
-    GIT_CONFIG_GLOBAL=/dev/null \
-    GIT_CONFIG_SYSTEM=/dev/null \
-    GIT_CONFIG_NOSYSTEM=1 \
-    GIT_TERMINAL_PROMPT=0 \
-    "$@"
+  run_clean_env stable '' "$@"
+}
+
+run_clean_exact() {
+  run_clean_env '' "${stable_rustc_command}" "$@"
 }
 
 check_cargo_control_file() {
@@ -217,6 +328,53 @@ has_component() {
   return 1
 }
 
+resolve_stable_binary() {
+  local binary_name="$1"
+  local binary_path
+  local canonical_binary_path
+
+  binary_path="$(run_clean "${rustup_command}" which --toolchain stable "${binary_name}")"
+  [ -n "${binary_path}" ] || die "rustup did not return the stable ${binary_name} path"
+  reject_unsafe_path "stable ${binary_name}" "${binary_path}"
+  reject_symlink_components "stable ${binary_name}" "${canonical_rustup_home}" "${binary_path}"
+  case "${binary_path}" in
+    "${canonical_rustup_home}"/toolchains/*/bin/"${binary_name}") ;;
+    *) die "stable ${binary_name} resolved outside RUSTUP_HOME: ${binary_path}" ;;
+  esac
+  canonical_binary_path="$(canonicalize_path "stable ${binary_name}" "${binary_path}")"
+  printf '%s\n' "${canonical_binary_path}"
+}
+
+validate_stable_binary() {
+  local binary_name="$1"
+  local binary_path="$2"
+  local relative_path
+  local toolchain_name
+  local toolchain_root
+  local toolchain_bin
+
+  case "${binary_path}" in
+    "${canonical_rustup_home}"/toolchains/*/bin/"${binary_name}") ;;
+    *) die "stable ${binary_name} is outside canonical RUSTUP_HOME: ${binary_path}" ;;
+  esac
+  relative_path="${binary_path#"${canonical_rustup_home}"/toolchains/}"
+  toolchain_name="${relative_path%/bin/${binary_name}}"
+  case "${toolchain_name}" in
+    ''|*/*) die "stable ${binary_name} has an invalid toolchain directory: ${binary_path}" ;;
+  esac
+  toolchain_root="${canonical_rustup_home}/toolchains/${toolchain_name}"
+  toolchain_bin="${toolchain_root}/bin"
+  [ "${binary_path}" = "${toolchain_bin}/${binary_name}" ] || \
+    die "stable ${binary_name} is not the exact toolchain binary: ${binary_path}"
+  [ -d "${toolchain_root}" ] && [ ! -L "${toolchain_root}" ] || \
+    die "stable ${binary_name} toolchain root is unsafe: ${toolchain_root}"
+  [ -d "${toolchain_bin}" ] && [ ! -L "${toolchain_bin}" ] || \
+    die "stable ${binary_name} toolchain bin is unsafe: ${toolchain_bin}"
+  [ -f "${binary_path}" ] && [ ! -L "${binary_path}" ] && [ -x "${binary_path}" ] || \
+    die "stable ${binary_name} must be an executable regular file: ${binary_path}"
+  printf '%s\n' "${toolchain_root}"
+}
+
 installed_components="$(run_clean "${rustup_command}" component list --toolchain stable --installed)"
 if ! has_component rustfmt "${installed_components}"; then
   run_clean "${rustup_command}" component add --toolchain stable rustfmt
@@ -225,8 +383,15 @@ if ! has_component clippy "${installed_components}"; then
   run_clean "${rustup_command}" component add --toolchain stable clippy
 fi
 
+stable_cargo_command="$(resolve_stable_binary cargo)"
+stable_rustc_command="$(resolve_stable_binary rustc)"
+stable_cargo_toolchain_root="$(validate_stable_binary cargo "${stable_cargo_command}")"
+stable_rustc_toolchain_root="$(validate_stable_binary rustc "${stable_rustc_command}")"
+[ "${stable_cargo_toolchain_root}" = "${stable_rustc_toolchain_root}" ] || \
+  die "stable cargo and rustc resolve to different toolchains"
+
 if [ -z "${just_command}" ]; then
-  run_clean "${cargo_command}" install just --locked
+  run_clean_exact "${stable_cargo_command}" install just --locked
 fi
 
 rustfmt_command="$(find_command rustfmt)"
@@ -236,7 +401,7 @@ find_command jq >/dev/null
 find_command node >/dev/null
 find_command python3 >/dev/null
 
-run_clean "${cargo_command}" fetch --quiet --locked
-run_clean "${cargo_command}" check --quiet --offline --locked --all-targets
+run_clean_exact "${stable_cargo_command}" fetch --quiet --locked
+run_clean_exact "${stable_cargo_command}" check --quiet --offline --locked --all-targets
 
 printf 'codex-cloud-setup: ready (%s)\n' "${repo_root}"

--- a/scripts/codex-cloud-setup.sh
+++ b/scripts/codex-cloud-setup.sh
@@ -1,5 +1,176 @@
-#!/usr/bin/env bash
+#!/bin/bash -p
 set -euo pipefail
 
-script_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-exec "${script_dir}/worktree-setup.sh" "$@"
+die() {
+  printf 'codex-cloud-setup: %s\n' "$*" >&2
+  exit 1
+}
+
+script_dir="${BASH_SOURCE[0]%/*}"
+if [ "${script_dir}" = "${BASH_SOURCE[0]}" ]; then
+  script_dir=.
+fi
+script_dir="$(cd -- "${script_dir}" && pwd -P)"
+
+original_home="${HOME:-}"
+[ -n "${original_home}" ] || die 'HOME is required'
+case "${original_home}" in
+  /*) ;;
+  *) die 'HOME must be an absolute path' ;;
+esac
+case "${original_home}" in
+  *:*|*$'\n'*) die 'HOME must not contain colon or newline' ;;
+esac
+
+if [ "${RPM_CODEX_CLOUD_TRUSTED_PATH+x}" = x ]; then
+  trusted_path="${RPM_CODEX_CLOUD_TRUSTED_PATH}"
+else
+  trusted_path="${original_home}/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+fi
+
+validate_trusted_path() {
+  local path_value="$1"
+  local entry
+
+  [ -n "${path_value}" ] || die 'trusted PATH must not be empty'
+  case "${path_value}" in
+    *::*|:*|*:)
+      die 'trusted PATH must not contain empty entries'
+      ;;
+  esac
+  while [ -n "${path_value}" ]; do
+    case "${path_value}" in
+      *:*)
+        entry="${path_value%%:*}"
+        path_value="${path_value#*:}"
+        ;;
+      *)
+        entry="${path_value}"
+        path_value=
+        ;;
+    esac
+    case "${entry}" in
+      /*) ;;
+      *) die "trusted PATH entry must be absolute: ${entry}" ;;
+    esac
+  done
+}
+
+validate_trusted_path "${trusted_path}"
+export PATH="${trusted_path}"
+
+find_command() {
+  local command_name="$1"
+  local command_path
+
+  command_path="$(command -v "${command_name}" 2>/dev/null || true)"
+  [ -n "${command_path}" ] || die "${command_name} is required on the trusted PATH"
+  case "${command_path}" in
+    /*) printf '%s\n' "${command_path}" ;;
+    *) die "${command_name} resolved outside the trusted PATH: ${command_path}" ;;
+  esac
+}
+
+find_optional_command() {
+  command -v "$1" 2>/dev/null || true
+}
+
+git_command="$(find_command git)"
+cargo_command="$(find_command cargo)"
+rustup_command="$(find_command rustup)"
+
+setup_home="$(/usr/bin/mktemp -d /tmp/rpm-codex-cloud-home.XXXXXX)"
+cleanup() {
+  /bin/rm -rf -- "${setup_home}"
+}
+trap cleanup EXIT
+
+cargo_home="${original_home}/.cargo"
+rustup_home="${original_home}/.rustup"
+
+run_clean() {
+  /usr/bin/env -i \
+    HOME="${setup_home}" \
+    PATH="${trusted_path}" \
+    CARGO_HOME="${cargo_home}" \
+    RUSTUP_HOME="${rustup_home}" \
+    RUSTUP_TOOLCHAIN=stable \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_CONFIG_SYSTEM=/dev/null \
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_TERMINAL_PROMPT=0 \
+    "$@"
+}
+
+check_cargo_control_file() {
+  local path="$1"
+  if [ -e "${path}" ] || [ -L "${path}" ]; then
+    die "refusing Cargo configuration or credentials for public setup: ${path}"
+  fi
+}
+
+check_cargo_controls() {
+  local directory="${repo_root}"
+  local candidate
+
+  while :; do
+    check_cargo_control_file "${directory}/.cargo/config"
+    check_cargo_control_file "${directory}/.cargo/config.toml"
+    [ "${directory}" = / ] && break
+    directory="${directory%/*}"
+    [ -n "${directory}" ] || directory=/
+  done
+
+  for candidate in \
+    "${cargo_home}/config" \
+    "${cargo_home}/config.toml" \
+    "${cargo_home}/credentials" \
+    "${cargo_home}/credentials.toml"
+  do
+    check_cargo_control_file "${candidate}"
+  done
+}
+
+repo_root_candidate="$(cd -- "${script_dir}/.." && pwd -P)"
+repo_root="$(run_clean "${git_command}" -C "${repo_root_candidate}" rev-parse --show-toplevel)"
+[ -n "${repo_root}" ] || die 'Git did not return a repository root'
+cd -- "${repo_root}"
+check_cargo_controls
+
+has_component() {
+  local component="$1"
+  local installed="$2"
+  local line
+
+  while IFS= read -r line; do
+    case "${line}" in
+      "${component}-"*' (installed)'|"${component}-"*) return 0 ;;
+    esac
+  done <<<"${installed}"
+  return 1
+}
+
+installed_components="$(run_clean "${rustup_command}" component list --toolchain stable --installed)"
+if ! has_component rustfmt "${installed_components}"; then
+  run_clean "${rustup_command}" component add --toolchain stable rustfmt
+fi
+if ! has_component clippy "${installed_components}"; then
+  run_clean "${rustup_command}" component add --toolchain stable clippy
+fi
+
+just_command="$(find_optional_command just)"
+if [ -z "${just_command}" ]; then
+  run_clean "${cargo_command}" install just --locked
+fi
+
+rustfmt_command="$(find_command rustfmt)"
+clippy_command="$(find_command cargo-clippy)"
+just_command="$(find_command just)"
+find_command jq >/dev/null
+find_command node >/dev/null
+find_command python3 >/dev/null
+
+run_clean "${cargo_command}" fetch --quiet --locked
+run_clean "${cargo_command}" check --quiet --offline --locked --all-targets
+
+printf 'codex-cloud-setup: ready (%s)\n' "${repo_root}"

--- a/scripts/test-codex-cloud-setup.sh
+++ b/scripts/test-codex-cloud-setup.sh
@@ -623,6 +623,68 @@ assert_contains "$(<"${regular_cargo_parent_symlink_output}")" \
   'Cargo bin contains a symlink path component'
 [ "$(<"${regular_cargo_parent_symlink_status}")" -eq 1 ]
 
+writable_cargo_home_case="$(new_case writable-cargo-home)"
+make_fake_environment "${writable_cargo_home_case}" warm
+cp "${writable_cargo_home_case}/trusted/bin/"* \
+  "${writable_cargo_home_case}/home/.cargo/bin/"
+chmod 775 "${writable_cargo_home_case}/home"
+writable_cargo_home_output="${writable_cargo_home_case}/output"
+writable_cargo_home_status="${writable_cargo_home_case}/status"
+run_setup "${writable_cargo_home_case}" \
+  "${writable_cargo_home_case}/home/.cargo/bin:${writable_cargo_home_case}/trusted/bin" \
+  "${writable_cargo_home_case}/trusted/bin" "${writable_cargo_home_output}" \
+  "${writable_cargo_home_status}"
+[ "$(<"${writable_cargo_home_status}")" -eq 1 ]
+assert_contains "$(<"${writable_cargo_home_output}")" \
+  'Cargo HOME is writable by a group or other user'
+
+writable_cargo_parent_case="$(new_case writable-cargo-parent)"
+make_fake_environment "${writable_cargo_parent_case}" warm
+cp "${writable_cargo_parent_case}/trusted/bin/"* \
+  "${writable_cargo_parent_case}/home/.cargo/bin/"
+chmod 775 "${writable_cargo_parent_case}/home/.cargo"
+writable_cargo_parent_output="${writable_cargo_parent_case}/output"
+writable_cargo_parent_status="${writable_cargo_parent_case}/status"
+run_setup "${writable_cargo_parent_case}" \
+  "${writable_cargo_parent_case}/home/.cargo/bin:${writable_cargo_parent_case}/trusted/bin" \
+  "${writable_cargo_parent_case}/trusted/bin" \
+  "${writable_cargo_parent_output}" "${writable_cargo_parent_status}"
+[ "$(<"${writable_cargo_parent_status}")" -eq 1 ]
+assert_contains "$(<"${writable_cargo_parent_output}")" \
+  'Cargo home is writable by a group or other user'
+
+aliased_cargo_parent_case="$(new_case aliased-cargo-parent)"
+make_fake_environment "${aliased_cargo_parent_case}" warm
+cp "${aliased_cargo_parent_case}/trusted/bin/"* \
+  "${aliased_cargo_parent_case}/home/.cargo/bin/"
+chmod 775 "${aliased_cargo_parent_case}/home"
+aliased_cargo_parent_output="${aliased_cargo_parent_case}/output"
+aliased_cargo_parent_status="${aliased_cargo_parent_case}/status"
+run_setup "${aliased_cargo_parent_case}" \
+  "${aliased_cargo_parent_case}/home//.cargo/bin:${aliased_cargo_parent_case}/trusted/bin" \
+  "${aliased_cargo_parent_case}/trusted/bin" "${aliased_cargo_parent_output}" \
+  "${aliased_cargo_parent_status}"
+[ "$(<"${aliased_cargo_parent_status}")" -eq 1 ]
+assert_contains "$(<"${aliased_cargo_parent_output}")" \
+  'trusted PATH entry contains an empty path component'
+
+if [ "${EUID}" -eq 0 ]; then
+  wrong_owner_cargo_parent_case="$(new_case wrong-owner-cargo-parent)"
+  make_fake_environment "${wrong_owner_cargo_parent_case}" warm
+  cp "${wrong_owner_cargo_parent_case}/trusted/bin/"* \
+    "${wrong_owner_cargo_parent_case}/home/.cargo/bin/"
+  chown 1001 "${wrong_owner_cargo_parent_case}/home/.cargo"
+  wrong_owner_cargo_parent_output="${wrong_owner_cargo_parent_case}/output"
+  wrong_owner_cargo_parent_status="${wrong_owner_cargo_parent_case}/status"
+  run_setup "${wrong_owner_cargo_parent_case}" \
+    "${wrong_owner_cargo_parent_case}/home/.cargo/bin:${wrong_owner_cargo_parent_case}/trusted/bin" \
+    "${wrong_owner_cargo_parent_case}/trusted/bin" \
+    "${wrong_owner_cargo_parent_output}" "${wrong_owner_cargo_parent_status}"
+  [ "$(<"${wrong_owner_cargo_parent_status}")" -eq 1 ]
+  assert_contains "$(<"${wrong_owner_cargo_parent_output}")" \
+    'Cargo home is not owned by the setup user'
+fi
+
 rustup_proxy_writable_case="$(new_case rustup-proxy-writable)"
 make_fake_environment "${rustup_proxy_writable_case}" rustup-proxies
 chmod 777 "${rustup_proxy_writable_case}/home/.cargo/bin/rustup"
@@ -925,7 +987,8 @@ if [ "${EUID}" -eq 0 ]; then
   mkdir -p "${platform_nvm_bin}"
   cp "${platform_nvm_case}/trusted/bin/"* "${platform_nvm_case}/home/.cargo/bin/"
   cp "${platform_nvm_case}/trusted/bin/node" "${platform_nvm_bin}/node"
-  chown -R 1001 "${platform_nvm_case}/home/.nvm"
+  chown -R 0 "${platform_nvm_case}/home/.nvm"
+  chown -R 1001 "${platform_nvm_bin}"
   platform_nvm_output="${platform_nvm_case}/output"
   platform_nvm_status="${platform_nvm_case}/status"
   run_setup "${platform_nvm_case}" __DEFAULT__ \
@@ -939,8 +1002,9 @@ if [ "${EUID}" -eq 0 ]; then
   mkdir -p "${mixed_nvm_bin}"
   cp "${mixed_nvm_case}/trusted/bin/"* "${mixed_nvm_case}/home/.cargo/bin/"
   cp "${mixed_nvm_case}/trusted/bin/node" "${mixed_nvm_bin}/node"
-  chown -R 1001 "${mixed_nvm_case}/home/.nvm"
-  chown 1002 "${mixed_nvm_bin}/node"
+  chown -R 0 "${mixed_nvm_case}/home/.nvm"
+  chown -R 1001 "${mixed_nvm_bin}"
+  chown 0 "${mixed_nvm_bin}/node"
   mixed_nvm_output="${mixed_nvm_case}/output"
   mixed_nvm_status="${mixed_nvm_case}/status"
   run_setup "${mixed_nvm_case}" __DEFAULT__ "${mixed_nvm_case}/shadow/bin" \
@@ -948,6 +1012,59 @@ if [ "${EUID}" -eq 0 ]; then
     "${mixed_nvm_bin}"
   [ "$(<"${mixed_nvm_status}")" -eq 1 ]
   assert_contains "$(<"${mixed_nvm_output}")" 'does not match the pinned NVM owner'
+
+  arbitrary_nvm_case="$(new_case arbitrary-nvm-owner)"
+  make_fake_environment "${arbitrary_nvm_case}" warm
+  arbitrary_nvm_bin="${arbitrary_nvm_case}/home/.nvm/versions/node/vfixture/bin"
+  mkdir -p "${arbitrary_nvm_bin}"
+  cp "${arbitrary_nvm_case}/trusted/bin/"* "${arbitrary_nvm_case}/home/.cargo/bin/"
+  cp "${arbitrary_nvm_case}/trusted/bin/node" "${arbitrary_nvm_bin}/node"
+  chown -R 1001 "${arbitrary_nvm_case}/home/.nvm"
+  arbitrary_nvm_output="${arbitrary_nvm_case}/output"
+  arbitrary_nvm_status="${arbitrary_nvm_case}/status"
+  run_setup "${arbitrary_nvm_case}" __DEFAULT__ \
+    "${arbitrary_nvm_case}/shadow/bin" "${arbitrary_nvm_output}" \
+    "${arbitrary_nvm_status}" "${arbitrary_nvm_case}/home" "${arbitrary_nvm_bin}"
+  [ "$(<"${arbitrary_nvm_status}")" -eq 1 ]
+  assert_contains "$(<"${arbitrary_nvm_output}")" \
+    'NVM_BIN ancestors are not owned by the setup user or root'
+
+  arbitrary_nvm_transition_case="$(new_case arbitrary-nvm-transition)"
+  make_fake_environment "${arbitrary_nvm_transition_case}" warm
+  arbitrary_nvm_transition_bin="${arbitrary_nvm_transition_case}/home/.nvm/versions/node/vfixture/bin"
+  mkdir -p "${arbitrary_nvm_transition_bin}"
+  cp "${arbitrary_nvm_transition_case}/trusted/bin/"* \
+    "${arbitrary_nvm_transition_case}/home/.cargo/bin/"
+  cp "${arbitrary_nvm_transition_case}/trusted/bin/node" \
+    "${arbitrary_nvm_transition_bin}/node"
+  chown -R 0 "${arbitrary_nvm_transition_case}/home/.nvm"
+  chown -R 1002 "${arbitrary_nvm_transition_bin}"
+  arbitrary_nvm_transition_output="${arbitrary_nvm_transition_case}/output"
+  arbitrary_nvm_transition_status="${arbitrary_nvm_transition_case}/status"
+  run_setup "${arbitrary_nvm_transition_case}" __DEFAULT__ \
+    "${arbitrary_nvm_transition_case}/shadow/bin" \
+    "${arbitrary_nvm_transition_output}" "${arbitrary_nvm_transition_status}" \
+    "${arbitrary_nvm_transition_case}/home" "${arbitrary_nvm_transition_bin}"
+  [ "$(<"${arbitrary_nvm_transition_status}")" -eq 1 ]
+  assert_contains "$(<"${arbitrary_nvm_transition_output}")" \
+    'NVM_BIN has an untrusted owner transition at bin'
+
+  multiple_nvm_case="$(new_case multiple-nvm-owner-transition)"
+  make_fake_environment "${multiple_nvm_case}" warm
+  multiple_nvm_bin="${multiple_nvm_case}/home/.nvm/versions/node/vfixture/bin"
+  mkdir -p "${multiple_nvm_bin}"
+  cp "${multiple_nvm_case}/trusted/bin/"* "${multiple_nvm_case}/home/.cargo/bin/"
+  cp "${multiple_nvm_case}/trusted/bin/node" "${multiple_nvm_bin}/node"
+  chown -R 0 "${multiple_nvm_case}/home/.nvm"
+  chown -R 1001 "${multiple_nvm_case}/home/.nvm/versions"
+  multiple_nvm_output="${multiple_nvm_case}/output"
+  multiple_nvm_status="${multiple_nvm_case}/status"
+  run_setup "${multiple_nvm_case}" __DEFAULT__ \
+    "${multiple_nvm_case}/shadow/bin" "${multiple_nvm_output}" \
+    "${multiple_nvm_status}" "${multiple_nvm_case}/home" "${multiple_nvm_bin}"
+  [ "$(<"${multiple_nvm_status}")" -eq 1 ]
+  assert_contains "$(<"${multiple_nvm_output}")" \
+    'NVM_BIN ownership changes before the trusted bin transition'
 fi
 
 default_unset_nvm_case="$(new_case default-unset-nvm)"
@@ -987,6 +1104,48 @@ run_setup "${invalid_nvm_case}" "${invalid_nvm_case}/trusted/bin" \
   "${invalid_nvm_case}/home" "${invalid_nvm_case}/outside/node/bin"
 [ "$(<"${invalid_nvm_status}")" -eq 1 ]
 assert_contains "$(<"${invalid_nvm_output}")" 'NVM_BIN must be under HOME/.nvm/versions/node/<version>/bin'
+
+platform_python_case="$(new_case platform-python)"
+make_fake_environment "${platform_python_case}" warm python3
+platform_python_output="${platform_python_case}/output"
+platform_python_status="${platform_python_case}/status"
+run_setup "${platform_python_case}" \
+  "${platform_python_case}/trusted/bin:/usr/bin" \
+  "${platform_python_case}/trusted/bin" "${platform_python_output}" \
+  "${platform_python_status}"
+[ "$(<"${platform_python_status}")" -eq 0 ]
+assert_contains "$(<"${platform_python_output}")" 'codex-cloud-setup: ready ('
+
+untrusted_python_symlink_case="$(new_case untrusted-python-symlink)"
+make_fake_environment "${untrusted_python_symlink_case}" warm python3
+ln -s /usr/bin/python3 "${untrusted_python_symlink_case}/trusted/bin/python3"
+untrusted_python_symlink_output="${untrusted_python_symlink_case}/output"
+untrusted_python_symlink_status="${untrusted_python_symlink_case}/status"
+run_setup "${untrusted_python_symlink_case}" \
+  "${untrusted_python_symlink_case}/trusted/bin:/usr/bin" \
+  "${untrusted_python_symlink_case}/trusted/bin" \
+  "${untrusted_python_symlink_output}" "${untrusted_python_symlink_status}"
+[ "$(<"${untrusted_python_symlink_status}")" -eq 1 ]
+assert_contains "$(<"${untrusted_python_symlink_output}")" \
+  'python3 is not an approved executable symlink'
+
+nested_python_symlink_case="$(new_case nested-python-symlink)"
+make_fake_environment "${nested_python_symlink_case}" warm python3
+mkdir -p "${nested_python_symlink_case}/external/python3.vendor"
+printf '#!/bin/bash\nexit 0\n' \
+  >"${nested_python_symlink_case}/external/python3.vendor/runner"
+chmod +x "${nested_python_symlink_case}/external/python3.vendor/runner"
+ln -s "${nested_python_symlink_case}/external/python3.vendor/runner" \
+  "${nested_python_symlink_case}/trusted/bin/python3"
+nested_python_symlink_output="${nested_python_symlink_case}/output"
+nested_python_symlink_status="${nested_python_symlink_case}/status"
+run_setup "${nested_python_symlink_case}" \
+  "${nested_python_symlink_case}/trusted/bin:/usr/bin" \
+  "${nested_python_symlink_case}/trusted/bin" \
+  "${nested_python_symlink_output}" "${nested_python_symlink_status}"
+[ "$(<"${nested_python_symlink_status}")" -eq 1 ]
+assert_contains "$(<"${nested_python_symlink_output}")" \
+  'python3 is not an approved executable symlink'
 
 missing_tool_case="$(new_case missing-tool)"
 make_fake_environment "${missing_tool_case}" warm jq

--- a/scripts/test-codex-cloud-setup.sh
+++ b/scripts/test-codex-cloud-setup.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/rpm-codex-cloud-setup.XXXXXX")"
+trap 'rm -rf -- "${temp_dir}"' EXIT
+
+assert_contains() {
+  local actual="$1"
+  local expected="$2"
+  [[ "${actual}" == *"${expected}"* ]] || {
+    printf 'expected output to contain: %s\nactual output:\n%s\n' \
+      "${expected}" "${actual}" >&2
+    exit 1
+  }
+}
+
+assert_not_contains() {
+  local actual="$1"
+  local unexpected="$2"
+  [[ "${actual}" != *"${unexpected}"* ]] || {
+    printf 'expected output not to contain: %s\nactual output:\n%s\n' \
+      "${unexpected}" "${actual}" >&2
+    exit 1
+  }
+}
+
+make_fake_environment() {
+  local case_dir="$1"
+  local mode="$2"
+  local omit_command="${3:-}"
+  local trusted_bin="${case_dir}/trusted/bin"
+  local repo_dir="${case_dir}/repo"
+  local home_dir="${case_dir}/home"
+  local ambient_tmp="${case_dir}/ambient-tmp"
+  local log_file="${case_dir}/commands"
+  local recipe_log="${case_dir}/recipes"
+  local command_name
+
+  mkdir -p "${trusted_bin}" "${repo_dir}" "${home_dir}"
+  mkdir -p "${case_dir}/shadow/bin"
+  : >"${recipe_log}"
+
+  cat >"${trusted_bin}/git" <<EOF
+#!/bin/bash
+set -euo pipefail
+original_home='${home_dir}'
+for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy NO_PROXY no_proxy CARGO_HOME RUSTUP_HOME \
+  CARGO_REGISTRIES_CRATES_IO_INDEX CARGO_HTTP_PROXY CARGO_NET_OFFLINE \
+  CARGO_SOURCE_CRATES_IO_REPLACE_WITH CARGO_SOURCE_FOO_REPLACE_WITH \
+  CARGO_REGISTRY_TOKEN RUSTUP_DIST_SERVER RUSTUP_UPDATE_ROOT RUSTC_WRAPPER \
+  RUSTFLAGS RPM_CLOUD_TEST_SECRET
+do
+  case "\${variable}" in
+    CARGO_HOME|RUSTUP_HOME|RUSTUP_TOOLCHAIN) ;;
+    *) [ -z "\${!variable+x}" ] || { printf 'git-env-leak=%s\\n' "\${variable}" >&2; exit 90; } ;;
+  esac
+done
+[ "\${CARGO_HOME}" = "\${original_home}/.cargo" ] || exit 91
+[ "\${RUSTUP_HOME}" = "\${original_home}/.rustup" ] || exit 92
+[ "\${RUSTUP_TOOLCHAIN}" = stable ] || exit 93
+[ "\${HOME}" != "\${original_home}" ] || exit 94
+case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
+[ "\${GIT_CONFIG_GLOBAL}" = /dev/null ] || exit 96
+[ "\${GIT_CONFIG_SYSTEM}" = /dev/null ] || exit 97
+[ "\${GIT_CONFIG_NOSYSTEM}" = 1 ] || exit 98
+[ "\${GIT_TERMINAL_PROMPT}" = 0 ] || exit 99
+if [ "\${1:-}" = -C ] && [ "\${3:-}" = rev-parse ] && [ "\${4:-}" = --show-toplevel ]; then
+  printf '%s\\n' '${repo_dir}'
+  exit 0
+fi
+exit 64
+EOF
+
+  cat >"${trusted_bin}/rustup" <<EOF
+#!/bin/bash
+set -euo pipefail
+log_file='${log_file}'
+mode='${mode}'
+original_home='${home_dir}'
+for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy \
+  NO_PROXY no_proxy CARGO_REGISTRIES_CRATES_IO_INDEX CARGO_HTTP_PROXY CARGO_NET_OFFLINE \
+  CARGO_SOURCE_CRATES_IO_REPLACE_WITH CARGO_SOURCE_FOO_REPLACE_WITH CARGO_REGISTRY_TOKEN RUSTUP_DIST_SERVER \
+  RUSTUP_UPDATE_ROOT RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER RUSTFLAGS \
+  RPM_CLOUD_TEST_SECRET
+do
+  [ -z "\${!variable+x}" ] || { printf 'env-leak=%s\\n' "\${variable}" >>"\${log_file}"; exit 90; }
+done
+[ "\${CARGO_HOME}" = "\${original_home}/.cargo" ] || exit 91
+[ "\${RUSTUP_HOME}" = "\${original_home}/.rustup" ] || exit 92
+[ "\${RUSTUP_TOOLCHAIN}" = stable ] || exit 93
+[ "\${HOME}" != "\${original_home}" ] || exit 94
+case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
+[ "\${GIT_CONFIG_GLOBAL}" = /dev/null ] || exit 96
+[ "\${GIT_CONFIG_SYSTEM}" = /dev/null ] || exit 97
+[ "\${GIT_CONFIG_NOSYSTEM}" = 1 ] || exit 98
+[ "\${GIT_TERMINAL_PROMPT}" = 0 ] || exit 99
+printf 'rustup %s\\n' "\$*" >>"\${log_file}"
+if [ "\${1:-}" = component ] && [ "\${2:-}" = list ]; then
+  if [ "\${mode}" = warm ] || [ "\${mode}" = missing-just ] || [ "\${mode}" = fetch-failure ]; then
+    printf 'rustfmt-x86_64-unknown-linux-gnu\\nclippy-x86_64-unknown-linux-gnu\\n'
+  fi
+  exit 0
+fi
+if [ "\${1:-}" = component ] && [ "\${2:-}" = add ] && [ "\${mode}" = fresh ]; then
+  bin_dir="\${PATH%%:*}"
+  case "\${*: -1}" in
+    rustfmt) printf '#!/bin/bash\\nexit 0\\n' >"\${bin_dir}/rustfmt"; /bin/chmod +x "\${bin_dir}/rustfmt" ;;
+    clippy) printf '#!/bin/bash\\nexit 0\\n' >"\${bin_dir}/cargo-clippy"; /bin/chmod +x "\${bin_dir}/cargo-clippy" ;;
+  esac
+fi
+EOF
+
+  cat >"${trusted_bin}/cargo" <<EOF
+#!/bin/bash
+set -euo pipefail
+log_file='${log_file}'
+mode='${mode}'
+original_home='${home_dir}'
+for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy \
+  NO_PROXY no_proxy CARGO_HOME RUSTUP_HOME CARGO_REGISTRIES_CRATES_IO_INDEX \
+  CARGO_HTTP_PROXY CARGO_NET_OFFLINE CARGO_SOURCE_CRATES_IO_REPLACE_WITH \
+  CARGO_SOURCE_FOO_REPLACE_WITH CARGO_REGISTRY_TOKEN \
+  RUSTUP_DIST_SERVER RUSTUP_UPDATE_ROOT RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER \
+  RUSTFLAGS RPM_CLOUD_TEST_SECRET
+do
+  case "\${variable}" in
+    CARGO_HOME|RUSTUP_HOME) ;;
+    *) [ -z "\${!variable+x}" ] || { printf 'env-leak=%s\\n' "\${variable}" >>"\${log_file}"; exit 90; } ;;
+  esac
+done
+[ "\${CARGO_HOME}" = "\${original_home}/.cargo" ] || exit 91
+[ "\${RUSTUP_HOME}" = "\${original_home}/.rustup" ] || exit 92
+[ "\${RUSTUP_TOOLCHAIN}" = stable ] || exit 93
+[ "\${HOME}" != "\${original_home}" ] || exit 94
+case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
+[ "\${GIT_CONFIG_GLOBAL}" = /dev/null ] || exit 96
+[ "\${GIT_CONFIG_SYSTEM}" = /dev/null ] || exit 97
+[ "\${GIT_CONFIG_NOSYSTEM}" = 1 ] || exit 98
+[ "\${GIT_TERMINAL_PROMPT}" = 0 ] || exit 99
+printf 'cargo %s\\n' "\$*" >>"\${log_file}"
+printf 'env=scrubbed\\n' >>"\${log_file}"
+case "\${1:-}" in
+  install)
+    if [ "\${mode}" = fresh ]; then
+      printf '%s\\n' '#!/bin/bash' 'set -euo pipefail' \
+        "printf 'just %s\\n' \"\\\$*\" >>'${recipe_log}'" \
+        'case "\${1:-}" in' '  check|test|validate) exit 0 ;;' \
+        '  *) exit 64 ;;' 'esac' >"\${PATH%%:*}/just"
+      /bin/chmod +x "\${PATH%%:*}/just"
+    fi
+    ;;
+  fetch)
+    if [ "\${mode}" = fetch-failure ]; then exit 42; fi
+    ;;
+  check) ;;
+esac
+EOF
+
+  for command_name in jq node python3; do
+    [ "${command_name}" = "${omit_command}" ] && continue
+    printf '#!/bin/bash\nexit 0\n' >"${trusted_bin}/${command_name}"
+  done
+
+  if [ "${mode}" = warm ] || [ "${mode}" = missing-just ] || [ "${mode}" = fetch-failure ]; then
+    for command_name in rustfmt cargo-clippy; do
+      printf '#!/bin/bash\nexit 0\n' >"${trusted_bin}/${command_name}"
+    done
+  fi
+  if [ "${mode}" = warm ] || [ "${mode}" = fetch-failure ]; then
+    printf '#!/bin/bash\nexit 0\n' >"${trusted_bin}/just"
+  fi
+
+  if [ "${omit_command}" = rustup ]; then
+    rm -f "${trusted_bin}/rustup"
+  fi
+  chmod +x "${trusted_bin}"/*
+}
+
+make_shadow_environment() {
+  local case_dir="$1"
+  printf '#!/bin/bash\nexit 96\n' >"${case_dir}/shadow/bin/bash"
+  printf '#!/bin/bash\nexit 97\n' >"${case_dir}/shadow/bin/cargo"
+  chmod +x "${case_dir}/shadow/bin/bash" "${case_dir}/shadow/bin/cargo"
+}
+
+run_setup() {
+  local case_dir="$1"
+  local trusted_path="$2"
+  local ambient_path="$3"
+  local output_file="$4"
+  local status_file="$5"
+  local home_override="${6:-${case_dir}/home}"
+
+  mkdir -p "${case_dir}/outside" "${case_dir}/ambient-tmp"
+  printf 'printf leaked-bash-env >>%q\n' "${case_dir}/commands" >"${case_dir}/bash-env"
+  set +e
+  /usr/bin/env \
+    PATH="${ambient_path}" \
+    HOME="${home_override}" \
+    RPM_CODEX_CLOUD_TRUSTED_PATH="${trusted_path}" \
+    HTTP_PROXY=http://ambient.invalid \
+    HTTPS_PROXY=https://ambient.invalid \
+    http_proxy=http://ambient.invalid \
+    https_proxy=https://ambient.invalid \
+    ALL_PROXY=http://ambient.invalid \
+    all_proxy=http://ambient.invalid \
+    NO_PROXY=ambient.invalid \
+    no_proxy=ambient.invalid \
+    CARGO_HOME=/tmp/ambient-cargo-home \
+    RUSTUP_HOME=/tmp/ambient-rustup-home \
+    CARGO_REGISTRIES_CRATES_IO_INDEX=https://ambient.invalid/index \
+    CARGO_HTTP_PROXY=http://ambient.invalid \
+    CARGO_NET_OFFLINE=true \
+    CARGO_SOURCE_CRATES_IO_REPLACE_WITH=ambient-source \
+    CARGO_SOURCE_FOO_REPLACE_WITH=ambient-source \
+    CARGO_REGISTRY_TOKEN=ambient-token \
+    RUSTUP_DIST_SERVER=https://ambient.invalid/dist \
+    RUSTUP_UPDATE_ROOT=https://ambient.invalid/update \
+    RUSTC_WRAPPER=/tmp/ambient-wrapper \
+    CARGO_BUILD_RUSTC_WRAPPER=/tmp/ambient-wrapper \
+    RUSTFLAGS='--cfg ambient_secret' \
+    RUSTUP_TOOLCHAIN=ambient-toolchain \
+    TMPDIR="${case_dir}/ambient-tmp" \
+    BASH_ENV="${case_dir}/bash-env" \
+    RPM_CLOUD_TEST_SECRET=ambient-secret \
+    /bin/sh -c 'cd "$1/outside" && exec "$2"' sh "${case_dir}" \
+      "${script_dir}/codex-cloud-setup.sh" >"${output_file}" 2>&1
+  printf '%s\n' "$?" >"${status_file}"
+  set -e
+}
+
+new_case() {
+  local name="$1"
+  local case_dir="${temp_dir}/${name}"
+  mkdir -p "${case_dir}"
+  printf '%s\n' "${case_dir}"
+}
+
+commands_without_environment_markers() {
+  local line
+  while IFS= read -r line; do
+    [ "${line}" = env=scrubbed ] || printf '%s\n' "${line}"
+  done <"$1"
+}
+
+fresh_case="$(new_case fresh)"
+make_fake_environment "${fresh_case}" fresh
+make_shadow_environment "${fresh_case}"
+fresh_log="${fresh_case}/commands"
+fresh_output="${fresh_case}/output"
+fresh_status="${fresh_case}/status"
+run_setup "${fresh_case}" "${fresh_case}/trusted/bin" "${fresh_case}/shadow/bin" \
+  "${fresh_output}" "${fresh_status}"
+[ "$(<"${fresh_status}")" -eq 0 ]
+assert_contains "$(<"${fresh_output}")" 'codex-cloud-setup: ready ('
+expected_fresh=$'rustup component list --toolchain stable --installed\nrustup component add --toolchain stable rustfmt\nrustup component add --toolchain stable clippy\ncargo install just --locked\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
+actual_fresh="$(commands_without_environment_markers "${fresh_log}")"
+[ "${actual_fresh}" = "${expected_fresh}" ] || {
+  printf 'unexpected fresh setup commands:\n%s\n' "${actual_fresh}" >&2
+  exit 1
+}
+assert_contains "$(<"${fresh_log}")" 'env=scrubbed'
+assert_not_contains "$(<"${fresh_log}")" 'cargo test'
+assert_not_contains "$(<"${fresh_log}")" 'just validate'
+"${fresh_case}/trusted/bin/just" check
+"${fresh_case}/trusted/bin/just" test
+"${fresh_case}/trusted/bin/just" validate
+expected_recipes=$'just check\njust test\njust validate'
+[ "$(<"${fresh_case}/recipes")" = "${expected_recipes}" ] || {
+  printf 'unexpected fresh recipe commands:\n%s\n' "$(<"${fresh_case}/recipes")" >&2
+  exit 1
+}
+assert_not_contains "$(<"${fresh_log}")" 'just check'
+assert_not_contains "$(<"${fresh_log}")" 'just test'
+assert_not_contains "$(<"${fresh_log}")" 'just validate'
+
+warm_case="$(new_case warm)"
+make_fake_environment "${warm_case}" warm
+warm_log="${warm_case}/commands"
+warm_output="${warm_case}/output"
+warm_status="${warm_case}/status"
+run_setup "${warm_case}" "${warm_case}/trusted/bin" "${warm_case}/trusted/bin" \
+  "${warm_output}" "${warm_status}"
+[ "$(<"${warm_status}")" -eq 0 ]
+expected_warm=$'rustup component list --toolchain stable --installed\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
+actual_warm="$(commands_without_environment_markers "${warm_log}")"
+[ "${actual_warm}" = "${expected_warm}" ] || {
+  printf 'unexpected warm setup commands:\n%s\n' "${actual_warm}" >&2
+  exit 1
+}
+
+missing_tool_case="$(new_case missing-tool)"
+make_fake_environment "${missing_tool_case}" warm jq
+missing_tool_output="${missing_tool_case}/output"
+missing_tool_status="${missing_tool_case}/status"
+run_setup "${missing_tool_case}" "${missing_tool_case}/trusted/bin" \
+  "${missing_tool_case}/trusted/bin" "${missing_tool_output}" "${missing_tool_status}"
+[ "$(<"${missing_tool_status}")" -eq 1 ]
+assert_contains "$(<"${missing_tool_output}")" 'jq is required on the trusted PATH'
+
+rustup_absent_case="$(new_case rustup-absent)"
+make_fake_environment "${rustup_absent_case}" warm rustup
+rustup_absent_output="${rustup_absent_case}/output"
+rustup_absent_status="${rustup_absent_case}/status"
+run_setup "${rustup_absent_case}" "${rustup_absent_case}/trusted/bin" \
+  "${rustup_absent_case}/trusted/bin" "${rustup_absent_output}" "${rustup_absent_status}"
+[ "$(<"${rustup_absent_status}")" -eq 1 ]
+assert_contains "$(<"${rustup_absent_output}")" 'rustup is required on the trusted PATH'
+
+no_tools_case="$(new_case no-tools)"
+make_fake_environment "${no_tools_case}" no-tools
+no_tools_output="${no_tools_case}/output"
+no_tools_status="${no_tools_case}/status"
+run_setup "${no_tools_case}" "${no_tools_case}/trusted/bin" \
+  "${no_tools_case}/trusted/bin" "${no_tools_output}" "${no_tools_status}"
+[ "$(<"${no_tools_status}")" -eq 1 ]
+assert_contains "$(<"${no_tools_output}")" 'rustfmt is required on the trusted PATH'
+
+missing_just_case="$(new_case missing-just)"
+make_fake_environment "${missing_just_case}" missing-just
+missing_just_output="${missing_just_case}/output"
+missing_just_status="${missing_just_case}/status"
+run_setup "${missing_just_case}" "${missing_just_case}/trusted/bin" \
+  "${missing_just_case}/trusted/bin" "${missing_just_output}" "${missing_just_status}"
+[ "$(<"${missing_just_status}")" -eq 1 ]
+assert_contains "$(<"${missing_just_output}")" 'just is required on the trusted PATH'
+
+fetch_failure_case="$(new_case fetch-failure)"
+make_fake_environment "${fetch_failure_case}" fetch-failure
+fetch_failure_log="${fetch_failure_case}/commands"
+fetch_failure_output="${fetch_failure_case}/output"
+fetch_failure_status="${fetch_failure_case}/status"
+run_setup "${fetch_failure_case}" "${fetch_failure_case}/trusted/bin" \
+  "${fetch_failure_case}/trusted/bin" "${fetch_failure_output}" "${fetch_failure_status}"
+[ "$(<"${fetch_failure_status}")" -eq 42 ]
+assert_contains "$(<"${fetch_failure_log}")" 'cargo fetch --quiet --locked'
+assert_not_contains "$(<"${fetch_failure_log}")" 'cargo check'
+
+config_case="$(new_case cargo-config)"
+make_fake_environment "${config_case}" warm
+mkdir -p "${config_case}/repo/.cargo"
+printf 'secret-token=must-not-be-read\n' >"${config_case}/repo/.cargo/config.toml"
+config_output="${config_case}/output"
+config_status="${config_case}/status"
+run_setup "${config_case}" "${config_case}/trusted/bin" "${config_case}/trusted/bin" \
+  "${config_output}" "${config_status}"
+[ "$(<"${config_status}")" -eq 1 ]
+assert_contains "$(<"${config_output}")" 'refusing Cargo configuration or credentials'
+assert_not_contains "$(<"${config_output}")" 'must-not-be-read'
+
+credentials_case="$(new_case credentials)"
+make_fake_environment "${credentials_case}" warm
+mkdir -p "${credentials_case}/home/.cargo"
+printf 'token=must-not-be-read\n' >"${credentials_case}/home/.cargo/credentials.toml"
+credentials_output="${credentials_case}/output"
+credentials_status="${credentials_case}/status"
+run_setup "${credentials_case}" "${credentials_case}/trusted/bin" \
+  "${credentials_case}/trusted/bin" "${credentials_output}" "${credentials_status}"
+[ "$(<"${credentials_status}")" -eq 1 ]
+assert_contains "$(<"${credentials_output}")" 'refusing Cargo configuration or credentials'
+assert_not_contains "$(<"${credentials_output}")" 'must-not-be-read'
+
+invalid_path_case="$(new_case invalid-path)"
+make_fake_environment "${invalid_path_case}" warm
+invalid_output="${invalid_path_case}/output"
+invalid_status="${invalid_path_case}/status"
+run_setup "${invalid_path_case}" relative/path "${invalid_path_case}/trusted/bin" \
+  "${invalid_output}" "${invalid_status}"
+[ "$(<"${invalid_status}")" -eq 1 ]
+assert_contains "$(<"${invalid_output}")" 'trusted PATH entry must be absolute'
+
+invalid_home_case="$(new_case invalid-home)"
+make_fake_environment "${invalid_home_case}" warm
+invalid_home_output="${invalid_home_case}/output"
+invalid_home_status="${invalid_home_case}/status"
+run_setup "${invalid_home_case}" "${invalid_home_case}/trusted/bin" \
+  "${invalid_home_case}/trusted/bin" "${invalid_home_output}" "${invalid_home_status}" \
+  relative-home
+[ "$(<"${invalid_home_status}")" -eq 1 ]
+assert_contains "$(<"${invalid_home_output}")" 'HOME must be an absolute path'
+
+colon_home_case="$(new_case colon-home)"
+make_fake_environment "${colon_home_case}" warm
+colon_home_output="${colon_home_case}/output"
+colon_home_status="${colon_home_case}/status"
+run_setup "${colon_home_case}" "${colon_home_case}/trusted/bin" \
+  "${colon_home_case}/trusted/bin" "${colon_home_output}" "${colon_home_status}" \
+  "${colon_home_case}/home:alternate"
+[ "$(<"${colon_home_status}")" -eq 1 ]
+assert_contains "$(<"${colon_home_output}")" 'HOME must not contain colon or newline'
+
+empty_path_case="$(new_case empty-path)"
+make_fake_environment "${empty_path_case}" warm
+empty_output="${empty_path_case}/output"
+empty_status="${empty_path_case}/status"
+run_setup "${empty_path_case}" "${empty_path_case}/trusted/bin::/usr/bin" \
+  "${empty_path_case}/trusted/bin" "${empty_output}" "${empty_status}"
+[ "$(<"${empty_status}")" -eq 1 ]
+assert_contains "$(<"${empty_output}")" 'trusted PATH must not contain empty entries'
+
+printf 'codex_cloud_setup_tests=ok\n'

--- a/scripts/test-codex-cloud-setup.sh
+++ b/scripts/test-codex-cloud-setup.sh
@@ -6,6 +6,41 @@ trusted_temp_root=/tmp
 temp_dir="$(/usr/bin/mktemp -d "${trusted_temp_root}/rpm-codex-cloud-setup.XXXXXX")"
 trap 'rm -rf -- "${temp_dir}"' EXIT
 
+fixture_ca_input=
+for candidate in /etc/ssl/cert.pem /etc/ssl/certs/ca-certificates.crt \
+  /etc/pki/tls/certs/ca-bundle.crt; do
+  if [ -f "${candidate}" ] && [ ! -L "${candidate}" ]; then
+    fixture_ca_input="${candidate}"
+    break
+  fi
+done
+[ -n "${fixture_ca_input}" ] || {
+  printf 'no platform CA fixture file is available\n' >&2
+  exit 1
+}
+fixture_canonicalizer=
+for candidate in /usr/bin/realpath /bin/realpath /usr/local/bin/realpath \
+  /opt/homebrew/bin/realpath; do
+  if [ -f "${candidate}" ] && [ -x "${candidate}" ]; then
+    fixture_canonicalizer="${candidate}"
+    break
+  fi
+done
+[ -n "${fixture_canonicalizer}" ] || {
+  printf 'no trusted realpath canonicalizer is available\n' >&2
+  exit 1
+}
+fixture_ca_file="$("${fixture_canonicalizer}" -- "${fixture_ca_input}")"
+fixture_ca_dir=
+for candidate in /etc/ssl/certs /etc/pki/tls/certs \
+  /usr/local/share/ca-certificates; do
+  if [ -d "${candidate}" ] && [ ! -L "${candidate}" ]; then
+    fixture_ca_dir="$("${fixture_canonicalizer}" -- "${candidate}")"
+    break
+  fi
+done
+[ -n "${fixture_ca_dir}" ] || fixture_ca_dir="${fixture_ca_file%/*}"
+
 run_tmpdir_regression() {
   local regression_root
   local marker_name
@@ -16,7 +51,9 @@ run_tmpdir_regression() {
 
   regression_root="$(/usr/bin/mktemp -d "${trusted_temp_root}/rpm-codex-cloud-setup-regression.XXXXXX")"
   marker_name="rpm-codex-cloud-setup-marker-${RANDOM}-${RANDOM}"
-  malicious_tmpdir="${regression_root}/tmp'; echo \$(printf x >${marker_name}); #"
+  marker_path="${regression_root}/${marker_name}"
+  malicious_tmpdir="${regression_root}/tmp'; echo \$(printf x >${marker_path}); #"
+  mkdir -p -- "${malicious_tmpdir%/*}"
   printf 'TMPDIR must be ignored by the fixture harness\n' >"${malicious_tmpdir}"
   output_file="${regression_root}/output"
   set +e
@@ -29,9 +66,7 @@ run_tmpdir_regression() {
     rm -rf -- "${regression_root}"
     exit 1
   fi
-  marker_path="$(/usr/bin/find "${trusted_temp_root}" -type f -name "${marker_name}" \
-    -print -quit 2>/dev/null)"
-  if [ -n "${marker_path}" ]; then
+  if [ -e "${marker_path}" ]; then
     printf 'malicious TMPDIR executed a fake shim payload: %s\n' "${marker_path}" >&2
     rm -f -- "${marker_path}"
     rm -rf -- "${regression_root}"
@@ -39,10 +74,6 @@ run_tmpdir_regression() {
   fi
   rm -rf -- "${regression_root}"
 }
-
-if [ "${RPM_CLOUD_TEST_TMPDIR_REGRESSION:-}" != 1 ]; then
-  run_tmpdir_regression
-fi
 
 assert_contains() {
   local actual="$1"
@@ -75,6 +106,7 @@ make_fake_environment() {
   local stable_toolchain_bin="${home_dir}/.rustup/toolchains/stable-fixture/bin"
   local stable_canonical_toolchain_bin
   local other_toolchain_bin="${home_dir}/.rustup/toolchains/other-fixture/bin"
+  local other_canonical_toolchain_bin="${home_dir}/.rustup/toolchains/other-fixture/bin"
   local ambient_tmp="${case_dir}/ambient-tmp"
   local log_file="${case_dir}/commands"
   local recipe_log="${case_dir}/recipes"
@@ -84,6 +116,10 @@ make_fake_environment() {
     "${stable_toolchain_bin}"
   canonical_rustup_home="$(cd -- "${home_dir}/.rustup" && pwd -P)"
   stable_canonical_toolchain_bin="$(cd -- "${stable_toolchain_bin}" && pwd -P)"
+  if [ "${mode}" = different-toolchain ] || [ "${mode}" = unselected-toolchain ]; then
+    mkdir -p "${other_toolchain_bin}"
+    other_canonical_toolchain_bin="$(cd -- "${other_toolchain_bin}" && pwd -P)"
+  fi
   mkdir -p "${case_dir}/shadow/bin"
   : >"${log_file}"
   : >"${recipe_log}"
@@ -98,7 +134,8 @@ for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_prox
   CARGO_SOURCE_CRATES_IO_REPLACE_WITH CARGO_SOURCE_FOO_REPLACE_WITH \
   CARGO_REGISTRY_TOKEN RUSTUP_DIST_SERVER RUSTUP_UPDATE_ROOT RUSTC_WRAPPER \
   RUSTFLAGS RPM_CLOUD_TEST_SECRET NVM_BIN RPM_CODEX_CLOUD_TRUSTED_PATH \
-  RUSTDOCFLAGS RUSTC_WORKSPACE_WRAPPER
+  RUSTDOCFLAGS RUSTC_WORKSPACE_WRAPPER SSL_CERT_FILE SSL_CERT_DIR \
+  CURL_CA_BUNDLE CARGO_HTTP_CAINFO
 do
   case "\${variable}" in
     CARGO_HOME|RUSTUP_HOME|RUSTUP_TOOLCHAIN) ;;
@@ -107,7 +144,7 @@ do
 done
 [ "\${CARGO_HOME}" = "\${original_home}/.cargo" ] || exit 91
 [ "\${RUSTUP_HOME}" = "\${canonical_rustup_home}" ] || exit 92
-[ "\${RUSTUP_TOOLCHAIN}" = stable ] || exit 93
+[ "\${RUSTUP_TOOLCHAIN}" = stable-fixture ] || exit 93
 [ "\${HOME}" != "\${original_home}" ] || exit 94
 case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
 [ "\${GIT_CONFIG_GLOBAL}" = /dev/null ] || exit 96
@@ -129,18 +166,48 @@ log_file='${log_file}'
 mode='${mode}'
 original_home='${home_dir}'
 canonical_rustup_home='${canonical_rustup_home}'
-for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy \
-  NO_PROXY no_proxy CARGO_REGISTRIES_CRATES_IO_INDEX CARGO_HTTP_PROXY CARGO_NET_OFFLINE \
+for variable in CARGO_REGISTRIES_CRATES_IO_INDEX CARGO_HTTP_PROXY CARGO_NET_OFFLINE \
   CARGO_SOURCE_CRATES_IO_REPLACE_WITH CARGO_SOURCE_FOO_REPLACE_WITH CARGO_REGISTRY_TOKEN RUSTUP_DIST_SERVER \
   RUSTUP_UPDATE_ROOT RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER RUSTFLAGS \
-  RPM_CLOUD_TEST_SECRET NVM_BIN RPM_CODEX_CLOUD_TRUSTED_PATH RUSTDOCFLAGS \
-  RUSTC_WORKSPACE_WRAPPER
+  RPM_CLOUD_TEST_SECRET NVM_BIN RPM_CODEX_CLOUD_TRUSTED_PATH RUSTDOCFLAGS RUSTC_WORKSPACE_WRAPPER
 do
   [ -z "\${!variable+x}" ] || { printf 'env-leak=%s\\n' "\${variable}" >>"\${log_file}"; exit 90; }
 done
+assert_no_transport() {
+  local variable
+  for variable in HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY \
+    http_proxy https_proxy all_proxy no_proxy SSL_CERT_FILE SSL_CERT_DIR \
+    CURL_CA_BUNDLE CARGO_HTTP_CAINFO
+  do
+    [ -z "\${!variable+x}" ] || { printf 'transport-leak=%s\\n' "\${variable}" >>"\${log_file}"; exit 100; }
+  done
+}
+assert_online_transport() {
+  [ "\${HTTP_PROXY:-}" = http://ambient.invalid ] || exit 101
+  [ "\${HTTPS_PROXY:-}" = https://ambient.invalid ] || exit 102
+  [ "\${ALL_PROXY:-}" = http://ambient.invalid ] || exit 103
+  [ "\${NO_PROXY:-}" = ambient.invalid ] || exit 104
+  [ "\${http_proxy:-}" = http://ambient.invalid ] || exit 105
+  [ "\${https_proxy:-}" = https://ambient.invalid ] || exit 106
+  [ "\${all_proxy:-}" = http://ambient.invalid ] || exit 107
+  [ "\${no_proxy:-}" = ambient.invalid ] || exit 108
+  [ "\${SSL_CERT_FILE:-}" = '${fixture_ca_file}' ] || exit 109
+  [ "\${SSL_CERT_DIR:-}" = '${fixture_ca_dir}' ] || exit 110
+  [ "\${CURL_CA_BUNDLE:-}" = '${fixture_ca_file}' ] || exit 111
+  [ "\${CARGO_HTTP_CAINFO:-}" = '${fixture_ca_file}' ] || exit 112
+}
+if [ "\${1:-}" = component ] && [ "\${2:-}" = add ]; then
+  assert_online_transport
+else
+  assert_no_transport
+fi
 [ "\${CARGO_HOME}" = "\${original_home}/.cargo" ] || exit 91
 [ "\${RUSTUP_HOME}" = "\${canonical_rustup_home}" ] || exit 92
-[ "\${RUSTUP_TOOLCHAIN}" = stable ] || exit 93
+if [ "\${1:-}" = toolchain ] && [ "\${2:-}" = list ]; then
+  [ -z "\${RUSTUP_TOOLCHAIN+x}" ] || exit 93
+else
+  [ "\${RUSTUP_TOOLCHAIN}" = stable-fixture ] || exit 93
+fi
 [ "\${HOME}" != "\${original_home}" ] || exit 94
 case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
 [ "\${GIT_CONFIG_GLOBAL}" = /dev/null ] || exit 96
@@ -148,20 +215,44 @@ case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
 [ "\${GIT_CONFIG_NOSYSTEM}" = 1 ] || exit 98
 [ "\${GIT_TERMINAL_PROMPT}" = 0 ] || exit 99
 printf 'rustup %s\\n' "\$*" >>"\${log_file}"
+if [ "\${1:-}" = toolchain ] && [ "\${2:-}" = list ] && \
+  [ "\${3:-}" = --verbose ]; then
+  case "\${mode}" in
+    tracking-stable)
+      printf 'stable (default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
+      ;;
+    multiple-stable)
+      printf 'stable-fixture (active, default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
+      printf 'stable-secondary (default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
+      ;;
+    custom-stable)
+      printf 'stable-custom (active, default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
+      ;;
+    host-mismatch)
+      printf 'stable-foreign (active, default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
+      ;;
+    *)
+      printf 'stable-fixture (active, default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
+      ;;
+  esac
+  exit 0
+fi
 if [ "\${1:-}" = which ] && [ "\${2:-}" = --toolchain ] && \\
-  [ "\${3:-}" = stable ] && [ "\${4:-}" = cargo ]; then
+  [ "\${3:-}" = stable-fixture ] && [ "\${4:-}" = cargo ]; then
   case "\${mode}" in
     dotdot) printf '%s\\n' '${stable_canonical_toolchain_bin}/../bin/cargo' ;;
+    unselected-toolchain) printf '%s\\n' '${other_canonical_toolchain_bin}/cargo' ;;
     *) printf '%s\\n' '${stable_canonical_toolchain_bin}/cargo' ;;
   esac
   exit 0
 fi
 if [ "\${1:-}" = which ] && [ "\${2:-}" = --toolchain ] && \\
-  [ "\${3:-}" = stable ] && [ "\${4:-}" = rustc ]; then
+  [ "\${3:-}" = stable-fixture ] && [ "\${4:-}" = rustc ]; then
   case "\${mode}" in
     rustc-missing) exit 0 ;;
     rustc-failure) printf 'fake rustc lookup failed\\n' >&2; exit 77 ;;
     different-toolchain) printf '%s\\n' '${canonical_rustup_home}/toolchains/other-fixture/bin/rustc' ;;
+    unselected-toolchain) printf '%s\\n' '${other_canonical_toolchain_bin}/rustc' ;;
     *) printf '%s\\n' '${stable_canonical_toolchain_bin}/rustc' ;;
   esac
   exit 0
@@ -197,8 +288,7 @@ log_file='${log_file}'
 mode='${mode}'
 original_home='${home_dir}'
 canonical_rustup_home='${canonical_rustup_home}'
-for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy \
-  NO_PROXY no_proxy CARGO_HOME RUSTUP_HOME CARGO_REGISTRIES_CRATES_IO_INDEX \
+for variable in CARGO_HOME RUSTUP_HOME CARGO_REGISTRIES_CRATES_IO_INDEX \
   CARGO_HTTP_PROXY CARGO_NET_OFFLINE CARGO_SOURCE_CRATES_IO_REPLACE_WITH \
   CARGO_SOURCE_FOO_REPLACE_WITH CARGO_REGISTRY_TOKEN \
   RUSTUP_DIST_SERVER RUSTUP_UPDATE_ROOT RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER \
@@ -210,6 +300,34 @@ do
     *) [ -z "\${!variable+x}" ] || { printf 'env-leak=%s\\n' "\${variable}" >>"\${log_file}"; exit 90; } ;;
   esac
 done
+assert_no_transport() {
+  local variable
+  for variable in HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY \
+    http_proxy https_proxy all_proxy no_proxy SSL_CERT_FILE SSL_CERT_DIR \
+    CURL_CA_BUNDLE CARGO_HTTP_CAINFO
+  do
+    [ -z "\${!variable+x}" ] || { printf 'transport-leak=%s\\n' "\${variable}" >>"\${log_file}"; exit 100; }
+  done
+}
+assert_online_transport() {
+  [ "\${HTTP_PROXY:-}" = http://ambient.invalid ] || exit 101
+  [ "\${HTTPS_PROXY:-}" = https://ambient.invalid ] || exit 102
+  [ "\${ALL_PROXY:-}" = http://ambient.invalid ] || exit 103
+  [ "\${NO_PROXY:-}" = ambient.invalid ] || exit 104
+  [ "\${http_proxy:-}" = http://ambient.invalid ] || exit 105
+  [ "\${https_proxy:-}" = https://ambient.invalid ] || exit 106
+  [ "\${all_proxy:-}" = http://ambient.invalid ] || exit 107
+  [ "\${no_proxy:-}" = ambient.invalid ] || exit 108
+  [ "\${SSL_CERT_FILE:-}" = '${fixture_ca_file}' ] || exit 109
+  [ "\${SSL_CERT_DIR:-}" = '${fixture_ca_dir}' ] || exit 110
+  [ "\${CURL_CA_BUNDLE:-}" = '${fixture_ca_file}' ] || exit 111
+  [ "\${CARGO_HTTP_CAINFO:-}" = '${fixture_ca_file}' ] || exit 112
+}
+case "\${1:-}" in
+  install|fetch) assert_online_transport ;;
+  check) assert_no_transport ;;
+  *) assert_no_transport ;;
+esac
 [ "\${CARGO_HOME}" = "\${original_home}/.cargo" ] || exit 91
 [ "\${RUSTUP_HOME}" = "\${canonical_rustup_home}" ] || exit 92
 [ -z "\${RUSTUP_TOOLCHAIN+x}" ] || { printf 'rustup-toolchain-leak\\n' >>"\${log_file}"; exit 93; }
@@ -241,10 +359,14 @@ EOF
   printf '#!/bin/bash\\nexit 0\\n' >"${stable_toolchain_bin}/rustc"
   chmod +x "${stable_toolchain_bin}/cargo" "${stable_toolchain_bin}/rustc"
 
-  if [ "${mode}" = different-toolchain ]; then
+  if [ "${mode}" = different-toolchain ] || [ "${mode}" = unselected-toolchain ]; then
     mkdir -p "${other_toolchain_bin}"
     printf '#!/bin/bash\\nexit 0\\n' >"${other_toolchain_bin}/rustc"
     chmod +x "${other_toolchain_bin}/rustc"
+  fi
+  if [ "${mode}" = unselected-toolchain ]; then
+    cp "${stable_toolchain_bin}/cargo" "${other_toolchain_bin}/cargo"
+    chmod +x "${other_toolchain_bin}/cargo"
   fi
   if [ "${mode}" = external-symlink ]; then
     mkdir -p "${case_dir}/external"
@@ -297,6 +419,7 @@ run_setup() {
   local status_file="$5"
   local home_override="${6:-${case_dir}/home}"
   local nvm_bin_override="${7:-}"
+  local transport_override="${8:-}"
   local -a env_args
 
   mkdir -p "${case_dir}/outside" "${case_dir}/ambient-tmp"
@@ -327,6 +450,10 @@ run_setup() {
     CARGO_BUILD_RUSTC_WRAPPER=/tmp/ambient-wrapper
     RUSTFLAGS='--cfg ambient_secret'
     RUSTUP_TOOLCHAIN=ambient-toolchain
+    "SSL_CERT_FILE=${fixture_ca_input}"
+    "SSL_CERT_DIR=${fixture_ca_dir}"
+    "CURL_CA_BUNDLE=${fixture_ca_input}"
+    "CARGO_HTTP_CAINFO=${fixture_ca_input}"
     "TMPDIR=${case_dir}/ambient-tmp"
     "BASH_ENV=${case_dir}/bash-env"
     RPM_CLOUD_TEST_SECRET=ambient-secret
@@ -334,8 +461,11 @@ run_setup() {
   if [ "${trusted_path}" != __DEFAULT__ ]; then
     env_args+=("RPM_CODEX_CLOUD_TRUSTED_PATH=${trusted_path}")
   fi
-  if [ "$#" -ge 7 ]; then
+  if [ "$#" -ge 7 ] && [ "${nvm_bin_override}" != __NO_NVM__ ]; then
     env_args+=("NVM_BIN=${nvm_bin_override}")
+  fi
+  if [ "$#" -ge 8 ]; then
+    env_args+=("${transport_override}")
   fi
   NVM_BIN=/tmp/ambient-nvm-bin \
   RPM_CODEX_CLOUD_TRUSTED_PATH=/tmp/ambient-trusted/bin \
@@ -355,6 +485,24 @@ new_case() {
   printf '%s\n' "${case_dir}"
 }
 
+if [ "${RPM_CLOUD_TEST_TMPDIR_REGRESSION:-}" = 1 ]; then
+  tmpdir_probe_case="$(new_case tmpdir-probe)"
+  make_fake_environment "${tmpdir_probe_case}" warm
+  make_shadow_environment "${tmpdir_probe_case}"
+  tmpdir_probe_output="${tmpdir_probe_case}/output"
+  tmpdir_probe_status="${tmpdir_probe_case}/status"
+  run_setup "${tmpdir_probe_case}" "${tmpdir_probe_case}/trusted/bin" \
+    "${tmpdir_probe_case}/trusted/bin" "${tmpdir_probe_output}" \
+    "${tmpdir_probe_status}"
+  if [ "$(<"${tmpdir_probe_status}")" -ne 0 ]; then
+    cat "${tmpdir_probe_output}" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+run_tmpdir_regression
+
 commands_without_environment_markers() {
   local line
   while IFS= read -r line; do
@@ -373,7 +521,7 @@ run_setup "${fresh_case}" "${fresh_trusted_path}" "${fresh_case}/shadow/bin" \
   "${fresh_output}" "${fresh_status}"
 [ "$(<"${fresh_status}")" -eq 0 ]
 assert_contains "$(<"${fresh_output}")" 'codex-cloud-setup: ready ('
-expected_fresh=$'rustup component list --toolchain stable --installed\nrustup component add --toolchain stable rustfmt\nrustup component add --toolchain stable clippy\nrustup which --toolchain stable cargo\nrustup which --toolchain stable rustc\ncargo install just --locked\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
+expected_fresh=$'rustup toolchain list --verbose\nrustup component list --toolchain stable-fixture --installed\nrustup component add --toolchain stable-fixture rustfmt\nrustup component add --toolchain stable-fixture clippy\nrustup which --toolchain stable-fixture cargo\nrustup which --toolchain stable-fixture rustc\ncargo install just --locked\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
 actual_fresh="$(commands_without_environment_markers "${fresh_log}")"
 [ "${actual_fresh}" = "${expected_fresh}" ] || {
   printf 'unexpected fresh setup commands:\n%s\n' "${actual_fresh}" >&2
@@ -404,7 +552,7 @@ warm_status="${warm_case}/status"
 run_setup "${warm_case}" "${warm_case}/trusted/bin" "${warm_case}/trusted/bin" \
   "${warm_output}" "${warm_status}"
 [ "$(<"${warm_status}")" -eq 0 ]
-expected_warm=$'rustup component list --toolchain stable --installed\nrustup which --toolchain stable cargo\nrustup which --toolchain stable rustc\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
+expected_warm=$'rustup toolchain list --verbose\nrustup component list --toolchain stable-fixture --installed\nrustup which --toolchain stable-fixture cargo\nrustup which --toolchain stable-fixture rustc\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
 actual_warm="$(commands_without_environment_markers "${warm_log}")"
 [ "${actual_warm}" = "${expected_warm}" ] || {
   printf 'unexpected warm setup commands:\n%s\n' "${actual_warm}" >&2
@@ -412,6 +560,144 @@ actual_warm="$(commands_without_environment_markers "${warm_log}")"
 }
 assert_not_contains "$(<"${warm_log}")" 'cargo-proxy'
 assert_not_contains "$(<"${warm_log}")" 'rustup-proxy-network-attempt'
+
+multiple_stable_case="$(new_case multiple-stable)"
+make_fake_environment "${multiple_stable_case}" multiple-stable
+multiple_stable_output="${multiple_stable_case}/output"
+multiple_stable_status="${multiple_stable_case}/status"
+run_setup "${multiple_stable_case}" \
+  "${multiple_stable_case}/home/.cargo/bin:${multiple_stable_case}/trusted/bin" \
+  "${multiple_stable_case}/trusted/bin" "${multiple_stable_output}" \
+  "${multiple_stable_status}"
+[ "$(<"${multiple_stable_status}")" -ne 0 ]
+assert_contains "$(<"${multiple_stable_output}")" 'exactly one active/default stable host toolchain'
+
+custom_stable_case="$(new_case custom-stable)"
+make_fake_environment "${custom_stable_case}" custom-stable
+custom_stable_output="${custom_stable_case}/output"
+custom_stable_status="${custom_stable_case}/status"
+run_setup "${custom_stable_case}" \
+  "${custom_stable_case}/home/.cargo/bin:${custom_stable_case}/trusted/bin" \
+  "${custom_stable_case}/trusted/bin" "${custom_stable_output}" \
+  "${custom_stable_status}"
+[ "$(<"${custom_stable_status}")" -ne 0 ]
+assert_contains "$(<"${custom_stable_output}")" 'does not match its active host name'
+
+host_mismatch_case="$(new_case host-mismatch)"
+make_fake_environment "${host_mismatch_case}" host-mismatch
+host_mismatch_output="${host_mismatch_case}/output"
+host_mismatch_status="${host_mismatch_case}/status"
+run_setup "${host_mismatch_case}" \
+  "${host_mismatch_case}/home/.cargo/bin:${host_mismatch_case}/trusted/bin" \
+  "${host_mismatch_case}/trusted/bin" "${host_mismatch_output}" \
+  "${host_mismatch_status}"
+[ "$(<"${host_mismatch_status}")" -ne 0 ]
+assert_contains "$(<"${host_mismatch_output}")" 'does not match its active host name'
+
+tracking_stable_case="$(new_case tracking-stable)"
+make_fake_environment "${tracking_stable_case}" tracking-stable
+tracking_stable_output="${tracking_stable_case}/output"
+tracking_stable_status="${tracking_stable_case}/status"
+run_setup "${tracking_stable_case}" \
+  "${tracking_stable_case}/home/.cargo/bin:${tracking_stable_case}/trusted/bin" \
+  "${tracking_stable_case}/trusted/bin" "${tracking_stable_output}" \
+  "${tracking_stable_status}"
+[ "$(<"${tracking_stable_status}")" -eq 1 ]
+assert_contains "$(<"${tracking_stable_output}")" 'tracking stable channel entry'
+
+proxy_userinfo_case="$(new_case proxy-userinfo)"
+make_fake_environment "${proxy_userinfo_case}" warm
+proxy_userinfo_output="${proxy_userinfo_case}/output"
+proxy_userinfo_status="${proxy_userinfo_case}/status"
+run_setup "${proxy_userinfo_case}" \
+  "${proxy_userinfo_case}/home/.cargo/bin:${proxy_userinfo_case}/trusted/bin" \
+  "${proxy_userinfo_case}/trusted/bin" "${proxy_userinfo_output}" \
+  "${proxy_userinfo_status}" "${proxy_userinfo_case}/home" __NO_NVM__ \
+  HTTP_PROXY=http://user:password@ambient.invalid
+[ "$(<"${proxy_userinfo_status}")" -eq 1 ]
+assert_contains "$(<"${proxy_userinfo_output}")" 'proxy userinfo'
+
+proxy_newline_case="$(new_case proxy-newline)"
+make_fake_environment "${proxy_newline_case}" warm
+proxy_newline_output="${proxy_newline_case}/output"
+proxy_newline_status="${proxy_newline_case}/status"
+proxy_newline_override=$'HTTP_PROXY=http://ambient.invalid\nunsafe'
+run_setup "${proxy_newline_case}" \
+  "${proxy_newline_case}/home/.cargo/bin:${proxy_newline_case}/trusted/bin" \
+  "${proxy_newline_case}/trusted/bin" "${proxy_newline_output}" \
+  "${proxy_newline_status}" "${proxy_newline_case}/home" __NO_NVM__ \
+  "${proxy_newline_override}"
+[ "$(<"${proxy_newline_status}")" -eq 1 ]
+assert_contains "$(<"${proxy_newline_output}")" 'must not contain a newline'
+
+unsafe_no_proxy_case="$(new_case unsafe-no-proxy)"
+make_fake_environment "${unsafe_no_proxy_case}" warm
+unsafe_no_proxy_output="${unsafe_no_proxy_case}/output"
+unsafe_no_proxy_status="${unsafe_no_proxy_case}/status"
+run_setup "${unsafe_no_proxy_case}" \
+  "${unsafe_no_proxy_case}/home/.cargo/bin:${unsafe_no_proxy_case}/trusted/bin" \
+  "${unsafe_no_proxy_case}/trusted/bin" "${unsafe_no_proxy_output}" \
+  "${unsafe_no_proxy_status}" "${unsafe_no_proxy_case}/home" __NO_NVM__ \
+  NO_PROXY='ambient.invalid;curl'
+[ "$(<"${unsafe_no_proxy_status}")" -eq 1 ]
+assert_contains "$(<"${unsafe_no_proxy_output}")" 'unsafe NO_PROXY value'
+
+ca_outside_case="$(new_case ca-outside)"
+make_fake_environment "${ca_outside_case}" warm
+ca_outside_path="${ca_outside_case}/outside-ca.pem"
+printf 'outside trusted CA root\n' >"${ca_outside_path}"
+ca_outside_output="${ca_outside_case}/output"
+ca_outside_status="${ca_outside_case}/status"
+run_setup "${ca_outside_case}" \
+  "${ca_outside_case}/home/.cargo/bin:${ca_outside_case}/trusted/bin" \
+  "${ca_outside_case}/trusted/bin" "${ca_outside_output}" \
+  "${ca_outside_status}" "${ca_outside_case}/home" __NO_NVM__ \
+  "SSL_CERT_FILE=${ca_outside_path}"
+[ "$(<"${ca_outside_status}")" -eq 1 ]
+assert_contains "$(<"${ca_outside_output}")" 'outside the trusted CA roots'
+
+ca_symlink_case="$(new_case ca-symlink)"
+make_fake_environment "${ca_symlink_case}" warm
+ca_symlink_path="${ca_symlink_case}/ca-link.pem"
+ln -s "${fixture_ca_input}" "${ca_symlink_path}"
+ca_symlink_output="${ca_symlink_case}/output"
+ca_symlink_status="${ca_symlink_case}/status"
+run_setup "${ca_symlink_case}" \
+  "${ca_symlink_case}/home/.cargo/bin:${ca_symlink_case}/trusted/bin" \
+  "${ca_symlink_case}/trusted/bin" "${ca_symlink_output}" \
+  "${ca_symlink_status}" "${ca_symlink_case}/home" __NO_NVM__ \
+  "SSL_CERT_FILE=${ca_symlink_path}"
+[ "$(<"${ca_symlink_status}")" -eq 1 ]
+assert_contains "$(<"${ca_symlink_output}")" 'regular trusted CA file'
+
+shadow_symlink_case="$(new_case shadow-symlink)"
+make_fake_environment "${shadow_symlink_case}" warm
+mkdir -p "${shadow_symlink_case}/outside"
+printf '#!/bin/bash\nexit 0\n' >"${shadow_symlink_case}/outside/cargo"
+chmod +x "${shadow_symlink_case}/outside/cargo"
+ln -s "${shadow_symlink_case}/outside/cargo" \
+  "${shadow_symlink_case}/home/.cargo/bin/cargo"
+shadow_symlink_output="${shadow_symlink_case}/output"
+shadow_symlink_status="${shadow_symlink_case}/status"
+run_setup "${shadow_symlink_case}" \
+  "${shadow_symlink_case}/home/.cargo/bin:${shadow_symlink_case}/trusted/bin" \
+  "${shadow_symlink_case}/trusted/bin" "${shadow_symlink_output}" \
+  "${shadow_symlink_status}"
+[ "$(<"${shadow_symlink_status}")" -eq 1 ]
+assert_contains "$(<"${shadow_symlink_output}")" 'symlink path component'
+
+shadow_writable_case="$(new_case shadow-writable)"
+make_fake_environment "${shadow_writable_case}" warm
+printf '#!/bin/bash\nexit 0\n' >"${shadow_writable_case}/home/.cargo/bin/cargo"
+chmod 777 "${shadow_writable_case}/home/.cargo/bin/cargo"
+shadow_writable_output="${shadow_writable_case}/output"
+shadow_writable_status="${shadow_writable_case}/status"
+run_setup "${shadow_writable_case}" \
+  "${shadow_writable_case}/home/.cargo/bin:${shadow_writable_case}/trusted/bin" \
+  "${shadow_writable_case}/trusted/bin" "${shadow_writable_output}" \
+  "${shadow_writable_status}"
+[ "$(<"${shadow_writable_status}")" -eq 1 ]
+assert_contains "$(<"${shadow_writable_output}")" 'writable by a group or other user'
 
 dotdot_case="$(new_case dotdot)"
 make_fake_environment "${dotdot_case}" dotdot
@@ -459,6 +745,18 @@ run_setup "${different_toolchain_case}" \
 [ "$(<"${different_toolchain_status}")" -ne 0 ]
 assert_contains "$(<"${different_toolchain_output}")" 'different toolchains'
 assert_not_contains "$(<"${different_toolchain_case}/commands")" 'cargo-proxy'
+
+unselected_toolchain_case="$(new_case unselected-toolchain)"
+make_fake_environment "${unselected_toolchain_case}" unselected-toolchain
+unselected_toolchain_output="${unselected_toolchain_case}/output"
+unselected_toolchain_status="${unselected_toolchain_case}/status"
+run_setup "${unselected_toolchain_case}" \
+  "${unselected_toolchain_case}/home/.cargo/bin:${unselected_toolchain_case}/trusted/bin" \
+  "${unselected_toolchain_case}/trusted/bin" "${unselected_toolchain_output}" \
+  "${unselected_toolchain_status}"
+[ "$(<"${unselected_toolchain_status}")" -ne 0 ]
+assert_contains "$(<"${unselected_toolchain_output}")" 'unexpected toolchain'
+assert_not_contains "$(<"${unselected_toolchain_case}/commands")" 'cargo-proxy'
 
 rustc_missing_case="$(new_case rustc-missing)"
 make_fake_environment "${rustc_missing_case}" rustc-missing

--- a/scripts/test-codex-cloud-setup.sh
+++ b/scripts/test-codex-cloud-setup.sh
@@ -32,12 +32,19 @@ make_fake_environment() {
   local trusted_bin="${case_dir}/trusted/bin"
   local repo_dir="${case_dir}/repo"
   local home_dir="${case_dir}/home"
+  local canonical_rustup_home
+  local stable_toolchain_bin="${home_dir}/.rustup/toolchains/stable-fixture/bin"
+  local stable_canonical_toolchain_bin
+  local other_toolchain_bin="${home_dir}/.rustup/toolchains/other-fixture/bin"
   local ambient_tmp="${case_dir}/ambient-tmp"
   local log_file="${case_dir}/commands"
   local recipe_log="${case_dir}/recipes"
   local command_name
 
-  mkdir -p "${trusted_bin}" "${repo_dir}" "${home_dir}/.cargo/bin"
+  mkdir -p "${trusted_bin}" "${repo_dir}" "${home_dir}/.cargo/bin" \
+    "${stable_toolchain_bin}"
+  canonical_rustup_home="$(cd -- "${home_dir}/.rustup" && pwd -P)"
+  stable_canonical_toolchain_bin="$(cd -- "${stable_toolchain_bin}" && pwd -P)"
   mkdir -p "${case_dir}/shadow/bin"
   : >"${log_file}"
   : >"${recipe_log}"
@@ -46,6 +53,7 @@ make_fake_environment() {
 #!/bin/bash
 set -euo pipefail
 original_home='${home_dir}'
+canonical_rustup_home='${canonical_rustup_home}'
 for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy NO_PROXY no_proxy CARGO_HOME RUSTUP_HOME \
   CARGO_REGISTRIES_CRATES_IO_INDEX CARGO_HTTP_PROXY CARGO_NET_OFFLINE \
   CARGO_SOURCE_CRATES_IO_REPLACE_WITH CARGO_SOURCE_FOO_REPLACE_WITH \
@@ -58,7 +66,7 @@ do
   esac
 done
 [ "\${CARGO_HOME}" = "\${original_home}/.cargo" ] || exit 91
-[ "\${RUSTUP_HOME}" = "\${original_home}/.rustup" ] || exit 92
+[ "\${RUSTUP_HOME}" = "\${canonical_rustup_home}" ] || exit 92
 [ "\${RUSTUP_TOOLCHAIN}" = stable ] || exit 93
 [ "\${HOME}" != "\${original_home}" ] || exit 94
 case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
@@ -80,6 +88,7 @@ set -euo pipefail
 log_file='${log_file}'
 mode='${mode}'
 original_home='${home_dir}'
+canonical_rustup_home='${canonical_rustup_home}'
 for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy \
   NO_PROXY no_proxy CARGO_REGISTRIES_CRATES_IO_INDEX CARGO_HTTP_PROXY CARGO_NET_OFFLINE \
   CARGO_SOURCE_CRATES_IO_REPLACE_WITH CARGO_SOURCE_FOO_REPLACE_WITH CARGO_REGISTRY_TOKEN RUSTUP_DIST_SERVER \
@@ -89,7 +98,7 @@ do
   [ -z "\${!variable+x}" ] || { printf 'env-leak=%s\\n' "\${variable}" >>"\${log_file}"; exit 90; }
 done
 [ "\${CARGO_HOME}" = "\${original_home}/.cargo" ] || exit 91
-[ "\${RUSTUP_HOME}" = "\${original_home}/.rustup" ] || exit 92
+[ "\${RUSTUP_HOME}" = "\${canonical_rustup_home}" ] || exit 92
 [ "\${RUSTUP_TOOLCHAIN}" = stable ] || exit 93
 [ "\${HOME}" != "\${original_home}" ] || exit 94
 case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
@@ -98,6 +107,24 @@ case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
 [ "\${GIT_CONFIG_NOSYSTEM}" = 1 ] || exit 98
 [ "\${GIT_TERMINAL_PROMPT}" = 0 ] || exit 99
 printf 'rustup %s\\n' "\$*" >>"\${log_file}"
+if [ "\${1:-}" = which ] && [ "\${2:-}" = --toolchain ] && \\
+  [ "\${3:-}" = stable ] && [ "\${4:-}" = cargo ]; then
+  case "\${mode}" in
+    dotdot) printf '%s\\n' '${stable_canonical_toolchain_bin}/../bin/cargo' ;;
+    *) printf '%s\\n' '${stable_canonical_toolchain_bin}/cargo' ;;
+  esac
+  exit 0
+fi
+if [ "\${1:-}" = which ] && [ "\${2:-}" = --toolchain ] && \\
+  [ "\${3:-}" = stable ] && [ "\${4:-}" = rustc ]; then
+  case "\${mode}" in
+    rustc-missing) exit 0 ;;
+    rustc-failure) printf 'fake rustc lookup failed\\n' >&2; exit 77 ;;
+    different-toolchain) printf '%s\\n' '${canonical_rustup_home}/toolchains/other-fixture/bin/rustc' ;;
+    *) printf '%s\\n' '${stable_canonical_toolchain_bin}/rustc' ;;
+  esac
+  exit 0
+fi
 if [ "\${1:-}" = component ] && [ "\${2:-}" = list ]; then
   if [ "\${mode}" = warm ] || [ "\${mode}" = missing-just ] || [ "\${mode}" = fetch-failure ]; then
     printf 'rustfmt-x86_64-unknown-linux-gnu\\nclippy-x86_64-unknown-linux-gnu\\n'
@@ -117,8 +144,18 @@ EOF
 #!/bin/bash
 set -euo pipefail
 log_file='${log_file}'
+printf 'cargo-proxy %s\\n' "\$*" >>"\${log_file}"
+printf 'rustup-proxy-network-attempt\\n' >>"\${log_file}"
+exit 88
+EOF
+
+cat >"${stable_toolchain_bin}/cargo" <<EOF
+#!/bin/bash
+set -euo pipefail
+log_file='${log_file}'
 mode='${mode}'
 original_home='${home_dir}'
+canonical_rustup_home='${canonical_rustup_home}'
 for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy \
   NO_PROXY no_proxy CARGO_HOME RUSTUP_HOME CARGO_REGISTRIES_CRATES_IO_INDEX \
   CARGO_HTTP_PROXY CARGO_NET_OFFLINE CARGO_SOURCE_CRATES_IO_REPLACE_WITH \
@@ -132,13 +169,13 @@ do
   esac
 done
 [ "\${CARGO_HOME}" = "\${original_home}/.cargo" ] || exit 91
-[ "\${RUSTUP_HOME}" = "\${original_home}/.rustup" ] || exit 92
-[ "\${RUSTUP_TOOLCHAIN}" = stable ] || exit 93
-[ "\${HOME}" != "\${original_home}" ] || exit 94
-case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
-[ "\${GIT_CONFIG_GLOBAL}" = /dev/null ] || exit 96
-[ "\${GIT_CONFIG_SYSTEM}" = /dev/null ] || exit 97
-[ "\${GIT_CONFIG_NOSYSTEM}" = 1 ] || exit 98
+[ "\${RUSTUP_HOME}" = "\${canonical_rustup_home}" ] || exit 92
+[ -z "\${RUSTUP_TOOLCHAIN+x}" ] || { printf 'rustup-toolchain-leak\\n' >>"\${log_file}"; exit 93; }
+[ "\${RUSTC}" = '${stable_canonical_toolchain_bin}/rustc' ] || exit 94
+[ "\${HOME}" != "\${original_home}" ] || exit 95
+case "\${HOME}" in '${ambient_tmp}'*) exit 96 ;; esac
+[ "\${GIT_CONFIG_GLOBAL}" = /dev/null ] || exit 97
+[ "\${GIT_CONFIG_SYSTEM}" = /dev/null ] || exit 98
 [ "\${GIT_TERMINAL_PROMPT}" = 0 ] || exit 99
 printf 'cargo %s\\n' "\$*" >>"\${log_file}"
 printf 'env=scrubbed\\n' >>"\${log_file}"
@@ -158,6 +195,30 @@ case "\${1:-}" in
   check) ;;
 esac
 EOF
+
+  printf '#!/bin/bash\\nexit 0\\n' >"${stable_toolchain_bin}/rustc"
+  chmod +x "${stable_toolchain_bin}/cargo" "${stable_toolchain_bin}/rustc"
+
+  if [ "${mode}" = different-toolchain ]; then
+    mkdir -p "${other_toolchain_bin}"
+    printf '#!/bin/bash\\nexit 0\\n' >"${other_toolchain_bin}/rustc"
+    chmod +x "${other_toolchain_bin}/rustc"
+  fi
+  if [ "${mode}" = external-symlink ]; then
+    mkdir -p "${case_dir}/external"
+    printf '#!/bin/bash\\nexit 0\\n' >"${case_dir}/external/cargo"
+    chmod +x "${case_dir}/external/cargo"
+    rm -f "${stable_toolchain_bin}/cargo"
+    ln -s "${case_dir}/external/cargo" "${stable_toolchain_bin}/cargo"
+  fi
+  if [ "${mode}" = parent-symlink ]; then
+    parent_toolchain_dir="${case_dir}/external/stable-fixture"
+    mkdir -p "${parent_toolchain_dir}/bin"
+    mv "${stable_toolchain_bin}/cargo" "${parent_toolchain_dir}/bin/cargo"
+    mv "${stable_toolchain_bin}/rustc" "${parent_toolchain_dir}/bin/rustc"
+    rmdir "${stable_toolchain_bin}" "${home_dir}/.rustup/toolchains/stable-fixture"
+    ln -s "${parent_toolchain_dir}" "${home_dir}/.rustup/toolchains/stable-fixture"
+  fi
 
   for command_name in jq node python3; do
     [ "${command_name}" = "${omit_command}" ] && continue
@@ -266,13 +327,15 @@ run_setup "${fresh_case}" "${fresh_trusted_path}" "${fresh_case}/shadow/bin" \
   "${fresh_output}" "${fresh_status}"
 [ "$(<"${fresh_status}")" -eq 0 ]
 assert_contains "$(<"${fresh_output}")" 'codex-cloud-setup: ready ('
-expected_fresh=$'rustup component list --toolchain stable --installed\nrustup component add --toolchain stable rustfmt\nrustup component add --toolchain stable clippy\ncargo install just --locked\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
+expected_fresh=$'rustup component list --toolchain stable --installed\nrustup component add --toolchain stable rustfmt\nrustup component add --toolchain stable clippy\nrustup which --toolchain stable cargo\nrustup which --toolchain stable rustc\ncargo install just --locked\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
 actual_fresh="$(commands_without_environment_markers "${fresh_log}")"
 [ "${actual_fresh}" = "${expected_fresh}" ] || {
   printf 'unexpected fresh setup commands:\n%s\n' "${actual_fresh}" >&2
   exit 1
 }
 assert_contains "$(<"${fresh_log}")" 'env=scrubbed'
+assert_not_contains "$(<"${fresh_log}")" 'cargo-proxy'
+assert_not_contains "$(<"${fresh_log}")" 'rustup-proxy-network-attempt'
 assert_not_contains "$(<"${fresh_log}")" 'cargo test'
 assert_not_contains "$(<"${fresh_log}")" 'just validate'
 "${fresh_case}/home/.cargo/bin/just" check
@@ -295,12 +358,85 @@ warm_status="${warm_case}/status"
 run_setup "${warm_case}" "${warm_case}/trusted/bin" "${warm_case}/trusted/bin" \
   "${warm_output}" "${warm_status}"
 [ "$(<"${warm_status}")" -eq 0 ]
-expected_warm=$'rustup component list --toolchain stable --installed\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
+expected_warm=$'rustup component list --toolchain stable --installed\nrustup which --toolchain stable cargo\nrustup which --toolchain stable rustc\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
 actual_warm="$(commands_without_environment_markers "${warm_log}")"
 [ "${actual_warm}" = "${expected_warm}" ] || {
   printf 'unexpected warm setup commands:\n%s\n' "${actual_warm}" >&2
   exit 1
 }
+assert_not_contains "$(<"${warm_log}")" 'cargo-proxy'
+assert_not_contains "$(<"${warm_log}")" 'rustup-proxy-network-attempt'
+
+dotdot_case="$(new_case dotdot)"
+make_fake_environment "${dotdot_case}" dotdot
+dotdot_output="${dotdot_case}/output"
+dotdot_status="${dotdot_case}/status"
+run_setup "${dotdot_case}" "${dotdot_case}/home/.cargo/bin:${dotdot_case}/trusted/bin" \
+  "${dotdot_case}/trusted/bin" \
+  "${dotdot_output}" "${dotdot_status}"
+[ "$(<"${dotdot_status}")" -ne 0 ]
+assert_contains "$(<"${dotdot_output}")" 'traversal component'
+assert_not_contains "$(<"${dotdot_case}/commands")" 'cargo-proxy'
+
+external_symlink_case="$(new_case external-symlink)"
+make_fake_environment "${external_symlink_case}" external-symlink
+external_symlink_output="${external_symlink_case}/output"
+external_symlink_status="${external_symlink_case}/status"
+run_setup "${external_symlink_case}" \
+  "${external_symlink_case}/home/.cargo/bin:${external_symlink_case}/trusted/bin" \
+  "${external_symlink_case}/trusted/bin" "${external_symlink_output}" \
+  "${external_symlink_status}"
+[ "$(<"${external_symlink_status}")" -ne 0 ]
+assert_contains "$(<"${external_symlink_output}")" 'symlink path component'
+assert_not_contains "$(<"${external_symlink_case}/commands")" 'cargo-proxy'
+
+parent_symlink_case="$(new_case parent-symlink)"
+make_fake_environment "${parent_symlink_case}" parent-symlink
+parent_symlink_output="${parent_symlink_case}/output"
+parent_symlink_status="${parent_symlink_case}/status"
+run_setup "${parent_symlink_case}" \
+  "${parent_symlink_case}/home/.cargo/bin:${parent_symlink_case}/trusted/bin" \
+  "${parent_symlink_case}/trusted/bin" "${parent_symlink_output}" \
+  "${parent_symlink_status}"
+[ "$(<"${parent_symlink_status}")" -ne 0 ]
+assert_contains "$(<"${parent_symlink_output}")" 'symlink path component'
+assert_not_contains "$(<"${parent_symlink_case}/commands")" 'cargo-proxy'
+
+different_toolchain_case="$(new_case different-toolchain)"
+make_fake_environment "${different_toolchain_case}" different-toolchain
+different_toolchain_output="${different_toolchain_case}/output"
+different_toolchain_status="${different_toolchain_case}/status"
+run_setup "${different_toolchain_case}" \
+  "${different_toolchain_case}/home/.cargo/bin:${different_toolchain_case}/trusted/bin" \
+  "${different_toolchain_case}/trusted/bin" "${different_toolchain_output}" \
+  "${different_toolchain_status}"
+[ "$(<"${different_toolchain_status}")" -ne 0 ]
+assert_contains "$(<"${different_toolchain_output}")" 'different toolchains'
+assert_not_contains "$(<"${different_toolchain_case}/commands")" 'cargo-proxy'
+
+rustc_missing_case="$(new_case rustc-missing)"
+make_fake_environment "${rustc_missing_case}" rustc-missing
+rustc_missing_output="${rustc_missing_case}/output"
+rustc_missing_status="${rustc_missing_case}/status"
+run_setup "${rustc_missing_case}" \
+  "${rustc_missing_case}/home/.cargo/bin:${rustc_missing_case}/trusted/bin" \
+  "${rustc_missing_case}/trusted/bin" "${rustc_missing_output}" \
+  "${rustc_missing_status}"
+[ "$(<"${rustc_missing_status}")" -ne 0 ]
+assert_contains "$(<"${rustc_missing_output}")" 'did not return the stable rustc path'
+assert_not_contains "$(<"${rustc_missing_case}/commands")" 'cargo-proxy'
+
+rustc_failure_case="$(new_case rustc-failure)"
+make_fake_environment "${rustc_failure_case}" rustc-failure
+rustc_failure_output="${rustc_failure_case}/output"
+rustc_failure_status="${rustc_failure_case}/status"
+run_setup "${rustc_failure_case}" \
+  "${rustc_failure_case}/home/.cargo/bin:${rustc_failure_case}/trusted/bin" \
+  "${rustc_failure_case}/trusted/bin" "${rustc_failure_output}" \
+  "${rustc_failure_status}"
+[ "$(<"${rustc_failure_status}")" -ne 0 ]
+assert_contains "$(<"${rustc_failure_output}")" 'fake rustc lookup failed'
+assert_not_contains "$(<"${rustc_failure_case}/commands")" 'cargo-proxy'
 
 default_nvm_case="$(new_case default-nvm)"
 make_fake_environment "${default_nvm_case}" warm

--- a/scripts/test-codex-cloud-setup.sh
+++ b/scripts/test-codex-cloud-setup.sh
@@ -2,8 +2,47 @@
 set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/rpm-codex-cloud-setup.XXXXXX")"
+trusted_temp_root=/tmp
+temp_dir="$(/usr/bin/mktemp -d "${trusted_temp_root}/rpm-codex-cloud-setup.XXXXXX")"
 trap 'rm -rf -- "${temp_dir}"' EXIT
+
+run_tmpdir_regression() {
+  local regression_root
+  local marker_name
+  local marker_path
+  local malicious_tmpdir
+  local output_file
+  local status
+
+  regression_root="$(/usr/bin/mktemp -d "${trusted_temp_root}/rpm-codex-cloud-setup-regression.XXXXXX")"
+  marker_name="rpm-codex-cloud-setup-marker-${RANDOM}-${RANDOM}"
+  malicious_tmpdir="${regression_root}/tmp'; echo \$(printf x >${marker_name}); #"
+  printf 'TMPDIR must be ignored by the fixture harness\n' >"${malicious_tmpdir}"
+  output_file="${regression_root}/output"
+  set +e
+  TMPDIR="${malicious_tmpdir}" RPM_CLOUD_TEST_TMPDIR_REGRESSION=1 \
+    "${script_dir}/$(basename -- "${BASH_SOURCE[0]}")" >"${output_file}" 2>&1
+  status="$?"
+  set -e
+  if [ "${status}" -ne 0 ]; then
+    cat "${output_file}" >&2
+    rm -rf -- "${regression_root}"
+    exit 1
+  fi
+  marker_path="$(/usr/bin/find "${trusted_temp_root}" -type f -name "${marker_name}" \
+    -print -quit 2>/dev/null)"
+  if [ -n "${marker_path}" ]; then
+    printf 'malicious TMPDIR executed a fake shim payload: %s\n' "${marker_path}" >&2
+    rm -f -- "${marker_path}"
+    rm -rf -- "${regression_root}"
+    exit 1
+  fi
+  rm -rf -- "${regression_root}"
+}
+
+if [ "${RPM_CLOUD_TEST_TMPDIR_REGRESSION:-}" != 1 ]; then
+  run_tmpdir_regression
+fi
 
 assert_contains() {
   local actual="$1"
@@ -58,7 +97,8 @@ for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_prox
   CARGO_REGISTRIES_CRATES_IO_INDEX CARGO_HTTP_PROXY CARGO_NET_OFFLINE \
   CARGO_SOURCE_CRATES_IO_REPLACE_WITH CARGO_SOURCE_FOO_REPLACE_WITH \
   CARGO_REGISTRY_TOKEN RUSTUP_DIST_SERVER RUSTUP_UPDATE_ROOT RUSTC_WRAPPER \
-  RUSTFLAGS RPM_CLOUD_TEST_SECRET
+  RUSTFLAGS RPM_CLOUD_TEST_SECRET NVM_BIN RPM_CODEX_CLOUD_TRUSTED_PATH \
+  RUSTDOCFLAGS RUSTC_WORKSPACE_WRAPPER
 do
   case "\${variable}" in
     CARGO_HOME|RUSTUP_HOME|RUSTUP_TOOLCHAIN) ;;
@@ -93,7 +133,8 @@ for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_prox
   NO_PROXY no_proxy CARGO_REGISTRIES_CRATES_IO_INDEX CARGO_HTTP_PROXY CARGO_NET_OFFLINE \
   CARGO_SOURCE_CRATES_IO_REPLACE_WITH CARGO_SOURCE_FOO_REPLACE_WITH CARGO_REGISTRY_TOKEN RUSTUP_DIST_SERVER \
   RUSTUP_UPDATE_ROOT RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER RUSTFLAGS \
-  RPM_CLOUD_TEST_SECRET
+  RPM_CLOUD_TEST_SECRET NVM_BIN RPM_CODEX_CLOUD_TRUSTED_PATH RUSTDOCFLAGS \
+  RUSTC_WORKSPACE_WRAPPER
 do
   [ -z "\${!variable+x}" ] || { printf 'env-leak=%s\\n' "\${variable}" >>"\${log_file}"; exit 90; }
 done
@@ -161,7 +202,8 @@ for variable in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_prox
   CARGO_HTTP_PROXY CARGO_NET_OFFLINE CARGO_SOURCE_CRATES_IO_REPLACE_WITH \
   CARGO_SOURCE_FOO_REPLACE_WITH CARGO_REGISTRY_TOKEN \
   RUSTUP_DIST_SERVER RUSTUP_UPDATE_ROOT RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER \
-  RUSTFLAGS RPM_CLOUD_TEST_SECRET
+  RUSTFLAGS RPM_CLOUD_TEST_SECRET NVM_BIN RPM_CODEX_CLOUD_TRUSTED_PATH \
+  RUSTDOCFLAGS RUSTC_WORKSPACE_WRAPPER
 do
   case "\${variable}" in
     CARGO_HOME|RUSTUP_HOME) ;;
@@ -295,7 +337,11 @@ run_setup() {
   if [ "$#" -ge 7 ]; then
     env_args+=("NVM_BIN=${nvm_bin_override}")
   fi
-  /usr/bin/env "${env_args[@]}" \
+  NVM_BIN=/tmp/ambient-nvm-bin \
+  RPM_CODEX_CLOUD_TRUSTED_PATH=/tmp/ambient-trusted/bin \
+  RUSTDOCFLAGS=--ambient-rustdocflags \
+  RUSTC_WORKSPACE_WRAPPER=/tmp/ambient-rustc-wrapper \
+  /usr/bin/env -i "${env_args[@]}" \
     /bin/sh -c 'cd "$1/outside" && exec "$2"' sh "${case_dir}" \
     "${script_dir}/codex-cloud-setup.sh" >"${output_file}" 2>&1
   printf '%s\n' "$?" >"${status_file}"

--- a/scripts/test-codex-cloud-setup.sh
+++ b/scripts/test-codex-cloud-setup.sh
@@ -37,8 +37,9 @@ make_fake_environment() {
   local recipe_log="${case_dir}/recipes"
   local command_name
 
-  mkdir -p "${trusted_bin}" "${repo_dir}" "${home_dir}"
+  mkdir -p "${trusted_bin}" "${repo_dir}" "${home_dir}/.cargo/bin"
   mkdir -p "${case_dir}/shadow/bin"
+  : >"${log_file}"
   : >"${recipe_log}"
 
   cat >"${trusted_bin}/git" <<EOF
@@ -65,6 +66,7 @@ case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
 [ "\${GIT_CONFIG_SYSTEM}" = /dev/null ] || exit 97
 [ "\${GIT_CONFIG_NOSYSTEM}" = 1 ] || exit 98
 [ "\${GIT_TERMINAL_PROMPT}" = 0 ] || exit 99
+printf '%s\n' "\${PATH}" >'${case_dir}/observed-trusted-path'
 if [ "\${1:-}" = -C ] && [ "\${3:-}" = rev-parse ] && [ "\${4:-}" = --show-toplevel ]; then
   printf '%s\\n' '${repo_dir}'
   exit 0
@@ -146,8 +148,8 @@ case "\${1:-}" in
       printf '%s\\n' '#!/bin/bash' 'set -euo pipefail' \
         "printf 'just %s\\n' \"\\\$*\" >>'${recipe_log}'" \
         'case "\${1:-}" in' '  check|test|validate) exit 0 ;;' \
-        '  *) exit 64 ;;' 'esac' >"\${PATH%%:*}/just"
-      /bin/chmod +x "\${PATH%%:*}/just"
+        '  *) exit 64 ;;' 'esac' >"\${CARGO_HOME}/bin/just"
+      /bin/chmod +x "\${CARGO_HOME}/bin/just"
     fi
     ;;
   fetch)
@@ -191,41 +193,50 @@ run_setup() {
   local output_file="$4"
   local status_file="$5"
   local home_override="${6:-${case_dir}/home}"
+  local nvm_bin_override="${7:-}"
+  local -a env_args
 
   mkdir -p "${case_dir}/outside" "${case_dir}/ambient-tmp"
   printf 'printf leaked-bash-env >>%q\n' "${case_dir}/commands" >"${case_dir}/bash-env"
   set +e
-  /usr/bin/env \
-    PATH="${ambient_path}" \
-    HOME="${home_override}" \
-    RPM_CODEX_CLOUD_TRUSTED_PATH="${trusted_path}" \
-    HTTP_PROXY=http://ambient.invalid \
-    HTTPS_PROXY=https://ambient.invalid \
-    http_proxy=http://ambient.invalid \
-    https_proxy=https://ambient.invalid \
-    ALL_PROXY=http://ambient.invalid \
-    all_proxy=http://ambient.invalid \
-    NO_PROXY=ambient.invalid \
-    no_proxy=ambient.invalid \
-    CARGO_HOME=/tmp/ambient-cargo-home \
-    RUSTUP_HOME=/tmp/ambient-rustup-home \
-    CARGO_REGISTRIES_CRATES_IO_INDEX=https://ambient.invalid/index \
-    CARGO_HTTP_PROXY=http://ambient.invalid \
-    CARGO_NET_OFFLINE=true \
-    CARGO_SOURCE_CRATES_IO_REPLACE_WITH=ambient-source \
-    CARGO_SOURCE_FOO_REPLACE_WITH=ambient-source \
-    CARGO_REGISTRY_TOKEN=ambient-token \
-    RUSTUP_DIST_SERVER=https://ambient.invalid/dist \
-    RUSTUP_UPDATE_ROOT=https://ambient.invalid/update \
-    RUSTC_WRAPPER=/tmp/ambient-wrapper \
-    CARGO_BUILD_RUSTC_WRAPPER=/tmp/ambient-wrapper \
-    RUSTFLAGS='--cfg ambient_secret' \
-    RUSTUP_TOOLCHAIN=ambient-toolchain \
-    TMPDIR="${case_dir}/ambient-tmp" \
-    BASH_ENV="${case_dir}/bash-env" \
-    RPM_CLOUD_TEST_SECRET=ambient-secret \
+  env_args=(
+    "PATH=${ambient_path}"
+    "HOME=${home_override}"
+    HTTP_PROXY=http://ambient.invalid
+    HTTPS_PROXY=https://ambient.invalid
+    http_proxy=http://ambient.invalid
+    https_proxy=https://ambient.invalid
+    ALL_PROXY=http://ambient.invalid
+    all_proxy=http://ambient.invalid
+    NO_PROXY=ambient.invalid
+    no_proxy=ambient.invalid
+    CARGO_HOME=/tmp/ambient-cargo-home
+    RUSTUP_HOME=/tmp/ambient-rustup-home
+    CARGO_REGISTRIES_CRATES_IO_INDEX=https://ambient.invalid/index
+    CARGO_HTTP_PROXY=http://ambient.invalid
+    CARGO_NET_OFFLINE=true
+    CARGO_SOURCE_CRATES_IO_REPLACE_WITH=ambient-source
+    CARGO_SOURCE_FOO_REPLACE_WITH=ambient-source
+    CARGO_REGISTRY_TOKEN=ambient-token
+    RUSTUP_DIST_SERVER=https://ambient.invalid/dist
+    RUSTUP_UPDATE_ROOT=https://ambient.invalid/update
+    RUSTC_WRAPPER=/tmp/ambient-wrapper
+    CARGO_BUILD_RUSTC_WRAPPER=/tmp/ambient-wrapper
+    RUSTFLAGS='--cfg ambient_secret'
+    RUSTUP_TOOLCHAIN=ambient-toolchain
+    "TMPDIR=${case_dir}/ambient-tmp"
+    "BASH_ENV=${case_dir}/bash-env"
+    RPM_CLOUD_TEST_SECRET=ambient-secret
+  )
+  if [ "${trusted_path}" != __DEFAULT__ ]; then
+    env_args+=("RPM_CODEX_CLOUD_TRUSTED_PATH=${trusted_path}")
+  fi
+  if [ "$#" -ge 7 ]; then
+    env_args+=("NVM_BIN=${nvm_bin_override}")
+  fi
+  /usr/bin/env "${env_args[@]}" \
     /bin/sh -c 'cd "$1/outside" && exec "$2"' sh "${case_dir}" \
-      "${script_dir}/codex-cloud-setup.sh" >"${output_file}" 2>&1
+    "${script_dir}/codex-cloud-setup.sh" >"${output_file}" 2>&1
   printf '%s\n' "$?" >"${status_file}"
   set -e
 }
@@ -250,7 +261,8 @@ make_shadow_environment "${fresh_case}"
 fresh_log="${fresh_case}/commands"
 fresh_output="${fresh_case}/output"
 fresh_status="${fresh_case}/status"
-run_setup "${fresh_case}" "${fresh_case}/trusted/bin" "${fresh_case}/shadow/bin" \
+fresh_trusted_path="${fresh_case}/home/.cargo/bin:${fresh_case}/trusted/bin"
+run_setup "${fresh_case}" "${fresh_trusted_path}" "${fresh_case}/shadow/bin" \
   "${fresh_output}" "${fresh_status}"
 [ "$(<"${fresh_status}")" -eq 0 ]
 assert_contains "$(<"${fresh_output}")" 'codex-cloud-setup: ready ('
@@ -263,9 +275,9 @@ actual_fresh="$(commands_without_environment_markers "${fresh_log}")"
 assert_contains "$(<"${fresh_log}")" 'env=scrubbed'
 assert_not_contains "$(<"${fresh_log}")" 'cargo test'
 assert_not_contains "$(<"${fresh_log}")" 'just validate'
-"${fresh_case}/trusted/bin/just" check
-"${fresh_case}/trusted/bin/just" test
-"${fresh_case}/trusted/bin/just" validate
+"${fresh_case}/home/.cargo/bin/just" check
+"${fresh_case}/home/.cargo/bin/just" test
+"${fresh_case}/home/.cargo/bin/just" validate
 expected_recipes=$'just check\njust test\njust validate'
 [ "$(<"${fresh_case}/recipes")" = "${expected_recipes}" ] || {
   printf 'unexpected fresh recipe commands:\n%s\n' "$(<"${fresh_case}/recipes")" >&2
@@ -290,6 +302,65 @@ actual_warm="$(commands_without_environment_markers "${warm_log}")"
   exit 1
 }
 
+default_nvm_case="$(new_case default-nvm)"
+make_fake_environment "${default_nvm_case}" warm
+default_nvm_bin="${default_nvm_case}/home/.nvm/versions/node/vfixture/bin"
+mkdir -p "${default_nvm_bin}"
+cp "${default_nvm_case}/trusted/bin/"* "${default_nvm_case}/home/.cargo/bin/"
+cp "${default_nvm_case}/trusted/bin/node" "${default_nvm_bin}/node"
+chmod +x "${default_nvm_bin}/node"
+default_nvm_output="${default_nvm_case}/output"
+default_nvm_status="${default_nvm_case}/status"
+run_setup "${default_nvm_case}" __DEFAULT__ "${default_nvm_case}/shadow/bin" \
+  "${default_nvm_output}" "${default_nvm_status}" "${default_nvm_case}/home" \
+  "${default_nvm_bin}"
+[ "$(<"${default_nvm_status}")" -eq 0 ]
+default_canonical_nvm_bin="$(cd -- "${default_nvm_bin}" && pwd -P)"
+default_expected_path="${default_canonical_nvm_bin}:${default_nvm_case}/home/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+[ "$(<"${default_nvm_case}/observed-trusted-path")" = "${default_expected_path}" ] || {
+  printf 'unexpected default trusted PATH:\n%s\n' \
+    "$(<"${default_nvm_case}/observed-trusted-path")" >&2
+  exit 1
+}
+
+default_unset_nvm_case="$(new_case default-unset-nvm)"
+make_fake_environment "${default_unset_nvm_case}" warm
+cp "${default_unset_nvm_case}/trusted/bin/"* \
+  "${default_unset_nvm_case}/home/.cargo/bin/"
+default_unset_nvm_output="${default_unset_nvm_case}/output"
+default_unset_nvm_status="${default_unset_nvm_case}/status"
+run_setup "${default_unset_nvm_case}" __DEFAULT__ \
+  "${default_unset_nvm_case}/shadow/bin" "${default_unset_nvm_output}" \
+  "${default_unset_nvm_status}"
+[ "$(<"${default_unset_nvm_status}")" -eq 0 ]
+default_unset_nvm_expected_path="${default_unset_nvm_case}/home/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+[ "$(<"${default_unset_nvm_case}/observed-trusted-path")" = \
+  "${default_unset_nvm_expected_path}" ] || {
+  printf 'unexpected default trusted PATH with unset NVM_BIN:\n%s\n' \
+    "$(<"${default_unset_nvm_case}/observed-trusted-path")" >&2
+  exit 1
+}
+
+empty_nvm_case="$(new_case empty-nvm)"
+make_fake_environment "${empty_nvm_case}" warm
+empty_nvm_output="${empty_nvm_case}/output"
+empty_nvm_status="${empty_nvm_case}/status"
+run_setup "${empty_nvm_case}" __DEFAULT__ "${empty_nvm_case}/shadow/bin" \
+  "${empty_nvm_output}" "${empty_nvm_status}" "${empty_nvm_case}/home" ''
+[ "$(<"${empty_nvm_status}")" -eq 1 ]
+assert_contains "$(<"${empty_nvm_output}")" 'NVM_BIN must not be empty'
+[ ! -s "${empty_nvm_case}/commands" ]
+
+invalid_nvm_case="$(new_case invalid-nvm)"
+make_fake_environment "${invalid_nvm_case}" warm
+invalid_nvm_output="${invalid_nvm_case}/output"
+invalid_nvm_status="${invalid_nvm_case}/status"
+run_setup "${invalid_nvm_case}" "${invalid_nvm_case}/trusted/bin" \
+  "${invalid_nvm_case}/trusted/bin" "${invalid_nvm_output}" "${invalid_nvm_status}" \
+  "${invalid_nvm_case}/home" "${invalid_nvm_case}/outside/node/bin"
+[ "$(<"${invalid_nvm_status}")" -eq 1 ]
+assert_contains "$(<"${invalid_nvm_output}")" 'NVM_BIN must be under HOME/.nvm/versions/node/<version>/bin'
+
 missing_tool_case="$(new_case missing-tool)"
 make_fake_environment "${missing_tool_case}" warm jq
 missing_tool_output="${missing_tool_case}/output"
@@ -309,7 +380,8 @@ run_setup "${rustup_absent_case}" "${rustup_absent_case}/trusted/bin" \
 assert_contains "$(<"${rustup_absent_output}")" 'rustup is required on the trusted PATH'
 
 no_tools_case="$(new_case no-tools)"
-make_fake_environment "${no_tools_case}" no-tools
+make_fake_environment "${no_tools_case}" warm
+rm -f "${no_tools_case}/trusted/bin/rustfmt" "${no_tools_case}/trusted/bin/cargo-clippy"
 no_tools_output="${no_tools_case}/output"
 no_tools_status="${no_tools_case}/status"
 run_setup "${no_tools_case}" "${no_tools_case}/trusted/bin" \
@@ -318,13 +390,17 @@ run_setup "${no_tools_case}" "${no_tools_case}/trusted/bin" \
 assert_contains "$(<"${no_tools_output}")" 'rustfmt is required on the trusted PATH'
 
 missing_just_case="$(new_case missing-just)"
-make_fake_environment "${missing_just_case}" missing-just
+make_fake_environment "${missing_just_case}" fresh
+missing_just_log="${missing_just_case}/commands"
 missing_just_output="${missing_just_case}/output"
 missing_just_status="${missing_just_case}/status"
 run_setup "${missing_just_case}" "${missing_just_case}/trusted/bin" \
   "${missing_just_case}/trusted/bin" "${missing_just_output}" "${missing_just_status}"
 [ "$(<"${missing_just_status}")" -eq 1 ]
-assert_contains "$(<"${missing_just_output}")" 'just is required on the trusted PATH'
+assert_contains "$(<"${missing_just_output}")" 'just is missing and trusted PATH must include '
+assert_not_contains "$(<"${missing_just_log}")" 'rustup component add'
+assert_not_contains "$(<"${missing_just_log}")" 'cargo install just --locked'
+assert_not_contains "$(<"${missing_just_log}")" 'cargo fetch'
 
 fetch_failure_case="$(new_case fetch-failure)"
 make_fake_environment "${fetch_failure_case}" fetch-failure

--- a/scripts/test-codex-cloud-setup.sh
+++ b/scripts/test-codex-cloud-setup.sh
@@ -103,7 +103,8 @@ make_fake_environment() {
   local repo_dir="${case_dir}/repo"
   local home_dir="${case_dir}/home"
   local canonical_rustup_home
-  local stable_toolchain_bin="${home_dir}/.rustup/toolchains/stable-fixture/bin"
+  local toolchain_name=stable-x86_64-unknown-linux-gnu
+  local stable_toolchain_bin
   local stable_canonical_toolchain_bin
   local other_toolchain_bin="${home_dir}/.rustup/toolchains/other-fixture/bin"
   local other_canonical_toolchain_bin="${home_dir}/.rustup/toolchains/other-fixture/bin"
@@ -111,6 +112,11 @@ make_fake_environment() {
   local log_file="${case_dir}/commands"
   local recipe_log="${case_dir}/recipes"
   local command_name
+
+  if [ "${mode}" = versioned-toolchain ]; then
+    toolchain_name=1.89.0-x86_64-unknown-linux-gnu
+  fi
+  stable_toolchain_bin="${home_dir}/.rustup/toolchains/${toolchain_name}/bin"
 
   mkdir -p "${trusted_bin}" "${repo_dir}" "${home_dir}/.cargo/bin" \
     "${stable_toolchain_bin}"
@@ -144,7 +150,7 @@ do
 done
 [ "\${CARGO_HOME}" = "\${original_home}/.cargo" ] || exit 91
 [ "\${RUSTUP_HOME}" = "\${canonical_rustup_home}" ] || exit 92
-[ "\${RUSTUP_TOOLCHAIN}" = stable-fixture ] || exit 93
+[ "\${RUSTUP_TOOLCHAIN}" = '${toolchain_name}' ] || exit 93
 [ "\${HOME}" != "\${original_home}" ] || exit 94
 case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
 [ "\${GIT_CONFIG_GLOBAL}" = /dev/null ] || exit 96
@@ -206,7 +212,7 @@ fi
 if [ "\${1:-}" = toolchain ] && [ "\${2:-}" = list ]; then
   [ -z "\${RUSTUP_TOOLCHAIN+x}" ] || exit 93
 else
-  [ "\${RUSTUP_TOOLCHAIN}" = stable-fixture ] || exit 93
+  [ "\${RUSTUP_TOOLCHAIN}" = '${toolchain_name}' ] || exit 93
 fi
 [ "\${HOME}" != "\${original_home}" ] || exit 94
 case "\${HOME}" in '${ambient_tmp}'*) exit 95 ;; esac
@@ -219,26 +225,26 @@ if [ "\${1:-}" = toolchain ] && [ "\${2:-}" = list ] && \
   [ "\${3:-}" = --verbose ]; then
   case "\${mode}" in
     tracking-stable)
-      printf 'stable (default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
+      printf 'stable (default) %s\\n' '${canonical_rustup_home}/toolchains/${toolchain_name}'
       ;;
     multiple-stable)
-      printf 'stable-fixture (active, default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
-      printf 'stable-secondary (default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
+      printf 'stable-x86_64-unknown-linux-gnu (active, default) %s\\n' '${canonical_rustup_home}/toolchains/${toolchain_name}'
+      printf 'stable-aarch64-unknown-linux-gnu (default) %s\\n' '${canonical_rustup_home}/toolchains/${toolchain_name}'
       ;;
     custom-stable)
-      printf 'stable-custom (active, default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
+      printf 'stable-custom (active, default) %s\\n' '${canonical_rustup_home}/toolchains/stable-custom'
       ;;
     host-mismatch)
-      printf 'stable-foreign (active, default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
+      printf 'stable-aarch64-unknown-linux-gnu (active, default) %s\\n' '${canonical_rustup_home}/toolchains/${toolchain_name}'
       ;;
     *)
-      printf 'stable-fixture (active, default) %s\\n' '${canonical_rustup_home}/toolchains/stable-fixture'
+      printf '%s (active, default) %s\\n' '${toolchain_name}' '${canonical_rustup_home}/toolchains/${toolchain_name}'
       ;;
   esac
   exit 0
 fi
 if [ "\${1:-}" = which ] && [ "\${2:-}" = --toolchain ] && \\
-  [ "\${3:-}" = stable-fixture ] && [ "\${4:-}" = cargo ]; then
+  [ "\${3:-}" = '${toolchain_name}' ] && [ "\${4:-}" = cargo ]; then
   case "\${mode}" in
     dotdot) printf '%s\\n' '${stable_canonical_toolchain_bin}/../bin/cargo' ;;
     unselected-toolchain) printf '%s\\n' '${other_canonical_toolchain_bin}/cargo' ;;
@@ -247,7 +253,7 @@ if [ "\${1:-}" = which ] && [ "\${2:-}" = --toolchain ] && \\
   exit 0
 fi
 if [ "\${1:-}" = which ] && [ "\${2:-}" = --toolchain ] && \\
-  [ "\${3:-}" = stable-fixture ] && [ "\${4:-}" = rustc ]; then
+  [ "\${3:-}" = '${toolchain_name}' ] && [ "\${4:-}" = rustc ]; then
   case "\${mode}" in
     rustc-missing) exit 0 ;;
     rustc-failure) printf 'fake rustc lookup failed\\n' >&2; exit 77 ;;
@@ -258,7 +264,9 @@ if [ "\${1:-}" = which ] && [ "\${2:-}" = --toolchain ] && \\
   exit 0
 fi
 if [ "\${1:-}" = component ] && [ "\${2:-}" = list ]; then
-  if [ "\${mode}" = warm ] || [ "\${mode}" = missing-just ] || [ "\${mode}" = fetch-failure ]; then
+  if [ "\${mode}" = warm ] || [ "\${mode}" = rustup-proxies ] || \
+    [ "\${mode}" = versioned-toolchain ] || [ "\${mode}" = missing-just ] || \
+    [ "\${mode}" = fetch-failure ]; then
     printf 'rustfmt-x86_64-unknown-linux-gnu\\nclippy-x86_64-unknown-linux-gnu\\n'
   fi
   exit 0
@@ -376,12 +384,12 @@ EOF
     ln -s "${case_dir}/external/cargo" "${stable_toolchain_bin}/cargo"
   fi
   if [ "${mode}" = parent-symlink ]; then
-    parent_toolchain_dir="${case_dir}/external/stable-fixture"
+    parent_toolchain_dir="${case_dir}/external/${toolchain_name}"
     mkdir -p "${parent_toolchain_dir}/bin"
     mv "${stable_toolchain_bin}/cargo" "${parent_toolchain_dir}/bin/cargo"
     mv "${stable_toolchain_bin}/rustc" "${parent_toolchain_dir}/bin/rustc"
-    rmdir "${stable_toolchain_bin}" "${home_dir}/.rustup/toolchains/stable-fixture"
-    ln -s "${parent_toolchain_dir}" "${home_dir}/.rustup/toolchains/stable-fixture"
+    rmdir "${stable_toolchain_bin}" "${home_dir}/.rustup/toolchains/${toolchain_name}"
+    ln -s "${parent_toolchain_dir}" "${home_dir}/.rustup/toolchains/${toolchain_name}"
   fi
 
   for command_name in jq node python3; do
@@ -389,13 +397,24 @@ EOF
     printf '#!/bin/bash\nexit 0\n' >"${trusted_bin}/${command_name}"
   done
 
-  if [ "${mode}" = warm ] || [ "${mode}" = missing-just ] || [ "${mode}" = fetch-failure ]; then
+  if [ "${mode}" = warm ] || [ "${mode}" = rustup-proxies ] || \
+    [ "${mode}" = versioned-toolchain ] || [ "${mode}" = missing-just ] || \
+    [ "${mode}" = fetch-failure ]; then
     for command_name in rustfmt cargo-clippy; do
       printf '#!/bin/bash\nexit 0\n' >"${trusted_bin}/${command_name}"
     done
   fi
-  if [ "${mode}" = warm ] || [ "${mode}" = fetch-failure ]; then
+  if [ "${mode}" = warm ] || [ "${mode}" = rustup-proxies ] || \
+    [ "${mode}" = versioned-toolchain ] || [ "${mode}" = fetch-failure ]; then
     printf '#!/bin/bash\nexit 0\n' >"${trusted_bin}/just"
+  fi
+
+  if [ "${mode}" = rustup-proxies ]; then
+    cp "${trusted_bin}/rustup" "${home_dir}/.cargo/bin/rustup"
+    chmod +x "${home_dir}/.cargo/bin/rustup"
+    ln -s rustup "${home_dir}/.cargo/bin/cargo"
+    ln -s rustup "${home_dir}/.cargo/bin/rustfmt"
+    ln -s rustup "${home_dir}/.cargo/bin/cargo-clippy"
   fi
 
   if [ "${omit_command}" = rustup ]; then
@@ -521,7 +540,7 @@ run_setup "${fresh_case}" "${fresh_trusted_path}" "${fresh_case}/shadow/bin" \
   "${fresh_output}" "${fresh_status}"
 [ "$(<"${fresh_status}")" -eq 0 ]
 assert_contains "$(<"${fresh_output}")" 'codex-cloud-setup: ready ('
-expected_fresh=$'rustup toolchain list --verbose\nrustup component list --toolchain stable-fixture --installed\nrustup component add --toolchain stable-fixture rustfmt\nrustup component add --toolchain stable-fixture clippy\nrustup which --toolchain stable-fixture cargo\nrustup which --toolchain stable-fixture rustc\ncargo install just --locked\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
+expected_fresh=$'rustup toolchain list --verbose\nrustup component list --toolchain stable-x86_64-unknown-linux-gnu --installed\nrustup component add --toolchain stable-x86_64-unknown-linux-gnu rustfmt\nrustup component add --toolchain stable-x86_64-unknown-linux-gnu clippy\nrustup which --toolchain stable-x86_64-unknown-linux-gnu cargo\nrustup which --toolchain stable-x86_64-unknown-linux-gnu rustc\ncargo install just --locked\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
 actual_fresh="$(commands_without_environment_markers "${fresh_log}")"
 [ "${actual_fresh}" = "${expected_fresh}" ] || {
   printf 'unexpected fresh setup commands:\n%s\n' "${actual_fresh}" >&2
@@ -552,7 +571,7 @@ warm_status="${warm_case}/status"
 run_setup "${warm_case}" "${warm_case}/trusted/bin" "${warm_case}/trusted/bin" \
   "${warm_output}" "${warm_status}"
 [ "$(<"${warm_status}")" -eq 0 ]
-expected_warm=$'rustup toolchain list --verbose\nrustup component list --toolchain stable-fixture --installed\nrustup which --toolchain stable-fixture cargo\nrustup which --toolchain stable-fixture rustc\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
+expected_warm=$'rustup toolchain list --verbose\nrustup component list --toolchain stable-x86_64-unknown-linux-gnu --installed\nrustup which --toolchain stable-x86_64-unknown-linux-gnu cargo\nrustup which --toolchain stable-x86_64-unknown-linux-gnu rustc\ncargo fetch --quiet --locked\ncargo check --quiet --offline --locked --all-targets'
 actual_warm="$(commands_without_environment_markers "${warm_log}")"
 [ "${actual_warm}" = "${expected_warm}" ] || {
   printf 'unexpected warm setup commands:\n%s\n' "${actual_warm}" >&2
@@ -560,6 +579,87 @@ actual_warm="$(commands_without_environment_markers "${warm_log}")"
 }
 assert_not_contains "$(<"${warm_log}")" 'cargo-proxy'
 assert_not_contains "$(<"${warm_log}")" 'rustup-proxy-network-attempt'
+
+rustup_proxies_case="$(new_case rustup-proxies)"
+make_fake_environment "${rustup_proxies_case}" rustup-proxies
+rustup_proxies_output="${rustup_proxies_case}/output"
+rustup_proxies_status="${rustup_proxies_case}/status"
+run_setup "${rustup_proxies_case}" \
+  "${rustup_proxies_case}/home/.cargo/bin:${rustup_proxies_case}/trusted/bin" \
+  "${rustup_proxies_case}/trusted/bin" "${rustup_proxies_output}" \
+  "${rustup_proxies_status}"
+[ "$(<"${rustup_proxies_status}")" -eq 0 ]
+assert_contains "$(<"${rustup_proxies_output}")" 'codex-cloud-setup: ready ('
+assert_not_contains "$(<"${rustup_proxies_case}/commands")" 'rustup-proxy-network-attempt'
+
+cargo_parent_symlink_case="$(new_case cargo-parent-symlink)"
+make_fake_environment "${cargo_parent_symlink_case}" rustup-proxies
+mv "${cargo_parent_symlink_case}/home/.cargo" \
+  "${cargo_parent_symlink_case}/home/cargo-platform-cache"
+ln -s cargo-platform-cache "${cargo_parent_symlink_case}/home/.cargo"
+cargo_parent_symlink_output="${cargo_parent_symlink_case}/output"
+cargo_parent_symlink_status="${cargo_parent_symlink_case}/status"
+run_setup "${cargo_parent_symlink_case}" \
+  "${cargo_parent_symlink_case}/home/.cargo/bin:${cargo_parent_symlink_case}/trusted/bin" \
+  "${cargo_parent_symlink_case}/trusted/bin" "${cargo_parent_symlink_output}" \
+  "${cargo_parent_symlink_status}"
+assert_contains "$(<"${cargo_parent_symlink_output}")" 'Cargo bin contains a symlink path component'
+[ "$(<"${cargo_parent_symlink_status}")" -eq 1 ]
+
+regular_cargo_parent_symlink_case="$(new_case regular-cargo-parent-symlink)"
+make_fake_environment "${regular_cargo_parent_symlink_case}" warm
+cp "${regular_cargo_parent_symlink_case}/trusted/bin/"* \
+  "${regular_cargo_parent_symlink_case}/home/.cargo/bin/"
+mv "${regular_cargo_parent_symlink_case}/home/.cargo" \
+  "${regular_cargo_parent_symlink_case}/home/cargo-platform-cache"
+ln -s cargo-platform-cache "${regular_cargo_parent_symlink_case}/home/.cargo"
+regular_cargo_parent_symlink_output="${regular_cargo_parent_symlink_case}/output"
+regular_cargo_parent_symlink_status="${regular_cargo_parent_symlink_case}/status"
+run_setup "${regular_cargo_parent_symlink_case}" \
+  "${regular_cargo_parent_symlink_case}/home/.cargo/bin:${regular_cargo_parent_symlink_case}/trusted/bin" \
+  "${regular_cargo_parent_symlink_case}/trusted/bin" \
+  "${regular_cargo_parent_symlink_output}" "${regular_cargo_parent_symlink_status}"
+assert_contains "$(<"${regular_cargo_parent_symlink_output}")" \
+  'Cargo bin contains a symlink path component'
+[ "$(<"${regular_cargo_parent_symlink_status}")" -eq 1 ]
+
+rustup_proxy_writable_case="$(new_case rustup-proxy-writable)"
+make_fake_environment "${rustup_proxy_writable_case}" rustup-proxies
+chmod 777 "${rustup_proxy_writable_case}/home/.cargo/bin/rustup"
+rustup_proxy_writable_output="${rustup_proxy_writable_case}/output"
+rustup_proxy_writable_status="${rustup_proxy_writable_case}/status"
+run_setup "${rustup_proxy_writable_case}" \
+  "${rustup_proxy_writable_case}/home/.cargo/bin:${rustup_proxy_writable_case}/trusted/bin" \
+  "${rustup_proxy_writable_case}/trusted/bin" "${rustup_proxy_writable_output}" \
+  "${rustup_proxy_writable_status}"
+[ "$(<"${rustup_proxy_writable_status}")" -eq 1 ]
+assert_contains "$(<"${rustup_proxy_writable_output}")" 'writable by a group or other user'
+
+rustup_proxy_escape_case="$(new_case rustup-proxy-escape)"
+make_fake_environment "${rustup_proxy_escape_case}" warm
+ln -s "${rustup_proxy_escape_case}/trusted/bin/rustup" \
+  "${rustup_proxy_escape_case}/home/.cargo/bin/cargo"
+rustup_proxy_escape_output="${rustup_proxy_escape_case}/output"
+rustup_proxy_escape_status="${rustup_proxy_escape_case}/status"
+run_setup "${rustup_proxy_escape_case}" \
+  "${rustup_proxy_escape_case}/home/.cargo/bin:${rustup_proxy_escape_case}/trusted/bin" \
+  "${rustup_proxy_escape_case}/trusted/bin" "${rustup_proxy_escape_output}" \
+  "${rustup_proxy_escape_status}"
+[ "$(<"${rustup_proxy_escape_status}")" -eq 1 ]
+assert_contains "$(<"${rustup_proxy_escape_output}")" 'rustup proxy target must be an executable regular file'
+
+versioned_toolchain_case="$(new_case versioned-toolchain)"
+make_fake_environment "${versioned_toolchain_case}" versioned-toolchain
+versioned_toolchain_output="${versioned_toolchain_case}/output"
+versioned_toolchain_status="${versioned_toolchain_case}/status"
+run_setup "${versioned_toolchain_case}" "${versioned_toolchain_case}/trusted/bin" \
+  "${versioned_toolchain_case}/trusted/bin" "${versioned_toolchain_output}" \
+  "${versioned_toolchain_status}"
+[ "$(<"${versioned_toolchain_status}")" -eq 0 ]
+assert_contains "$(<"${versioned_toolchain_case}/commands")" \
+  'rustup which --toolchain 1.89.0-x86_64-unknown-linux-gnu cargo'
+assert_contains "$(<"${versioned_toolchain_case}/commands")" \
+  'rustup which --toolchain 1.89.0-x86_64-unknown-linux-gnu rustc'
 
 multiple_stable_case="$(new_case multiple-stable)"
 make_fake_environment "${multiple_stable_case}" multiple-stable
@@ -570,7 +670,7 @@ run_setup "${multiple_stable_case}" \
   "${multiple_stable_case}/trusted/bin" "${multiple_stable_output}" \
   "${multiple_stable_status}"
 [ "$(<"${multiple_stable_status}")" -ne 0 ]
-assert_contains "$(<"${multiple_stable_output}")" 'exactly one active/default stable host toolchain'
+assert_contains "$(<"${multiple_stable_output}")" 'exactly one active/default concrete stable host toolchain'
 
 custom_stable_case="$(new_case custom-stable)"
 make_fake_environment "${custom_stable_case}" custom-stable
@@ -581,7 +681,7 @@ run_setup "${custom_stable_case}" \
   "${custom_stable_case}/trusted/bin" "${custom_stable_output}" \
   "${custom_stable_status}"
 [ "$(<"${custom_stable_status}")" -ne 0 ]
-assert_contains "$(<"${custom_stable_output}")" 'does not match its active host name'
+assert_contains "$(<"${custom_stable_output}")" 'not a supported Cloud host'
 
 host_mismatch_case="$(new_case host-mismatch)"
 make_fake_environment "${host_mismatch_case}" host-mismatch
@@ -684,7 +784,7 @@ run_setup "${shadow_symlink_case}" \
   "${shadow_symlink_case}/trusted/bin" "${shadow_symlink_output}" \
   "${shadow_symlink_status}"
 [ "$(<"${shadow_symlink_status}")" -eq 1 ]
-assert_contains "$(<"${shadow_symlink_output}")" 'symlink path component'
+assert_contains "$(<"${shadow_symlink_output}")" 'rustup proxy target must be an executable regular file'
 
 shadow_writable_case="$(new_case shadow-writable)"
 make_fake_environment "${shadow_writable_case}" warm
@@ -802,6 +902,53 @@ default_expected_path="${default_canonical_nvm_bin}:${default_nvm_case}/home/.ca
     "$(<"${default_nvm_case}/observed-trusted-path")" >&2
   exit 1
 }
+
+nvm_writable_case="$(new_case nvm-writable)"
+make_fake_environment "${nvm_writable_case}" warm
+nvm_writable_bin="${nvm_writable_case}/home/.nvm/versions/node/vfixture/bin"
+mkdir -p "${nvm_writable_bin}"
+cp "${nvm_writable_case}/trusted/bin/"* "${nvm_writable_case}/home/.cargo/bin/"
+cp "${nvm_writable_case}/trusted/bin/node" "${nvm_writable_bin}/node"
+chmod 775 "${nvm_writable_case}/home/.nvm/versions/node/vfixture"
+nvm_writable_output="${nvm_writable_case}/output"
+nvm_writable_status="${nvm_writable_case}/status"
+run_setup "${nvm_writable_case}" __DEFAULT__ "${nvm_writable_case}/shadow/bin" \
+  "${nvm_writable_output}" "${nvm_writable_status}" \
+  "${nvm_writable_case}/home" "${nvm_writable_bin}"
+[ "$(<"${nvm_writable_status}")" -eq 1 ]
+assert_contains "$(<"${nvm_writable_output}")" 'NVM_BIN is writable by a group or other user'
+
+if [ "${EUID}" -eq 0 ]; then
+  platform_nvm_case="$(new_case platform-nvm-owner)"
+  make_fake_environment "${platform_nvm_case}" warm
+  platform_nvm_bin="${platform_nvm_case}/home/.nvm/versions/node/vfixture/bin"
+  mkdir -p "${platform_nvm_bin}"
+  cp "${platform_nvm_case}/trusted/bin/"* "${platform_nvm_case}/home/.cargo/bin/"
+  cp "${platform_nvm_case}/trusted/bin/node" "${platform_nvm_bin}/node"
+  chown -R 1001 "${platform_nvm_case}/home/.nvm"
+  platform_nvm_output="${platform_nvm_case}/output"
+  platform_nvm_status="${platform_nvm_case}/status"
+  run_setup "${platform_nvm_case}" __DEFAULT__ \
+    "${platform_nvm_case}/shadow/bin" "${platform_nvm_output}" \
+    "${platform_nvm_status}" "${platform_nvm_case}/home" "${platform_nvm_bin}"
+  [ "$(<"${platform_nvm_status}")" -eq 0 ]
+
+  mixed_nvm_case="$(new_case mixed-nvm-owner)"
+  make_fake_environment "${mixed_nvm_case}" warm
+  mixed_nvm_bin="${mixed_nvm_case}/home/.nvm/versions/node/vfixture/bin"
+  mkdir -p "${mixed_nvm_bin}"
+  cp "${mixed_nvm_case}/trusted/bin/"* "${mixed_nvm_case}/home/.cargo/bin/"
+  cp "${mixed_nvm_case}/trusted/bin/node" "${mixed_nvm_bin}/node"
+  chown -R 1001 "${mixed_nvm_case}/home/.nvm"
+  chown 1002 "${mixed_nvm_bin}/node"
+  mixed_nvm_output="${mixed_nvm_case}/output"
+  mixed_nvm_status="${mixed_nvm_case}/status"
+  run_setup "${mixed_nvm_case}" __DEFAULT__ "${mixed_nvm_case}/shadow/bin" \
+    "${mixed_nvm_output}" "${mixed_nvm_status}" "${mixed_nvm_case}/home" \
+    "${mixed_nvm_bin}"
+  [ "$(<"${mixed_nvm_status}")" -eq 1 ]
+  assert_contains "$(<"${mixed_nvm_output}")" 'does not match the pinned NVM owner'
+fi
 
 default_unset_nvm_case="$(new_case default-unset-nvm)"
 make_fake_environment "${default_unset_nvm_case}" warm

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -2493,12 +2493,15 @@ for script in \
   scripts/check-agent-backlog-access.sh \
   scripts/collect-pr-review-context.sh \
   scripts/create-review-followup-issue.sh \
+  scripts/test-codex-cloud-setup.sh \
   scripts/ticket-gen
 do
   [ -f "${script}" ] || continue
   name="$(basename "${script}")"
   check "script_${name}_syntax" bash -n "${script}"
 done
+
+check "codex_cloud_setup_contract" bash scripts/test-codex-cloud-setup.sh
 
 check "script_check_agent_issue_readiness_syntax" \
   python3 -c 'import ast,pathlib; ast.parse(pathlib.Path("scripts/check-agent-issue-readiness.py").read_text())'


### PR DESCRIPTION
## Summary
- harden the Codex Cloud setup entrypoint with a privileged Bash boundary, validated trusted PATH entries, absolute command resolution, and a scrubbed execution environment
- reject ambient Cargo configuration, credentials, source replacement, unsafe path aliases, and writable or wrong-owner Cargo parent directories before dependency work
- support the inspected universal-container layout through a constrained root-to-UID-1001 NVM bin transition, standard Rustup proxy validation, a concrete installed stable toolchain, and the exact protected `/usr/bin/python3` symlink
- preserve vetted proxy and CA transport only for online component/install/fetch steps, then perform the locked all-targets warm-up offline
- document Cloud platform trust boundaries for cache provenance, network allowlists, secrets, build scripts, and reset behavior
- add a deterministic fake-command integration suite and wire it into agent asset validation

## Validation
- `bash -n scripts/codex-cloud-setup.sh scripts/test-codex-cloud-setup.sh` — passed
- `bash scripts/test-codex-cloud-setup.sh` — passed (`codex_cloud_setup_tests=ok`)
- `just validate` — passed
- `git diff --check` — passed
- pre-push hook — Clippy passed; 228 library tests and 2 binary tests passed
- independent Luna Max test-manager and final security review — P0/P1/P2 = 0

## Stack
This PR is based on `feat/issue-188-remove-claude-validation` because #191 tightens the generic setup path after the Claude-specific wiring removal. It should be retargeted to `main` after #188 lands.

## Residual platform boundary
Actual Codex Cloud network allowlists, secret isolation, HOME/cache reset provenance, and build-script/proc-macro sandboxing cannot be proven locally and are documented as platform-owned constraints. Root-only wrong-owner fixtures are present but were statically reviewed because the local verification UID was non-root.

Closes #191