### PR TITLE
chore(codex): enforce repository skill invocation policy

### DIFF
--- a/.agents/docs/skill-authoring.md
+++ b/.agents/docs/skill-authoring.md
@@ -6,8 +6,54 @@ Use progressive disclosure:
 - `references/*`: detailed workflows, prompt templates, schemas, examples, decision taxonomies, and checklists.
 - `scripts/*`: deterministic executable helpers. Prefer scripts for repeated fragile command logic.
 - `assets/*`: templates or files copied into outputs. Do not put instructions here.
-- `agents/openai.yaml`: UI metadata only. Keep it short and make `default_prompt` mention `$skill-name`.
+- `agents/openai.yaml`: short UI and invocation metadata. Make `default_prompt` mention `$skill-name` and keep the policy mapping explicit.
 - `.codex/agents/*`: background/subagent configuration, not skill instructions. Link to skills or scripts instead of duplicating long procedures.
+
+## Repository skill inventory and invocation policy
+
+Every directory under `.agents/skills/` is registered below and owns an
+`agents/openai.yaml` file. The OpenAI metadata key
+`policy.allow_implicit_invocation` defaults to `true`; setting it to `false`
+prevents automatic model selection while preserving explicit `$skill-name`
+invocation.
+
+| Skill | `allow_implicit_invocation` | Decision |
+| --- | --- | --- |
+| `fixture-governance` | `true` | Implicit-eligible deterministic fixture guidance. |
+| `merge-gatekeeper` | `false` | Explicit-only scheduled merge owner. |
+| `open-pr-review-batch` | `false` | Explicit-only review posting across every open PR. |
+| `pr-resolution-loop` | `false` | Explicit-only review-resolution lifecycle transition. |
+| `pr-review-resolution` | `false` | Explicit-only actionable review feedback resolution. |
+| `prepare-backlog` | `false` | Explicit-only issue capture and research entry point. |
+| `rust-analyzer` | `true` | Implicit-eligible local Rust diagnostics; historical compatibility notes remain factual. |
+| `safe-direct-merge` | `false` | Explicit-only manual merge path outside the lifecycle queue. |
+| `spec-governance` | `true` | Implicit-eligible contract and SPEC consistency guidance. |
+| `take-ticket` | `false` | Explicit-only issue claim and execution entry point. |
+
+The seven `false` entries can claim or trigger repository-wide review, issue,
+label, or merge lifecycle effects and require an explicit user or scheduled
+caller. The three `true` entries provide implicit-eligible local analysis or
+guidance and keep implicit discovery available. Tool and sandbox permissions
+continue to govern command execution. `take-ticket`, `prepare-backlog`, and
+`merge-gatekeeper` also retain their legacy `SKILL.md` entry guard where the
+entry point itself must be hidden from model invocation.
+
+The following overlaps are deliberate dispositions for this inventory:
+
+- `pr-resolution-loop` and `pr-review-resolution` overlap in review feedback
+  handling. Issue #202 owns the eventual removal of `pr-resolution-loop`;
+  `pr-review-resolution` remains canonical. No directory is removed here.
+- `merge-gatekeeper` owns the normal `awaiting-merge` queue, while
+  `safe-direct-merge` handles explicitly authorized PRs outside that queue.
+- `open-pr-review-batch` posts non-blocking reviews; `pr-review-resolution`
+  resolves feedback after it exists.
+- `take-ticket` executes ready issues; `prepare-backlog` captures or researches
+  backlog items.
+
+No other duplicate directory has a mechanically safe removal disposition.
+Issue #188 owns Claude validation assets. The repository keeps only factual
+historical compatibility notes in skill references, while Codex invocation
+behavior is governed by the `agents/openai.yaml` policy above.
 
 Avoid long inline prompt templates in `SKILL.md`. Put them in `references/` and point to the file from `SKILL.md`.
 

--- a/.agents/skills/fixture-governance/agents/openai.yaml
+++ b/.agents/skills/fixture-governance/agents/openai.yaml
@@ -2,3 +2,5 @@ interface:
   display_name: "Fixture Governance"
   short_description: "Create and maintain safe, deterministic fixtures."
   default_prompt: "Use $fixture-governance to design or review deterministic, non-mutating RPM fixtures."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/merge-gatekeeper/agents/openai.yaml
+++ b/.agents/skills/merge-gatekeeper/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Merge Gatekeeper"
+  short_description: "Run the deterministic gate for one scheduled RPM merge."
+  default_prompt: "Use $merge-gatekeeper in scheduled mode to verify and execute at most one gated RPM merge."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/open-pr-review-batch/agents/openai.yaml
+++ b/.agents/skills/open-pr-review-batch/agents/openai.yaml
@@ -2,3 +2,5 @@ interface:
   display_name: "Open PR Review Batch"
   short_description: "Post a non-blocking, confidence-scored code review on every open PR."
   default_prompt: "Use $open-pr-review-batch to review every open PR in parallel and post one COMMENT review each."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/open-pr-review-batch/references/review-method.md
+++ b/.agents/skills/open-pr-review-batch/references/review-method.md
@@ -46,8 +46,6 @@ When no findings survive:
 
 No issues found. Checked for correctness, contract integrity, filesystem
 safety, and determinism.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
 ```
 
 When findings survive:
@@ -59,12 +57,10 @@ Found N issues:
 
 1. <brief description> (AGENTS.md / <SPEC path> says "<…>")
 <full-SHA permalink, ±1 line context>
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
 ```
 
 Permalink rules: use the full HEAD SHA (never `HEAD`/`main`/branch), repo must
-match `nameWithOwner`, `#L<start>-L<end>` after the path. Keep it brief; keep
-finding text emoji-free (the trailer line is the only emoji). Post with
+match `nameWithOwner`, `#L<start>-L<end>` after the path. Keep it brief and keep
+finding text emoji-free. Post with
 `gh pr review <n> --comment -F <file>`, then verify with
 `gh pr view <n> --json reviews`.

--- a/.agents/skills/pr-resolution-loop/agents/openai.yaml
+++ b/.agents/skills/pr-resolution-loop/agents/openai.yaml
@@ -1,4 +1,6 @@
 interface:
   display_name: "PR Resolution Loop"
-  short_description: "30-minute loop: select an open PR, resolve review feedback via a five-subagent pipeline, comment, and merge."
-  default_prompt: "Use $pr-resolution-loop to run the scheduled PR review resolution pipeline: select PR, collect context, route fixes through subagents, comment, and gate-checked merge."
+  short_description: "30-minute loop: select an open PR, resolve review feedback, comment, and transition it for gated merge."
+  default_prompt: "Use $pr-resolution-loop to run the scheduled PR review resolution pipeline: select PR, collect context, route fixes through subagents, comment, and transition it for gated merge."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/pr-review-resolution/agents/openai.yaml
+++ b/.agents/skills/pr-review-resolution/agents/openai.yaml
@@ -2,3 +2,5 @@ interface:
   display_name: "PR Review Resolution"
   short_description: "Resolve RPM PR review feedback with SPEC-aware defer rules."
   default_prompt: "Use $pr-review-resolution to collect RPM PR review context, classify feedback, apply accepted fixes, and create deferred follow-up issues when allowed."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/prepare-backlog/agents/openai.yaml
+++ b/.agents/skills/prepare-backlog/agents/openai.yaml
@@ -2,3 +2,5 @@ interface:
   display_name: "Prepare Backlog"
   short_description: "Capture ideas or advance RPM issue research."
   default_prompt: "Use $prepare-backlog to capture the supplied idea or run one bounded research cycle for the RPM Project backlog."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/rust-analyzer/agents/openai.yaml
+++ b/.agents/skills/rust-analyzer/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "RPM Rust Analyzer"
+  short_description: "Run deterministic Rust semantic diagnostics for RPM."
+  default_prompt: "Use $rust-analyzer to run the RPM Rust analyzer probe and deterministic diagnostic fallback."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/safe-direct-merge/agents/openai.yaml
+++ b/.agents/skills/safe-direct-merge/agents/openai.yaml
@@ -2,3 +2,5 @@ interface:
   display_name: "Safe Direct Merge"
   short_description: "Gate-checked squash merge for PRs outside the merge-gatekeeper queue."
   default_prompt: "Use $safe-direct-merge to gate-check and squash-merge PRs the scheduled merge-gatekeeper cannot reach, then clean up branches."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/spec-governance/agents/openai.yaml
+++ b/.agents/skills/spec-governance/agents/openai.yaml
@@ -2,3 +2,5 @@ interface:
   display_name: "SPEC Governance"
   short_description: "Keep SPEC.md authoritative when code changes contracts."
   default_prompt: "Use $spec-governance to compare code changes against SPEC.md and decide whether to block code or update the spec."
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/take-ticket/agents/openai.yaml
+++ b/.agents/skills/take-ticket/agents/openai.yaml
@@ -2,3 +2,5 @@ interface:
   display_name: "Take Ticket"
   short_description: "Execute one explicit or scheduled RPM ticket."
   default_prompt: "Use $take-ticket in explicit mode for the supplied issue, or scheduled mode to claim and execute at most one ready RPM issue."
+policy:
+  allow_implicit_invocation: false

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -371,6 +371,53 @@ def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
     return value.strip() == "true", None
 
 
+def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
+    """Validate required metadata as direct children of one interface mapping."""
+    blocks: list[dict[str, tuple[str, int]]] = []
+    current: dict[str, tuple[str, int]] | None = None
+    for line_number, raw_line in enumerate(text.splitlines(), 1):
+        leading = raw_line[: len(raw_line) - len(raw_line.lstrip(" \t"))]
+        if "\t" in leading:
+            return [f"line {line_number}: tabs are not allowed for interface indentation"]
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if indent == 0:
+            if re.match(r"^interface\s*:", stripped):
+                if stripped != "interface:":
+                    return [f"line {line_number}: interface must be a root mapping"]
+                blocks.append({})
+                current = blocks[-1]
+            else:
+                current = None
+            continue
+        if current is None or indent != 2:
+            continue
+        key, separator, value = stripped.partition(":")
+        if separator != ":":
+            return [f"line {line_number}: invalid interface child"]
+        key = key.strip()
+        if key in current:
+            return [f"line {line_number}: duplicate interface child {key!r}"]
+        current[key] = (value.strip(), line_number)
+
+    if len(blocks) != 1:
+        return ["expected exactly one root interface mapping"]
+
+    errors: list[str] = []
+    fields = blocks[0]
+    for key in ("display_name", "short_description"):
+        if key not in fields or not fields[key][0]:
+            errors.append(f"{key} is missing")
+    default_prompt = fields.get("default_prompt")
+    if default_prompt is None or not default_prompt[0]:
+        errors.append("default_prompt is missing")
+    elif f"${skill_name}" not in default_prompt[0]:
+        errors.append(f"default_prompt must mention ${skill_name}")
+    return errors
+
+
 def check_skill_inventory(errors: list[str]) -> None:
     skills_dir = ROOT / ".agents" / "skills"
     if not skills_dir.is_dir():
@@ -394,17 +441,11 @@ def check_skill_inventory(errors: list[str]) -> None:
         except OSError as error:
             fail(errors, f"{metadata_path.relative_to(ROOT)}: cannot read: {error}")
             continue
-        if not re.search(r"(?m)^interface:\s*$", text):
-            fail(errors, f"{metadata_path.relative_to(ROOT)}: interface block is missing")
-        if not re.search(r"(?m)^\s+display_name:\s*\S+", text):
-            fail(errors, f"{metadata_path.relative_to(ROOT)}: display_name is missing")
-        if not re.search(r"(?m)^\s+short_description:\s*\S+", text):
-            fail(errors, f"{metadata_path.relative_to(ROOT)}: short_description is missing")
-        if not re.search(
-            rf"(?m)^\s+default_prompt:\s*.*\${re.escape(skill_name)}",
-            text,
-        ):
-            fail(errors, f"{metadata_path.relative_to(ROOT)}: default_prompt must mention ${skill_name}")
+        for interface_error in validate_skill_interface_metadata(text, skill_name):
+            fail(
+                errors,
+                f"{metadata_path.relative_to(ROOT)}: invalid interface metadata: {interface_error}",
+            )
         value, policy_error = parse_skill_invocation_policy(text)
         if policy_error is not None:
             fail(

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -339,6 +339,13 @@ YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR = (
     "U+0085, U+2028, and U+2029 are not supported in openai.yaml"
 )
 YAML_UNSUPPORTED_LINE_SEPARATORS = frozenset(("\u0085", "\u2028", "\u2029"))
+YAML_UNSUPPORTED_STRUCTURE_SEPARATOR_ERROR = (
+    "U+000B, U+000C, U+001C, U+001D, and U+001E are not supported "
+    "as YAML line separators in openai.yaml"
+)
+YAML_UNSUPPORTED_STRUCTURE_SEPARATORS = frozenset(
+    ("\u000B", "\u000C", "\u001C", "\u001D", "\u001E")
+)
 YAML_TOKEN_ASCII_CONTINUATIONS = frozenset(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
 )
@@ -363,6 +370,10 @@ YAML_TOKEN_EXPLICIT_CONTINUATIONS = frozenset((0x200C, 0x200D))
 
 def contains_unsupported_yaml_line_separator(text: str) -> bool:
     return any(character in text for character in YAML_UNSUPPORTED_LINE_SEPARATORS)
+
+
+def contains_unsupported_yaml_structure_separator(text: str) -> bool:
+    return any(character in text for character in YAML_UNSUPPORTED_STRUCTURE_SEPARATORS)
 
 
 def is_supported_root_mapping_line(stripped: str) -> bool:
@@ -456,6 +467,8 @@ def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
     alongside the optional ``interface:`` mapping. Every non-comment root line
     must use one of those two supported mapping keys.
     """
+    if contains_unsupported_yaml_structure_separator(text):
+        return None, YAML_UNSUPPORTED_STRUCTURE_SEPARATOR_ERROR
     if contains_unsupported_yaml_line_separator(text):
         return None, YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR
     if text.startswith("\ufeff"):
@@ -463,6 +476,7 @@ def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
 
     blocks: list[list[tuple[int, str, int]]] = []
     current: list[tuple[int, str, int]] | None = None
+    active_root: str | None = None
     for line_number, raw_line in enumerate(text.splitlines(), 1):
         leading = raw_line[: len(raw_line) - len(raw_line.lstrip(" \t"))]
         if "\t" in leading:
@@ -481,12 +495,20 @@ def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
                 return None, f"line {line_number}: {YAML_UNSUPPORTED_ROOT_MAPPING_ERROR}"
             if not is_supported_root_mapping_header(stripped, root_key):
                 return None, f"line {line_number}: {root_key} must be a root mapping"
+            active_root = root_key
             if root_key == "policy":
                 blocks.append([])
                 current = blocks[-1]
             else:
                 current = None
             continue
+        if active_root is None:
+            return None, f"line {line_number}: {YAML_ROOT_MAPPING_ERROR}"
+        if indent != 2:
+            return None, (
+                f"line {line_number}: {active_root} descendants must be direct children "
+                "at two-space indentation"
+            )
         if current is not None:
             current.append((indent, stripped, line_number))
 
@@ -681,6 +703,8 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
 
     The only supported root mapping keys are ``interface:`` and ``policy:``.
     """
+    if contains_unsupported_yaml_structure_separator(text):
+        return [YAML_UNSUPPORTED_STRUCTURE_SEPARATOR_ERROR]
     if contains_unsupported_yaml_line_separator(text):
         return [YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR]
     if text.startswith("\ufeff"):
@@ -688,6 +712,7 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
 
     blocks: list[dict[str, tuple[str | None, int]]] = []
     current: dict[str, tuple[str | None, int]] | None = None
+    active_root: str | None = None
     for line_number, raw_line in enumerate(text.splitlines(), 1):
         leading = raw_line[: len(raw_line) - len(raw_line.lstrip(" \t"))]
         if "\t" in leading:
@@ -706,6 +731,7 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
             root_key = supported_root_mapping_key(stripped)
             if root_key not in YAML_SUPPORTED_ROOT_MAPPING_KEYS:
                 return [f"line {line_number}: {YAML_UNSUPPORTED_ROOT_MAPPING_ERROR}"]
+            active_root = root_key
             if root_key == "interface":
                 if not is_supported_root_mapping_header(stripped, "interface"):
                     return [f"line {line_number}: interface must be a root mapping"]
@@ -716,7 +742,14 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
                     return [f"line {line_number}: policy must be a root mapping"]
                 current = None
             continue
-        if current is None or indent != 2:
+        if active_root is None:
+            return [f"line {line_number}: {YAML_ROOT_MAPPING_ERROR}"]
+        if indent != 2:
+            return [
+                f"line {line_number}: {active_root} descendants must be direct children "
+                "at two-space indentation"
+            ]
+        if current is None:
             continue
         key, separator, value = stripped.partition(":")
         if separator != ":":

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 import tomllib
+import unicodedata
 from pathlib import Path
 
 
@@ -327,26 +328,160 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str]:
     return values
 
 
+YAML_SEPARATOR_SPACE = " "
+YAML_DOCUMENT_MARKER_ERROR = "YAML document markers are not supported in openai.yaml"
+YAML_ROOT_MAPPING_ERROR = "root-level YAML nodes must be supported mappings"
+YAML_UNSUPPORTED_ROOT_MAPPING_ERROR = (
+    "only interface and policy root mappings are supported"
+)
+YAML_SUPPORTED_ROOT_MAPPING_KEYS = frozenset(("interface", "policy"))
+YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR = (
+    "U+0085, U+2028, and U+2029 are not supported in openai.yaml"
+)
+YAML_UNSUPPORTED_LINE_SEPARATORS = frozenset(("\u0085", "\u2028", "\u2029"))
+YAML_TOKEN_ASCII_CONTINUATIONS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+)
+YAML_TOKEN_UNICODE_CONTINUATION_CATEGORIES = frozenset(
+    (
+        "Ll",
+        "Lm",
+        "Lo",
+        "Lt",
+        "Lu",
+        "Mc",
+        "Me",
+        "Mn",
+        "Nd",
+        "Nl",
+        "No",
+        "Cf",
+    )
+)
+YAML_TOKEN_EXPLICIT_CONTINUATIONS = frozenset((0x200C, 0x200D))
+
+
+def contains_unsupported_yaml_line_separator(text: str) -> bool:
+    return any(character in text for character in YAML_UNSUPPORTED_LINE_SEPARATORS)
+
+
+def is_supported_root_mapping_line(stripped: str) -> bool:
+    key, separator, value = stripped.partition(":")
+    return bool(
+        separator
+        and key.strip(" \t")
+        and (not value or value.startswith(YAML_SEPARATOR_SPACE))
+    )
+
+
+def supported_root_mapping_key(stripped: str) -> str | None:
+    if not is_supported_root_mapping_line(stripped):
+        return None
+    return stripped.partition(":")[0].strip(" \t")
+
+
+def is_supported_root_mapping_header(stripped: str, key: str) -> bool:
+    """Accept an empty root mapping value or an ASCII-space comment suffix."""
+    prefix = f"{key}:"
+    if stripped == prefix:
+        return True
+    if not stripped.startswith(prefix):
+        return False
+    suffix = stripped[len(prefix) :]
+    return suffix.startswith(YAML_SEPARATOR_SPACE) and suffix.lstrip(
+        YAML_SEPARATOR_SPACE
+    ).startswith("#")
+
+
+def strip_ascii_space_inline_comment(value: str) -> str:
+    """Remove a comment only when ``#`` has an ASCII space immediately before it."""
+    comment_index = next(
+        (
+            index
+            for index, character in enumerate(value)
+            if character == "#" and index > 0 and value[index - 1] == YAML_SEPARATOR_SPACE
+        ),
+        len(value),
+    )
+    return value[:comment_index].strip(YAML_SEPARATOR_SPACE)
+
+
+def is_skill_token_continuation(character: str) -> bool:
+    r"""Apply the explicit skill-token boundary contract without regex ``\w``."""
+    if not character:
+        return False
+    if character in YAML_TOKEN_ASCII_CONTINUATIONS:
+        return True
+    codepoint = ord(character)
+    if (
+        codepoint in YAML_TOKEN_EXPLICIT_CONTINUATIONS
+        or 0xFE00 <= codepoint <= 0xFE0F
+        or 0xE0100 <= codepoint <= 0xE01EF
+    ):
+        return True
+    return unicodedata.category(character) in YAML_TOKEN_UNICODE_CONTINUATION_CATEGORIES
+
+
+def has_complete_skill_token(value: str, skill_name: str) -> bool:
+    """Require a boundary on both sides of at least one exact skill token."""
+    token = f"${skill_name}"
+    search_start = 0
+    while True:
+        index = value.find(token, search_start)
+        if index < 0:
+            return False
+        token_end = index + len(token)
+        before = value[index - 1] if index else ""
+        after = value[token_end] if token_end < len(value) else ""
+        if not is_skill_token_continuation(before) and not is_skill_token_continuation(after):
+            return True
+        search_start = index + 1
+
+
+def is_yaml_document_marker(stripped: str) -> bool:
+    stripped = stripped.removeprefix("\ufeff")
+    return any(
+        stripped == marker
+        or stripped.startswith(f"{marker} ")
+        or stripped.startswith(f"{marker}\t")
+        for marker in ("---", "...")
+    )
+
+
 def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
     """Parse the deliberately small policy mapping in an openai.yaml file.
 
     A full YAML dependency is unnecessary here. The supported policy shape is
-    intentionally strict: one root ``policy:`` mapping with one direct child.
+    intentionally strict: one root ``policy:`` mapping with one direct child,
+    alongside the optional ``interface:`` mapping. Every non-comment root line
+    must use one of those two supported mapping keys.
     """
+    if contains_unsupported_yaml_line_separator(text):
+        return None, YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR
+    if text.startswith("\ufeff"):
+        text = text[1:]
+
     blocks: list[list[tuple[int, str, int]]] = []
     current: list[tuple[int, str, int]] | None = None
     for line_number, raw_line in enumerate(text.splitlines(), 1):
         leading = raw_line[: len(raw_line) - len(raw_line.lstrip(" \t"))]
         if "\t" in leading:
             return None, f"line {line_number}: tabs are not allowed for policy indentation"
-        stripped = raw_line.strip()
+        stripped = raw_line.strip(" \t")
         if not stripped or stripped.startswith("#"):
             continue
+        if is_yaml_document_marker(stripped):
+            return None, f"line {line_number}: {YAML_DOCUMENT_MARKER_ERROR}"
         indent = len(raw_line) - len(raw_line.lstrip(" "))
         if indent == 0:
-            if re.match(r"^policy\s*:", stripped):
-                if stripped != "policy:":
-                    return None, f"line {line_number}: policy must be a root mapping"
+            if not is_supported_root_mapping_line(stripped):
+                return None, f"line {line_number}: {YAML_ROOT_MAPPING_ERROR}"
+            root_key = supported_root_mapping_key(stripped)
+            if root_key not in YAML_SUPPORTED_ROOT_MAPPING_KEYS:
+                return None, f"line {line_number}: {YAML_UNSUPPORTED_ROOT_MAPPING_ERROR}"
+            if not is_supported_root_mapping_header(stripped, root_key):
+                return None, f"line {line_number}: {root_key} must be a root mapping"
+            if root_key == "policy":
                 blocks.append([])
                 current = blocks[-1]
             else:
@@ -366,9 +501,10 @@ def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
     key, separator, value = child.partition(":")
     if separator != ":" or key.strip() != "allow_implicit_invocation":
         return None, f"line {line_number}: unexpected policy child"
-    if value.strip() not in {"true", "false"}:
+    boolean_value = strip_ascii_space_inline_comment(value)
+    if boolean_value not in {"true", "false"}:
         return None, f"line {line_number}: allow_implicit_invocation must be boolean"
-    return value.strip() == "true", None
+    return boolean_value == "true", None
 
 
 INTERFACE_METADATA_SCALAR_ERROR = (
@@ -377,7 +513,6 @@ INTERFACE_METADATA_SCALAR_ERROR = (
     "ASCII space is the only separator, literal tabs are rejected, and "
     "single/double quotes with separation-space comments are supported)"
 )
-YAML_SEPARATOR_SPACE = " "
 LITERAL_SCALAR_CONTROL_ERROR = (
     "literal C0 and DEL control characters are not allowed in interface metadata scalars"
 )
@@ -393,9 +528,13 @@ def parse_yaml_string_scalar(value: str, line_number: int) -> tuple[str | None, 
     rejected. Double-quoted YAML escapes remain supported; single-quoted and
     plain backslashes remain literal.
     """
+    if contains_unsupported_yaml_line_separator(value):
+        return None, f"line {line_number}: {YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR}"
     source = value.strip(YAML_SEPARATOR_SPACE)
     if not source:
         return None, None
+    # The control-character contract is for literal source characters; valid
+    # double-quoted escape sequences are decoded below.
     if any(ord(character) <= 0x1F or ord(character) == 0x7F for character in source):
         return None, f"line {line_number}: {LITERAL_SCALAR_CONTROL_ERROR}"
 
@@ -475,7 +614,10 @@ def parse_yaml_string_scalar(value: str, line_number: int) -> tuple[str | None, 
                 index += width + 1
                 continue
             return None, f"line {line_number}: invalid double-quoted scalar escape"
-        return "".join(decoded), None
+        decoded_value = "".join(decoded)
+        if contains_unsupported_yaml_line_separator(decoded_value):
+            return None, f"line {line_number}: {YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR}"
+        return decoded_value, None
 
     if source.startswith("'"):
         end: int | None = None
@@ -535,7 +677,15 @@ def parse_yaml_string_scalar(value: str, line_number: int) -> tuple[str | None, 
 
 
 def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
-    """Validate required metadata as direct children of one interface mapping."""
+    """Validate direct children of one interface mapping in the supported subset.
+
+    The only supported root mapping keys are ``interface:`` and ``policy:``.
+    """
+    if contains_unsupported_yaml_line_separator(text):
+        return [YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR]
+    if text.startswith("\ufeff"):
+        text = text[1:]
+
     blocks: list[dict[str, tuple[str | None, int]]] = []
     current: dict[str, tuple[str | None, int]] | None = None
     for line_number, raw_line in enumerate(text.splitlines(), 1):
@@ -544,17 +694,26 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
             return [f"line {line_number}: tabs are not allowed for interface indentation"]
         if "\t" in raw_line:
             return [f"line {line_number}: literal tabs are not supported in interface metadata"]
-        stripped = raw_line.strip()
+        stripped = raw_line.strip(" \t")
         if not stripped or stripped.startswith("#"):
             continue
+        if is_yaml_document_marker(stripped):
+            return [f"line {line_number}: {YAML_DOCUMENT_MARKER_ERROR}"]
         indent = len(raw_line) - len(raw_line.lstrip(" "))
         if indent == 0:
-            if re.match(r"^interface\s*:", stripped):
-                if stripped != "interface:":
+            if not is_supported_root_mapping_line(stripped):
+                return [f"line {line_number}: {YAML_ROOT_MAPPING_ERROR}"]
+            root_key = supported_root_mapping_key(stripped)
+            if root_key not in YAML_SUPPORTED_ROOT_MAPPING_KEYS:
+                return [f"line {line_number}: {YAML_UNSUPPORTED_ROOT_MAPPING_ERROR}"]
+            if root_key == "interface":
+                if not is_supported_root_mapping_header(stripped, "interface"):
                     return [f"line {line_number}: interface must be a root mapping"]
                 blocks.append({})
                 current = blocks[-1]
             else:
+                if not is_supported_root_mapping_header(stripped, "policy"):
+                    return [f"line {line_number}: policy must be a root mapping"]
                 current = None
             continue
         if current is None or indent != 2:
@@ -585,7 +744,7 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
     default_prompt = fields.get("default_prompt")
     if default_prompt is None or not default_prompt[0]:
         errors.append("default_prompt is missing")
-    elif f"${skill_name}" not in default_prompt[0]:
+    elif not has_complete_skill_token(default_prompt[0], skill_name):
         errors.append(f"default_prompt must mention ${skill_name}")
     return errors
 

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -310,6 +310,9 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
     """Read the root fields needed by the repository policy.
 
     Root ``description`` is required and must be a non-empty string.
+    Its supported string forms include the YAML literal and folded block
+    scalar subset parsed by ``parse_frontmatter_block_scalar``. Other root
+    fields remain single-line scalar values.
     The supported forms are an empty ``metadata:`` block, an empty
     ``metadata: {}`` flow mapping, or a block mapping with one direct,
     non-empty ``short-description`` string child.  We keep that child out of
@@ -333,7 +336,8 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
     except ValueError:
         fail(errors, f"{path.relative_to(ROOT)}: unterminated frontmatter")
         return {}
-    frontmatter_source = "\n".join(lines[1:closing_line])
+    frontmatter_lines = lines[1:closing_line]
+    frontmatter_source = "\n".join(frontmatter_lines)
     if (
         "\r" in frontmatter_source
         or contains_yaml_surrogate(frontmatter_source)
@@ -353,7 +357,11 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
     active_nested_mapping: str | None = None
     metadata_flow_mapping = False
     metadata_keys: set[str] = set()
-    for line_number, line in enumerate(lines[1:closing_line], 2):
+    skip_until = 0
+    for line_index, line in enumerate(frontmatter_lines):
+        if line_index < skip_until:
+            continue
+        line_number = line_index + 2
         leading_whitespace = line[: len(line) - len(line.lstrip())]
         if any(character != YAML_SEPARATOR_SPACE for character in leading_whitespace):
             fail(
@@ -481,7 +489,30 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
             continue
         if key == "description":
             description_seen = True
-        parsed_value, scalar_error = parse_frontmatter_scalar(value, line_number)
+        block_header = parse_frontmatter_block_header(value, line_number)
+        if key == "description" and block_header is not None:
+            if isinstance(block_header, str):
+                fail(errors, f"{path.relative_to(ROOT)}: {block_header}")
+                skip_until = line_index + 1
+                while skip_until < len(frontmatter_lines):
+                    candidate = frontmatter_lines[skip_until]
+                    if candidate.strip(YAML_SEPARATOR_SPACE) == "":
+                        skip_until += 1
+                        continue
+                    candidate_indent = len(candidate) - len(
+                        candidate.lstrip(YAML_SEPARATOR_SPACE)
+                    )
+                    if candidate_indent == 0:
+                        break
+                    skip_until += 1
+                continue
+            parsed_value, skip_until, scalar_error = parse_frontmatter_block_scalar(
+                frontmatter_lines,
+                line_index,
+                block_header,
+            )
+        else:
+            parsed_value, scalar_error = parse_frontmatter_scalar(value, line_number)
         if scalar_error is not None:
             if key in FRONTMATTER_NON_EMPTY_STRING_KEYS:
                 fail(
@@ -1166,6 +1197,181 @@ def parse_frontmatter_scalar(
     if parsed is None:
         return None, f"line {line_number}: frontmatter values must be non-empty scalars"
     return parsed, None
+
+
+FRONTMATTER_BLOCK_SCALAR_HEADER_ERROR = (
+    "frontmatter description block scalar header must use '|' or '>' with "
+    "optional one-digit indentation and '-' or '+' chomping indicators"
+)
+FRONTMATTER_BLOCK_SCALAR_INDENTATION_ERROR = (
+    "frontmatter description block scalar content must be indented consistently"
+)
+
+
+def parse_frontmatter_block_header(
+    value: str, line_number: int
+) -> tuple[str, int | None, str] | str | None:
+    """Parse the supported root-description block-scalar header subset.
+
+    The boundary is intentionally explicit: ``|`` and ``>`` are accepted with
+    an optional one-digit indentation indicator, an optional ``-`` or ``+``
+    chomping indicator in either order, and an optional ASCII-space comment.
+    Tabs are accepted in comment text and after the required content
+    indentation; structural header and indentation tabs remain unsupported.
+    Collections and block scalars on other frontmatter fields remain outside
+    this parser contract.
+    """
+    source = value.strip(YAML_SEPARATOR_SPACE)
+    if not source.startswith(("|", ">")):
+        return None
+    match = re.fullmatch(
+        r"(?P<style>[|>])(?P<indicators>(?:[1-9][+-]?|[+-][1-9]?)?)(?: +#.*)?",
+        source,
+    )
+    if match is None:
+        return f"line {line_number}: {FRONTMATTER_BLOCK_SCALAR_HEADER_ERROR}"
+    comment_index = source.find("#")
+    structural_header = source if comment_index < 0 else source[:comment_index]
+    if "\t" in structural_header:
+        return f"line {line_number}: {FRONTMATTER_BLOCK_SCALAR_HEADER_ERROR}"
+    indicators = match.group("indicators")
+    indent_indicator = next(
+        (int(character) for character in indicators if character.isdigit()),
+        None,
+    )
+    chomping = next(
+        (character for character in indicators if character in "+-"),
+        "",
+    )
+    return match.group("style"), indent_indicator, chomping
+
+
+def fold_frontmatter_block_lines(
+    payloads: list[str], more_indented: list[bool]
+) -> str:
+    """Fold base-indented lines while preserving blank and indented breaks."""
+    if not payloads:
+        return ""
+    folded: list[str] = [payloads[0]]
+    for index in range(len(payloads) - 1):
+        current = payloads[index]
+        following = payloads[index + 1]
+        if more_indented[index] or more_indented[index + 1]:
+            separator = "\n"
+        elif current == "" and following != "":
+            run_start = index
+            while (
+                run_start > 0
+                and payloads[run_start - 1] == ""
+                and not more_indented[run_start - 1]
+            ):
+                run_start -= 1
+            separator = "\n" if (
+                run_start == 0
+                or more_indented[run_start - 1]
+            ) else ""
+        elif current == "" or following == "":
+            separator = "\n"
+        else:
+            separator = " "
+        folded.append(separator)
+        folded.append(following)
+    return "".join(folded)
+
+
+def parse_frontmatter_block_scalar(
+    lines: list[str],
+    header_index: int,
+    header: tuple[str, int | None, str],
+) -> tuple[str | None, int, str | None]:
+    """Parse a root ``description`` block scalar and return its next line.
+
+    Leading ASCII spaces determine indentation. Tabs after that indentation
+    remain scalar content, including when they begin a folded line.
+    """
+    style, indent_indicator, chomping = header
+    content_lines: list[tuple[int, str]] = []
+    line_index = header_index + 1
+    while line_index < len(lines):
+        line = lines[line_index]
+        if line.strip(YAML_SEPARATOR_SPACE) == "":
+            content_lines.append((line_index, line))
+            line_index += 1
+            continue
+        indent = len(line) - len(line.lstrip(YAML_SEPARATOR_SPACE))
+        if indent == 0:
+            break
+        content_lines.append((line_index, line))
+        line_index += 1
+
+    non_empty_lines = [
+        (physical_index, line)
+        for physical_index, line in content_lines
+        if line.strip(YAML_SEPARATOR_SPACE)
+    ]
+    if indent_indicator is None:
+        if non_empty_lines:
+            content_indent = len(non_empty_lines[0][1]) - len(
+                non_empty_lines[0][1].lstrip(YAML_SEPARATOR_SPACE)
+            )
+        else:
+            content_indent = 0
+    else:
+        content_indent = indent_indicator
+
+    if indent_indicator is None and non_empty_lines:
+        first_non_empty_index = non_empty_lines[0][0]
+        for physical_index, line in content_lines:
+            if physical_index >= first_non_empty_index:
+                break
+            indent = len(line) - len(line.lstrip(YAML_SEPARATOR_SPACE))
+            if indent > content_indent:
+                return (
+                    None,
+                    line_index,
+                    f"line {physical_index + 2}: {FRONTMATTER_BLOCK_SCALAR_INDENTATION_ERROR}",
+                )
+
+    payloads: list[str] = []
+    more_indented: list[bool] = []
+    for physical_index, line in content_lines:
+        indent = len(line) - len(line.lstrip(YAML_SEPARATOR_SPACE))
+        if (
+            non_empty_lines
+            and line.strip(YAML_SEPARATOR_SPACE)
+            and indent < content_indent
+        ):
+            return (
+                None,
+                line_index,
+                f"line {physical_index + 2}: {FRONTMATTER_BLOCK_SCALAR_INDENTATION_ERROR}",
+            )
+        if not non_empty_lines:
+            payload = ""
+            is_more_indented = False
+        elif indent < content_indent:
+            payload = ""
+            is_more_indented = False
+        else:
+            payload = line[content_indent:]
+            is_more_indented = indent > content_indent or payload.startswith("\t")
+        payloads.append(payload)
+        more_indented.append(is_more_indented)
+
+    if style == "|":
+        value = "\n".join(payloads)
+    else:
+        value = fold_frontmatter_block_lines(payloads, more_indented)
+    if payloads:
+        value += "\n"
+    if chomping == "-":
+        value = value.rstrip("\n")
+    elif chomping == "":
+        if not any(payload.strip(YAML_SEPARATOR_SPACE) for payload in payloads):
+            value = ""
+        else:
+            value = value.rstrip("\n") + "\n"
+    return value, line_index, None
 
 
 def validate_interface_asset_path(

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -455,6 +455,13 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
                 f"frontmatter field {key!r} must use YAML separation space after ':'",
             )
             continue
+        if key not in FRONTMATTER_ROOT_KEYS:
+            fail(
+                errors,
+                f"{path.relative_to(ROOT)}: line {line_number}: "
+                f"unsupported root frontmatter field {key!r}",
+            )
+            continue
         if key == "metadata":
             mapping_value = strip_ascii_space_inline_comment(value)
             if mapping_value not in {"", "{}"}:
@@ -476,7 +483,14 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
             description_seen = True
         parsed_value, scalar_error = parse_frontmatter_scalar(value, line_number)
         if scalar_error is not None:
-            fail(errors, f"{path.relative_to(ROOT)}: {scalar_error}")
+            if key in FRONTMATTER_NON_EMPTY_STRING_KEYS:
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    f"frontmatter field {key!r} must be a non-empty string",
+                )
+            else:
+                fail(errors, f"{path.relative_to(ROOT)}: {scalar_error}")
             continue
         if key == "description" and (
             not isinstance(parsed_value, str) or not parsed_value.strip()
@@ -485,6 +499,15 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
                 errors,
                 f"{path.relative_to(ROOT)}: line {line_number}: "
                 "frontmatter description must be a non-empty string",
+            )
+            continue
+        if key in FRONTMATTER_NON_EMPTY_STRING_KEYS and (
+            not isinstance(parsed_value, str) or not parsed_value.strip()
+        ):
+            fail(
+                errors,
+                f"{path.relative_to(ROOT)}: line {line_number}: "
+                f"frontmatter field {key!r} must be a non-empty string",
             )
             continue
         if key == "disable-model-invocation" and not isinstance(parsed_value, bool):
@@ -511,6 +534,21 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
 
 YAML_SEPARATOR_SPACE = " "
 FRONTMATTER_METADATA_KEYS = frozenset(("short-description",))
+# Hidden entry guards are repository-local extensions validated here.
+FRONTMATTER_ROOT_KEYS = frozenset((
+    "name",
+    "description",
+    "license",
+    "allowed-tools",
+    "metadata",
+    "argument-hint",
+    "disable-model-invocation",
+))
+FRONTMATTER_NON_EMPTY_STRING_KEYS = frozenset((
+    "license",
+    "argument-hint",
+    "allowed-tools",
+))
 FRONTMATTER_METADATA_VALUE_ERROR = (
     "metadata field 'short-description' must be a non-empty string"
 )
@@ -905,6 +943,14 @@ INTERFACE_METADATA_SCALAR_ERROR = (
     "ASCII space is the only separator, literal tabs are rejected, and "
     "single/double quotes with separation-space comments are supported)"
 )
+INTERFACE_METADATA_KEYS = frozenset((
+    "display_name",
+    "short_description",
+    "icon_small",
+    "icon_large",
+    "brand_color",
+    "default_prompt",
+))
 LITERAL_SCALAR_CONTROL_ERROR = (
     "literal C0 and DEL control characters are not allowed in interface metadata scalars; "
     "C1 controls and YAML noncharacters are also forbidden"
@@ -1168,6 +1214,8 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
             return [
                 f"line {line_number}: interface child {key!r} must use YAML separation space after ':'"
             ]
+        if key not in INTERFACE_METADATA_KEYS:
+            return [f"line {line_number}: unsupported interface child {key!r}"]
         if key in current:
             return [f"line {line_number}: duplicate interface child {key!r}"]
         parsed_value, scalar_error = parse_yaml_string_scalar(value, line_number)

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -703,6 +703,7 @@ def validate_supported_dependencies(text: str) -> str | None:
     dependencies_seen = False
     tools_seen = False
     tools_mode: str | None = None
+    tools_items_seen = False
     tool_keys: set[str] | None = None
 
     def finish_tool(line_number: int) -> str | None:
@@ -711,6 +712,11 @@ def validate_supported_dependencies(text: str) -> str | None:
         if not {"type", "value"}.issubset(tool_keys):
             return f"line {line_number}: dependency tool requires type and value"
         return None
+
+    def finish_tools(line_number: int) -> str | None:
+        if tools_mode == "sequence" and not tools_items_seen:
+            return f"line {line_number}: {YAML_DEPENDENCY_ERROR}"
+        return finish_tool(line_number)
 
     for line_number, raw_line in enumerate(text.splitlines(), 1):
         leading = raw_line[: len(raw_line) - len(raw_line.lstrip(" \t"))]
@@ -723,7 +729,7 @@ def validate_supported_dependencies(text: str) -> str | None:
             return f"line {line_number}: literal tabs are not supported in dependencies"
         indent = len(raw_line) - len(raw_line.lstrip(" "))
         if indent == 0:
-            if tool_error := finish_tool(line_number):
+            if tool_error := finish_tools(line_number):
                 return tool_error
             tool_keys = None
             if not is_supported_root_mapping_line(stripped):
@@ -740,12 +746,13 @@ def validate_supported_dependencies(text: str) -> str | None:
             dependencies_seen = True
             tools_seen = False
             tools_mode = None
+            tools_items_seen = False
             continue
 
         if active_root != "dependencies":
             continue
         if indent == 2:
-            if tool_error := finish_tool(line_number):
+            if tool_error := finish_tools(line_number):
                 return tool_error
             tool_keys = None
             key, separator, value = stripped.partition(":")
@@ -771,10 +778,12 @@ def validate_supported_dependencies(text: str) -> str | None:
                 return tool_error
             tool_keys = None
             if stripped == "-":
+                tools_items_seen = True
                 tool_keys = set()
                 continue
             if not stripped.startswith("- "):
                 return f"line {line_number}: {YAML_DEPENDENCY_ERROR}"
+            tools_items_seen = True
             tool_keys = set()
             inline_field = stripped[2:].strip()
             if inline_field and not inline_field.startswith("#"):
@@ -789,7 +798,7 @@ def validate_supported_dependencies(text: str) -> str | None:
             continue
         return f"line {line_number}: {YAML_DEPENDENCY_ERROR}"
 
-    return finish_tool(len(text.splitlines()) + 1)
+    return finish_tools(len(text.splitlines()) + 1)
 
 
 def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
@@ -864,6 +873,11 @@ def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
     key, separator, value = child.partition(":")
     if separator != ":" or key != "allow_implicit_invocation":
         return None, f"line {line_number}: unexpected policy child"
+    if value and not value.startswith(YAML_SEPARATOR_SPACE):
+        return None, (
+            f"line {line_number}: policy child {key!r} must use "
+            "YAML separation space after ':'"
+        )
     boolean_value = strip_ascii_space_inline_comment(value)
     if boolean_value not in {"true", "false"}:
         return None, f"line {line_number}: allow_implicit_invocation must be boolean"
@@ -1055,7 +1069,7 @@ def parse_frontmatter_scalar(
     value: str, line_number: int
 ) -> tuple[str | bool | None, str | None]:
     """Parse a scalar in the supported SKILL.md frontmatter subset."""
-    stripped = value.strip(YAML_SEPARATOR_SPACE)
+    stripped = strip_ascii_space_inline_comment(value).strip(YAML_SEPARATOR_SPACE)
     if stripped in {"true", "false"}:
         return stripped == "true", None
     parsed, error = parse_yaml_string_scalar(value, line_number)

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -309,6 +309,7 @@ def check_role_contracts(
 def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
     """Read the root fields needed by the repository policy.
 
+    Root ``description`` is required and must be a non-empty string.
     The supported forms are an empty ``metadata:`` block, an empty
     ``metadata: {}`` flow mapping, or a block mapping with one direct,
     non-empty ``short-description`` string child.  We keep that child out of
@@ -348,6 +349,7 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
         return {}
     values: dict[str, str | bool] = {}
     root_keys: set[str] = set()
+    description_seen = False
     active_nested_mapping: str | None = None
     metadata_flow_mapping = False
     metadata_keys: set[str] = set()
@@ -470,9 +472,20 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
             active_nested_mapping = None if metadata_flow_mapping else key
             metadata_keys.clear()
             continue
+        if key == "description":
+            description_seen = True
         parsed_value, scalar_error = parse_frontmatter_scalar(value, line_number)
         if scalar_error is not None:
             fail(errors, f"{path.relative_to(ROOT)}: {scalar_error}")
+            continue
+        if key == "description" and (
+            not isinstance(parsed_value, str) or not parsed_value.strip()
+        ):
+            fail(
+                errors,
+                f"{path.relative_to(ROOT)}: line {line_number}: "
+                "frontmatter description must be a non-empty string",
+            )
             continue
         if key == "disable-model-invocation" and not isinstance(parsed_value, bool):
             fail(
@@ -491,6 +504,8 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
         root_keys.add(key)
         if parsed_value is not None:
             values[key] = parsed_value
+    if not description_seen:
+        fail(errors, f"{path.relative_to(ROOT)}: frontmatter description is missing")
     return values
 
 

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -371,14 +371,179 @@ def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
     return value.strip() == "true", None
 
 
+INTERFACE_METADATA_SCALAR_ERROR = (
+    "interface metadata must be a non-empty YAML string scalar "
+    "(plain scalars cannot start with YAML indicators such as - ? : , @ % or `; "
+    "ASCII space is the only separator, literal tabs are rejected, and "
+    "single/double quotes with separation-space comments are supported)"
+)
+YAML_SEPARATOR_SPACE = " "
+LITERAL_SCALAR_CONTROL_ERROR = (
+    "literal C0 and DEL control characters are not allowed in interface metadata scalars"
+)
+
+
+def parse_yaml_string_scalar(value: str, line_number: int) -> tuple[str | None, str | None]:
+    """Parse the supported openai.yaml scalar subset without third-party dependencies.
+
+    Interface metadata accepts non-empty plain, single-quoted, or double-quoted
+    YAML string scalars. Plain scalars use YAML comment and leading-indicator
+    rules; a comment is allowed after one ASCII separation space. Nulls,
+    collections, tags, block scalars, non-string scalars, and literal tabs are
+    rejected. Double-quoted YAML escapes remain supported; single-quoted and
+    plain backslashes remain literal.
+    """
+    source = value.strip(YAML_SEPARATOR_SPACE)
+    if not source:
+        return None, None
+    if any(ord(character) <= 0x1F or ord(character) == 0x7F for character in source):
+        return None, f"line {line_number}: {LITERAL_SCALAR_CONTROL_ERROR}"
+
+    def validate_quoted_tail(tail: str) -> str | None:
+        if not tail:
+            return None
+        if not tail.startswith(YAML_SEPARATOR_SPACE):
+            return "trailing content after quoted scalar"
+        comment = tail.lstrip(YAML_SEPARATOR_SPACE)
+        if comment and not comment.startswith("#"):
+            return "trailing content after quoted scalar"
+        return None
+
+    if source.startswith('"'):
+        end: int | None = None
+        escaped = False
+        for index in range(1, len(source)):
+            character = source[index]
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                end = index
+                break
+        if end is None or escaped:
+            return None, f"line {line_number}: unterminated double-quoted scalar"
+        tail_error = validate_quoted_tail(source[end + 1 :])
+        if tail_error is not None:
+            return None, f"line {line_number}: {tail_error}"
+
+        escape_values = {
+            "0": "\0",
+            "a": "\a",
+            "b": "\b",
+            "t": "\t",
+            "n": "\n",
+            "v": "\v",
+            "f": "\f",
+            "r": "\r",
+            "e": "\x1b",
+            " ": " ",
+            '"': '"',
+            "/": "/",
+            "\\": "\\",
+            "N": "\x85",
+            "_": "\xa0",
+            "L": "\u2028",
+            "P": "\u2029",
+        }
+        decoded: list[str] = []
+        index = 1
+        while index < end:
+            character = source[index]
+            if character != "\\":
+                decoded.append(character)
+                index += 1
+                continue
+            index += 1
+            if index >= end:
+                return None, f"line {line_number}: invalid double-quoted scalar escape"
+            escape = source[index]
+            if escape in escape_values:
+                decoded.append(escape_values[escape])
+                index += 1
+                continue
+            if escape in {"x", "u", "U"}:
+                width = {"x": 2, "u": 4, "U": 8}[escape]
+                digits = source[index + 1 : index + 1 + width]
+                if len(digits) != width or not re.fullmatch(r"[0-9a-fA-F]+", digits):
+                    return None, f"line {line_number}: invalid double-quoted scalar escape"
+                codepoint = int(digits, 16)
+                try:
+                    decoded.append(chr(codepoint))
+                except ValueError:
+                    return None, f"line {line_number}: invalid double-quoted scalar escape"
+                index += width + 1
+                continue
+            return None, f"line {line_number}: invalid double-quoted scalar escape"
+        return "".join(decoded), None
+
+    if source.startswith("'"):
+        end: int | None = None
+        decoded: list[str] = []
+        index = 1
+        while index < len(source):
+            character = source[index]
+            if character != "'":
+                decoded.append(character)
+                index += 1
+                continue
+            if index + 1 < len(source) and source[index + 1] == "'":
+                decoded.append("'")
+                index += 2
+                continue
+            end = index
+            break
+        if end is None:
+            return None, f"line {line_number}: unterminated single-quoted scalar"
+        tail_error = validate_quoted_tail(source[end + 1 :])
+        if tail_error is not None:
+            return None, f"line {line_number}: {tail_error}"
+        return "".join(decoded), None
+
+    comment_index = next(
+        (
+            index
+            for index, character in enumerate(source)
+            if character == "#"
+            and (index == 0 or source[index - 1] == YAML_SEPARATOR_SPACE)
+        ),
+        len(source),
+    )
+    plain = source[:comment_index].rstrip(YAML_SEPARATOR_SPACE)
+    if not plain:
+        return None, None
+    if plain.startswith((",", "[", "]", "{", "}", "&", "*", "!", "|", ">", "@", "%", "`")):
+        return None, f"line {line_number}: {INTERFACE_METADATA_SCALAR_ERROR}"
+    if plain[0] in "-?:" and (
+        len(plain) == 1 or plain[1] == YAML_SEPARATOR_SPACE
+    ):
+        return None, f"line {line_number}: {INTERFACE_METADATA_SCALAR_ERROR}"
+    if re.search(r":[ \t]", plain):
+        return None, f"line {line_number}: {INTERFACE_METADATA_SCALAR_ERROR}"
+    if plain.lower() in {"null", "true", "false", "yes", "no", "on", "off", "~"}:
+        return None, f"line {line_number}: {INTERFACE_METADATA_SCALAR_ERROR}"
+    if plain.lower() in {".inf", "+.inf", "-.inf", ".nan"}:
+        return None, f"line {line_number}: {INTERFACE_METADATA_SCALAR_ERROR}"
+    if re.fullmatch(
+        r"[-+]?(?:[0-9][0-9_]*(?:\.[0-9_]*)?|\.[0-9_]+)(?:[eE][-+]?[0-9]+)?",
+        plain,
+    ) or re.fullmatch(r"[-+]?0[xob][0-9a-fA-F_]+", plain, re.IGNORECASE):
+        return None, f"line {line_number}: {INTERFACE_METADATA_SCALAR_ERROR}"
+    if re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}(?:[Tt ].*)?", plain):
+        return None, f"line {line_number}: {INTERFACE_METADATA_SCALAR_ERROR}"
+    return plain, None
+
+
 def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
     """Validate required metadata as direct children of one interface mapping."""
-    blocks: list[dict[str, tuple[str, int]]] = []
-    current: dict[str, tuple[str, int]] | None = None
+    blocks: list[dict[str, tuple[str | None, int]]] = []
+    current: dict[str, tuple[str | None, int]] | None = None
     for line_number, raw_line in enumerate(text.splitlines(), 1):
         leading = raw_line[: len(raw_line) - len(raw_line.lstrip(" \t"))]
         if "\t" in leading:
             return [f"line {line_number}: tabs are not allowed for interface indentation"]
+        if "\t" in raw_line:
+            return [f"line {line_number}: literal tabs are not supported in interface metadata"]
         stripped = raw_line.strip()
         if not stripped or stripped.startswith("#"):
             continue
@@ -398,9 +563,16 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
         if separator != ":":
             return [f"line {line_number}: invalid interface child"]
         key = key.strip()
+        if value and not value.startswith(YAML_SEPARATOR_SPACE):
+            return [
+                f"line {line_number}: interface child {key!r} must use YAML separation space after ':'"
+            ]
         if key in current:
             return [f"line {line_number}: duplicate interface child {key!r}"]
-        current[key] = (value.strip(), line_number)
+        parsed_value, scalar_error = parse_yaml_string_scalar(value, line_number)
+        if scalar_error is not None:
+            return [scalar_error]
+        current[key] = (parsed_value, line_number)
 
     if len(blocks) != 1:
         return ["expected exactly one root interface mapping"]

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -346,6 +346,9 @@ YAML_UNSUPPORTED_STRUCTURE_SEPARATOR_ERROR = (
 YAML_UNSUPPORTED_STRUCTURE_SEPARATORS = frozenset(
     ("\u000B", "\u000C", "\u001C", "\u001D", "\u001E")
 )
+YAML_LITERAL_CONTROL_ERROR = (
+    "literal C0 and DEL control characters are not allowed in openai.yaml"
+)
 YAML_TOKEN_ASCII_CONTINUATIONS = frozenset(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
 )
@@ -374,6 +377,14 @@ def contains_unsupported_yaml_line_separator(text: str) -> bool:
 
 def contains_unsupported_yaml_structure_separator(text: str) -> bool:
     return any(character in text for character in YAML_UNSUPPORTED_STRUCTURE_SEPARATORS)
+
+
+def contains_literal_yaml_control(text: str) -> bool:
+    return any(
+        (ord(character) <= 0x1F and character not in "\t\r\n")
+        or ord(character) == 0x7F
+        for character in text
+    )
 
 
 def is_supported_root_mapping_line(stripped: str) -> bool:
@@ -469,6 +480,8 @@ def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
     """
     if contains_unsupported_yaml_structure_separator(text):
         return None, YAML_UNSUPPORTED_STRUCTURE_SEPARATOR_ERROR
+    if contains_literal_yaml_control(text):
+        return None, YAML_LITERAL_CONTROL_ERROR
     if contains_unsupported_yaml_line_separator(text):
         return None, YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR
     if text.startswith("\ufeff"):
@@ -705,6 +718,8 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
     """
     if contains_unsupported_yaml_structure_separator(text):
         return [YAML_UNSUPPORTED_STRUCTURE_SEPARATOR_ERROR]
+    if contains_literal_yaml_control(text):
+        return [YAML_LITERAL_CONTROL_ERROR]
     if contains_unsupported_yaml_line_separator(text):
         return [YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR]
     if text.startswith("\ufeff"):
@@ -782,6 +797,19 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
     return errors
 
 
+def validate_skill_frontmatter_name(skill_name: str, skill_path: Path, errors: list[str]) -> None:
+    values = parse_frontmatter(skill_path, errors)
+    declared_name = values.get("name")
+    if declared_name is None:
+        fail(errors, f"{skill_path.relative_to(ROOT)}: frontmatter name is missing")
+    elif declared_name != skill_name:
+        fail(
+            errors,
+            f"{skill_path.relative_to(ROOT)}: frontmatter name {declared_name!r} "
+            f"does not match inventory entry {skill_name!r}",
+        )
+
+
 def check_skill_inventory(errors: list[str]) -> None:
     skills_dir = ROOT / ".agents" / "skills"
     if not skills_dir.is_dir():
@@ -796,6 +824,11 @@ def check_skill_inventory(errors: list[str]) -> None:
         fail(errors, f".agents/skills/{unexpected}: unregistered skill directory")
 
     for skill_name, allow_implicit in EXPECTED_SKILL_INVOCATION_POLICY.items():
+        skill_path = skills_dir / skill_name / "SKILL.md"
+        if not skill_path.is_file():
+            fail(errors, f"{skill_path.relative_to(ROOT)}: skill instructions are missing")
+        else:
+            validate_skill_frontmatter_name(skill_name, skill_path, errors)
         metadata_path = skills_dir / skill_name / "agents" / "openai.yaml"
         if not metadata_path.is_file():
             fail(errors, f"{metadata_path.relative_to(ROOT)}: metadata is missing")

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tomllib
 import unicodedata
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -501,6 +501,30 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
                 "frontmatter description must be a non-empty string",
             )
             continue
+        if key == "description":
+            description = parsed_value.strip()
+            if description.startswith("[TODO:"):
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    "frontmatter description contains an unfinished TODO placeholder",
+                )
+                continue
+            if "<" in description or ">" in description:
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    "frontmatter description cannot contain angle brackets (< or >)",
+                )
+                continue
+            if len(description) > 1024:
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    f"frontmatter description is too long ({len(description)} characters). "
+                    "Maximum is 1024 characters.",
+                )
+                continue
         if key in FRONTMATTER_NON_EMPTY_STRING_KEYS and (
             not isinstance(parsed_value, str) or not parsed_value.strip()
         ):
@@ -951,6 +975,9 @@ INTERFACE_METADATA_KEYS = frozenset((
     "brand_color",
     "default_prompt",
 ))
+INTERFACE_ICON_KEYS = frozenset(("icon_small", "icon_large"))
+INTERFACE_BRAND_COLOR_RE = re.compile(r"^#[0-9A-F]{6}$", re.IGNORECASE)
+WINDOWS_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:")
 LITERAL_SCALAR_CONTROL_ERROR = (
     "literal C0 and DEL control characters are not allowed in interface metadata scalars; "
     "C1 controls and YAML noncharacters are also forbidden"
@@ -1141,7 +1168,76 @@ def parse_frontmatter_scalar(
     return parsed, None
 
 
-def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
+def validate_interface_asset_path(
+    value: str,
+    key: str,
+    line_number: int,
+    skill_root: Path | None,
+) -> str | None:
+    """Validate an interface icon as a spelling-preserving skill asset path."""
+    error_prefix = f"line {line_number}: interface field {key!r}"
+    if "\\" in value or WINDOWS_DRIVE_PATH_RE.match(value):
+        return f"{error_prefix} must be a skill-relative POSIX path under 'assets'"
+    candidate = PurePosixPath(value)
+    if (
+        candidate.is_absolute()
+        or not candidate.parts
+        or candidate.parts[0] != "assets"
+        or ".." in candidate.parts
+    ):
+        return f"{error_prefix} must stay inside the skill directory"
+    if skill_root is None:
+        return None
+
+    try:
+        resolved_root = skill_root.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return f"{error_prefix} skill root cannot be resolved"
+    current = resolved_root
+    for component in candidate.parts:
+        try:
+            entries = list(current.iterdir())
+        except OSError:
+            return f"{error_prefix} path cannot be inspected"
+        requested_bytes = os.fsencode(component)
+        exact_entry = next(
+            (
+                entry
+                for entry in entries
+                if os.fsencode(entry.name) == requested_bytes
+            ),
+            None,
+        )
+        if exact_entry is None:
+            if any(entry.name.casefold() == component.casefold() for entry in entries):
+                return (
+                    f"{error_prefix} path component spelling must match the on-disk "
+                    "name exactly"
+                )
+            return f"{error_prefix} points to a missing file"
+        current = exact_entry
+
+    try:
+        assets_root = (resolved_root / "assets").resolve(strict=True)
+        resolved_target = current.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return f"{error_prefix} must resolve to a file inside skill assets"
+    if (
+        not assets_root.is_dir()
+        or not assets_root.is_relative_to(resolved_root)
+        or not resolved_target.is_relative_to(assets_root)
+    ):
+        return f"{error_prefix} must resolve to a file inside skill assets"
+    if not resolved_target.is_file():
+        return f"{error_prefix} points to a missing file"
+    return None
+
+
+def validate_skill_interface_metadata(
+    text: str,
+    skill_name: str,
+    skill_root: Path | None = None,
+) -> list[str]:
     """Validate direct children of one interface mapping in the supported subset.
 
     The supported root mapping keys are ``interface:``, ``dependencies:``, and
@@ -1236,6 +1332,22 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
         errors.append("default_prompt is missing")
     elif not has_complete_skill_token(default_prompt[0], skill_name):
         errors.append(f"default_prompt must mention ${skill_name}")
+    for key, (value, line_number) in fields.items():
+        if key in INTERFACE_ICON_KEYS:
+            if value is None:
+                continue
+            if asset_error := validate_interface_asset_path(
+                value,
+                key,
+                line_number,
+                skill_root,
+            ):
+                errors.append(asset_error)
+        elif key == "brand_color" and value is not None:
+            if INTERFACE_BRAND_COLOR_RE.fullmatch(value) is None:
+                errors.append(
+                    f"line {line_number}: interface field 'brand_color' must use #RRGGBB"
+                )
     return errors
 
 
@@ -1280,7 +1392,11 @@ def check_skill_inventory(errors: list[str]) -> None:
         except OSError as error:
             fail(errors, f"{metadata_path.relative_to(ROOT)}: cannot read: {error}")
             continue
-        for interface_error in validate_skill_interface_metadata(text, skill_name):
+        for interface_error in validate_skill_interface_metadata(
+            text,
+            skill_name,
+            metadata_path.parent.parent,
+        ):
             fail(
                 errors,
                 f"{metadata_path.relative_to(ROOT)}: invalid interface metadata: {interface_error}",

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -327,6 +327,10 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
     except OSError as error:
         fail(errors, f"{path.relative_to(ROOT)}: cannot read: {error}")
         return {}
+    # Accept CRLF as a line ending at the file boundary. A remaining carriage
+    # return is a bare or malformed CR and stays covered by the control check
+    # below, so scalar content cannot silently acquire a different newline.
+    text = text.replace("\r\n", "\n")
     if not text.startswith("---\n"):
         fail(errors, f"{path.relative_to(ROOT)}: missing frontmatter")
         return {}

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -307,7 +307,14 @@ def check_role_contracts(
 
 
 def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
-    """Parse the complete, deliberately flat SKILL.md frontmatter subset."""
+    """Read the root fields needed by the repository policy.
+
+    The supported forms are an empty ``metadata:`` block, an empty
+    ``metadata: {}`` flow mapping, or a block mapping with one direct,
+    non-empty ``short-description`` string child.  We keep that child out of
+    the root identity map, so a nested ``name`` can never satisfy the
+    inventory check.
+    """
     try:
         text = path.read_bytes().decode("utf-8")
     except UnicodeDecodeError as error:
@@ -328,6 +335,7 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
     frontmatter_source = "\n".join(lines[1:closing_line])
     if (
         "\r" in frontmatter_source
+        or contains_yaml_surrogate(frontmatter_source)
         or contains_unsupported_yaml_structure_separator(frontmatter_source)
         or contains_literal_yaml_control(frontmatter_source)
         or contains_unsupported_yaml_line_separator(frontmatter_source)
@@ -339,19 +347,99 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
         )
         return {}
     values: dict[str, str | bool] = {}
+    root_keys: set[str] = set()
+    active_nested_mapping: str | None = None
+    metadata_flow_mapping = False
+    metadata_keys: set[str] = set()
     for line_number, line in enumerate(lines[1:closing_line], 2):
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if line[:1].isspace():
+        leading_whitespace = line[: len(line) - len(line.lstrip())]
+        if any(character != YAML_SEPARATOR_SPACE for character in leading_whitespace):
             fail(
                 errors,
                 f"{path.relative_to(ROOT)}: line {line_number}: "
-                "nested frontmatter fields are not supported",
+                "frontmatter indentation must use ASCII spaces",
             )
             continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent != 0:
+            if metadata_flow_mapping:
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    "metadata flow mapping cannot contain indented children",
+                )
+                continue
+            if active_nested_mapping != "metadata":
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    "nested frontmatter fields are not supported",
+                )
+                continue
+            if indent != 2:
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    "metadata descendants must be direct children at two-space indentation",
+                )
+                continue
+            key, separator, value = stripped.partition(":")
+            if separator != ":" or re.fullmatch(r"[a-z][a-z0-9-]*", key) is None:
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: invalid metadata field",
+                )
+                continue
+            if value and not value.startswith(YAML_SEPARATOR_SPACE):
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    f"metadata field {key!r} must use YAML separation space after ':'",
+                )
+                continue
+            if key not in FRONTMATTER_METADATA_KEYS:
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    f"unsupported metadata field {key!r}",
+                )
+                continue
+            if key in metadata_keys:
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    f"duplicate metadata field {key!r}",
+                )
+                continue
+            metadata_keys.add(key)
+            if value.strip(YAML_SEPARATOR_SPACE).startswith("#"):
+                parsed_value, scalar_error = None, None
+            else:
+                parsed_value, scalar_error = parse_yaml_string_scalar(value, line_number)
+            if scalar_error is not None:
+                if INTERFACE_METADATA_SCALAR_ERROR in scalar_error:
+                    fail(
+                        errors,
+                        f"{path.relative_to(ROOT)}: line {line_number}: "
+                        f"{FRONTMATTER_METADATA_VALUE_ERROR}",
+                    )
+                else:
+                    fail(errors, f"{path.relative_to(ROOT)}: {scalar_error}")
+                continue
+            if parsed_value is None or not parsed_value.strip():
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    f"{FRONTMATTER_METADATA_VALUE_ERROR}",
+                )
+            continue
+
+        active_nested_mapping = None
+        metadata_flow_mapping = False
         key, separator, value = line.partition(":")
-        key = key.strip()
         if separator != ":" or re.fullmatch(r"[a-z][a-z0-9-]*", key) is None:
             fail(
                 errors,
@@ -365,6 +453,23 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
                 f"frontmatter field {key!r} must use YAML separation space after ':'",
             )
             continue
+        if key == "metadata":
+            mapping_value = strip_ascii_space_inline_comment(value)
+            if mapping_value not in {"", "{}"}:
+                fail(
+                    errors,
+                    f"{path.relative_to(ROOT)}: line {line_number}: "
+                    f"{FRONTMATTER_METADATA_SHAPE_ERROR}",
+                )
+                continue
+            if key in root_keys:
+                fail(errors, f"{path.relative_to(ROOT)}: duplicate root frontmatter field 'metadata'")
+                continue
+            root_keys.add(key)
+            metadata_flow_mapping = mapping_value == "{}"
+            active_nested_mapping = None if metadata_flow_mapping else key
+            metadata_keys.clear()
+            continue
         parsed_value, scalar_error = parse_frontmatter_scalar(value, line_number)
         if scalar_error is not None:
             fail(errors, f"{path.relative_to(ROOT)}: {scalar_error}")
@@ -376,25 +481,33 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
                 "disable-model-invocation must be boolean",
             )
             continue
-        if key in values:
+        if key in root_keys:
             if key == "name":
                 message = "expected exactly one root frontmatter name"
             else:
                 message = f"duplicate root frontmatter field {key!r}"
             fail(errors, f"{path.relative_to(ROOT)}: {message}")
             continue
+        root_keys.add(key)
         if parsed_value is not None:
             values[key] = parsed_value
     return values
 
 
 YAML_SEPARATOR_SPACE = " "
+FRONTMATTER_METADATA_KEYS = frozenset(("short-description",))
+FRONTMATTER_METADATA_VALUE_ERROR = (
+    "metadata field 'short-description' must be a non-empty string"
+)
+FRONTMATTER_METADATA_SHAPE_ERROR = (
+    "metadata must be an empty flow mapping or a block mapping"
+)
 YAML_DOCUMENT_MARKER_ERROR = "YAML document markers are not supported in openai.yaml"
 YAML_ROOT_MAPPING_ERROR = "root-level YAML nodes must be supported mappings"
 YAML_UNSUPPORTED_ROOT_MAPPING_ERROR = (
-    "only interface and policy root mappings are supported"
+    "only interface, dependencies, and policy root mappings are supported"
 )
-YAML_SUPPORTED_ROOT_MAPPING_KEYS = frozenset(("interface", "policy"))
+YAML_SUPPORTED_ROOT_MAPPING_KEYS = frozenset(("interface", "dependencies", "policy"))
 YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR = (
     "U+0085, U+2028, and U+2029 are not supported in openai.yaml"
 )
@@ -407,8 +520,13 @@ YAML_UNSUPPORTED_STRUCTURE_SEPARATORS = frozenset(
     ("\u000B", "\u000C", "\u001C", "\u001D", "\u001E")
 )
 YAML_LITERAL_CONTROL_ERROR = (
-    "literal C0 and DEL control characters are not allowed in openai.yaml"
+    "literal C0 and DEL control characters are not allowed in openai.yaml; "
+    "C1 controls and YAML noncharacters are also forbidden"
 )
+YAML_SURROGATE_ERROR = "surrogate Unicode code points are not allowed in YAML scalars"
+YAML_DEPENDENCY_ERROR = "dependencies.tools must be a sequence of supported tool mappings"
+YAML_DEPENDENCY_TOOL_KEYS = frozenset(("type", "value", "description", "transport", "url"))
+YAML_DEPENDENCY_TOOL_TYPE = "mcp"
 YAML_TOKEN_ASCII_CONTINUATIONS = frozenset(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
 )
@@ -443,15 +561,22 @@ def contains_literal_yaml_control(text: str) -> bool:
     return any(
         (ord(character) <= 0x1F and character not in "\t\r\n")
         or ord(character) == 0x7F
+        or 0x80 <= ord(character) <= 0x84
+        or 0x86 <= ord(character) <= 0x9F
+        or ord(character) in {0xFFFE, 0xFFFF}
         for character in text
     )
+
+
+def contains_yaml_surrogate(text: str) -> bool:
+    return any(0xD800 <= ord(character) <= 0xDFFF for character in text)
 
 
 def is_supported_root_mapping_line(stripped: str) -> bool:
     key, separator, value = stripped.partition(":")
     return bool(
         separator
-        and key.strip(" \t")
+        and re.fullmatch(r"[a-z][a-z0-9-]*", key) is not None
         and (not value or value.startswith(YAML_SEPARATOR_SPACE))
     )
 
@@ -459,7 +584,7 @@ def is_supported_root_mapping_line(stripped: str) -> bool:
 def supported_root_mapping_key(stripped: str) -> str | None:
     if not is_supported_root_mapping_line(stripped):
         return None
-    return stripped.partition(":")[0].strip(" \t")
+    return stripped.partition(":")[0]
 
 
 def is_supported_root_mapping_header(stripped: str, key: str) -> bool:
@@ -530,14 +655,153 @@ def is_yaml_document_marker(stripped: str) -> bool:
     )
 
 
+def parse_dependency_tool_field(
+    stripped: str, line_number: int, keys: set[str]
+) -> str | None:
+    key, separator, value = stripped.partition(":")
+    if separator != ":" or key not in YAML_DEPENDENCY_TOOL_KEYS:
+        return f"line {line_number}: {YAML_DEPENDENCY_ERROR}"
+    if value and not value.startswith(YAML_SEPARATOR_SPACE):
+        return (
+            f"line {line_number}: dependency tool field {key!r} must use "
+            "YAML separation space after ':'"
+        )
+    parsed_value, scalar_error = parse_yaml_string_scalar(value, line_number)
+    if scalar_error is not None:
+        return scalar_error
+    if parsed_value is None:
+        return f"line {line_number}: dependency tool field {key!r} must be a string"
+    if key == "type" and parsed_value != YAML_DEPENDENCY_TOOL_TYPE:
+        return (
+            f"line {line_number}: dependency tool type must be "
+            f"{YAML_DEPENDENCY_TOOL_TYPE!r}"
+        )
+    if key == "value" and not parsed_value.strip():
+        return f"line {line_number}: dependency tool field 'value' must be a non-empty string"
+    if key in keys:
+        return f"line {line_number}: duplicate dependency tool field {key!r}"
+    keys.add(key)
+    return None
+
+
+def validate_supported_dependencies(text: str) -> str | None:
+    """Validate the dependency shape supported by Codex's ``openai.yaml`` loader.
+
+    The installed OpenAI schema supports ``type: mcp`` and a non-empty string
+    ``value``, with optional ``description``, ``transport``, and ``url``
+    strings.  This validator intentionally accepts only ``tools: []`` or the
+    block sequence form with four-space items and six-space child fields (the
+    first field may follow ``-`` on the same line).  Flow sequences and inline
+    mapping forms remain unsupported.  A narrow structural check keeps this
+    repository validator aligned with that contract while allowing the other
+    root mappings to be validated by their dedicated checks.
+    """
+    if text.startswith("\ufeff"):
+        text = text[1:]
+
+    active_root: str | None = None
+    dependencies_seen = False
+    tools_seen = False
+    tools_mode: str | None = None
+    tool_keys: set[str] | None = None
+
+    def finish_tool(line_number: int) -> str | None:
+        if tool_keys is None:
+            return None
+        if not {"type", "value"}.issubset(tool_keys):
+            return f"line {line_number}: dependency tool requires type and value"
+        return None
+
+    for line_number, raw_line in enumerate(text.splitlines(), 1):
+        leading = raw_line[: len(raw_line) - len(raw_line.lstrip(" \t"))]
+        if "\t" in leading:
+            return f"line {line_number}: tabs are not allowed for dependency indentation"
+        stripped = raw_line.strip(" \t")
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "\t" in raw_line and active_root == "dependencies":
+            return f"line {line_number}: literal tabs are not supported in dependencies"
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if indent == 0:
+            if tool_error := finish_tool(line_number):
+                return tool_error
+            tool_keys = None
+            if not is_supported_root_mapping_line(stripped):
+                active_root = None
+                continue
+            root_key = supported_root_mapping_key(stripped)
+            active_root = root_key
+            if root_key != "dependencies":
+                continue
+            if not is_supported_root_mapping_header(stripped, "dependencies"):
+                return f"line {line_number}: dependencies must be a root mapping"
+            if dependencies_seen:
+                return f"line {line_number}: duplicate root dependencies mapping"
+            dependencies_seen = True
+            tools_seen = False
+            tools_mode = None
+            continue
+
+        if active_root != "dependencies":
+            continue
+        if indent == 2:
+            if tool_error := finish_tool(line_number):
+                return tool_error
+            tool_keys = None
+            key, separator, value = stripped.partition(":")
+            if separator != ":" or key != "tools":
+                return f"line {line_number}: {YAML_DEPENDENCY_ERROR}"
+            if tools_seen:
+                return f"line {line_number}: duplicate dependencies.tools mapping"
+            if value and not value.startswith(YAML_SEPARATOR_SPACE):
+                return f"line {line_number}: dependencies.tools must use YAML separation space after ':'"
+            tools_seen = True
+            tools_value = strip_ascii_space_inline_comment(value)
+            if tools_value == "[]":
+                tools_mode = "empty"
+            elif tools_value:
+                return f"line {line_number}: {YAML_DEPENDENCY_ERROR}"
+            else:
+                tools_mode = "sequence"
+            continue
+        if not tools_seen or tools_mode == "empty":
+            return f"line {line_number}: {YAML_DEPENDENCY_ERROR}"
+        if indent == 4:
+            if tool_error := finish_tool(line_number):
+                return tool_error
+            tool_keys = None
+            if stripped == "-":
+                tool_keys = set()
+                continue
+            if not stripped.startswith("- "):
+                return f"line {line_number}: {YAML_DEPENDENCY_ERROR}"
+            tool_keys = set()
+            inline_field = stripped[2:].strip()
+            if inline_field and not inline_field.startswith("#"):
+                if field_error := parse_dependency_tool_field(
+                    inline_field, line_number, tool_keys
+                ):
+                    return field_error
+            continue
+        if indent == 6 and tool_keys is not None:
+            if field_error := parse_dependency_tool_field(stripped, line_number, tool_keys):
+                return field_error
+            continue
+        return f"line {line_number}: {YAML_DEPENDENCY_ERROR}"
+
+    return finish_tool(len(text.splitlines()) + 1)
+
+
 def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
     """Parse the deliberately small policy mapping in an openai.yaml file.
 
     A full YAML dependency is unnecessary here. The supported policy shape is
     intentionally strict: one root ``policy:`` mapping with one direct child,
-    alongside the optional ``interface:`` mapping. Every non-comment root line
-    must use one of those two supported mapping keys.
+    alongside the optional ``interface:`` and ``dependencies:`` mappings. Every
+    non-comment root line must use one of the supported mapping keys.
     """
+    if contains_yaml_surrogate(text):
+        return None, YAML_SURROGATE_ERROR
     if contains_unsupported_yaml_structure_separator(text):
         return None, YAML_UNSUPPORTED_STRUCTURE_SEPARATOR_ERROR
     if contains_literal_yaml_control(text):
@@ -546,6 +810,8 @@ def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
         return None, YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR
     if text.startswith("\ufeff"):
         text = text[1:]
+    if dependency_error := validate_supported_dependencies(text):
+        return None, dependency_error
 
     blocks: list[list[tuple[int, str, int]]] = []
     current: list[tuple[int, str, int]] | None = None
@@ -577,6 +843,8 @@ def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
             continue
         if active_root is None:
             return None, f"line {line_number}: {YAML_ROOT_MAPPING_ERROR}"
+        if active_root == "dependencies":
+            continue
         if indent != 2:
             return None, (
                 f"line {line_number}: {active_root} descendants must be direct children "
@@ -594,7 +862,7 @@ def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
     if indent != 2:
         return None, f"line {line_number}: policy child must be directly indented by two spaces"
     key, separator, value = child.partition(":")
-    if separator != ":" or key.strip() != "allow_implicit_invocation":
+    if separator != ":" or key != "allow_implicit_invocation":
         return None, f"line {line_number}: unexpected policy child"
     boolean_value = strip_ascii_space_inline_comment(value)
     if boolean_value not in {"true", "false"}:
@@ -609,7 +877,8 @@ INTERFACE_METADATA_SCALAR_ERROR = (
     "single/double quotes with separation-space comments are supported)"
 )
 LITERAL_SCALAR_CONTROL_ERROR = (
-    "literal C0 and DEL control characters are not allowed in interface metadata scalars"
+    "literal C0 and DEL control characters are not allowed in interface metadata scalars; "
+    "C1 controls and YAML noncharacters are also forbidden"
 )
 
 
@@ -623,6 +892,8 @@ def parse_yaml_string_scalar(value: str, line_number: int) -> tuple[str | None, 
     rejected. Double-quoted YAML escapes remain supported; single-quoted and
     plain backslashes remain literal.
     """
+    if contains_yaml_surrogate(value):
+        return None, f"line {line_number}: {YAML_SURROGATE_ERROR}"
     if contains_unsupported_yaml_line_separator(value):
         return None, f"line {line_number}: {YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR}"
     source = value.strip(YAML_SEPARATOR_SPACE)
@@ -630,7 +901,14 @@ def parse_yaml_string_scalar(value: str, line_number: int) -> tuple[str | None, 
         return None, None
     # The control-character contract is for literal source characters; valid
     # double-quoted escape sequences are decoded below.
-    if any(ord(character) <= 0x1F or ord(character) == 0x7F for character in source):
+    if any(
+        (ord(character) <= 0x1F)
+        or ord(character) == 0x7F
+        or 0x80 <= ord(character) <= 0x84
+        or 0x86 <= ord(character) <= 0x9F
+        or ord(character) in {0xFFFE, 0xFFFF}
+        for character in source
+    ):
         return None, f"line {line_number}: {LITERAL_SCALAR_CONTROL_ERROR}"
 
     def validate_quoted_tail(tail: str) -> str | None:
@@ -710,6 +988,8 @@ def parse_yaml_string_scalar(value: str, line_number: int) -> tuple[str | None, 
                 continue
             return None, f"line {line_number}: invalid double-quoted scalar escape"
         decoded_value = "".join(decoded)
+        if contains_yaml_surrogate(decoded_value):
+            return None, f"line {line_number}: {YAML_SURROGATE_ERROR}"
         if contains_unsupported_yaml_line_separator(decoded_value):
             return None, f"line {line_number}: {YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR}"
         return decoded_value, None
@@ -789,8 +1069,11 @@ def parse_frontmatter_scalar(
 def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
     """Validate direct children of one interface mapping in the supported subset.
 
-    The only supported root mapping keys are ``interface:`` and ``policy:``.
+    The supported root mapping keys are ``interface:``, ``dependencies:``, and
+    ``policy:``.
     """
+    if contains_yaml_surrogate(text):
+        return [YAML_SURROGATE_ERROR]
     if contains_unsupported_yaml_structure_separator(text):
         return [YAML_UNSUPPORTED_STRUCTURE_SEPARATOR_ERROR]
     if contains_literal_yaml_control(text):
@@ -799,6 +1082,8 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
         return [YAML_UNSUPPORTED_LINE_SEPARATOR_ERROR]
     if text.startswith("\ufeff"):
         text = text[1:]
+    if dependency_error := validate_supported_dependencies(text):
+        return [dependency_error]
 
     blocks: list[dict[str, tuple[str | None, int]]] = []
     current: dict[str, tuple[str | None, int]] | None = None
@@ -827,13 +1112,19 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
                     return [f"line {line_number}: interface must be a root mapping"]
                 blocks.append({})
                 current = blocks[-1]
-            else:
+            elif root_key == "policy":
                 if not is_supported_root_mapping_header(stripped, "policy"):
                     return [f"line {line_number}: policy must be a root mapping"]
+                current = None
+            else:
+                if not is_supported_root_mapping_header(stripped, "dependencies"):
+                    return [f"line {line_number}: dependencies must be a root mapping"]
                 current = None
             continue
         if active_root is None:
             return [f"line {line_number}: {YAML_ROOT_MAPPING_ERROR}"]
+        if active_root == "dependencies":
+            continue
         if indent != 2:
             return [
                 f"line {line_number}: {active_root} descendants must be direct children "
@@ -844,7 +1135,6 @@ def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
         key, separator, value = stripped.partition(":")
         if separator != ":":
             return [f"line {line_number}: invalid interface child"]
-        key = key.strip()
         if value and not value.startswith(YAML_SEPARATOR_SPACE):
             return [
                 f"line {line_number}: interface child {key!r} must use YAML separation space after ':'"

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -306,25 +306,85 @@ def check_role_contracts(
                 )
 
 
-def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str]:
+def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str | bool]:
+    """Parse the complete, deliberately flat SKILL.md frontmatter subset."""
     try:
-        text = path.read_text()
+        text = path.read_bytes().decode("utf-8")
+    except UnicodeDecodeError as error:
+        fail(errors, f"{path.relative_to(ROOT)}: frontmatter is not valid UTF-8: {error}")
+        return {}
     except OSError as error:
         fail(errors, f"{path.relative_to(ROOT)}: cannot read: {error}")
         return {}
     if not text.startswith("---\n"):
         fail(errors, f"{path.relative_to(ROOT)}: missing frontmatter")
         return {}
+    lines = text.split("\n")
     try:
-        frontmatter = text.split("---\n", 2)[1]
-    except IndexError:
+        closing_line = lines.index("---", 1)
+    except ValueError:
         fail(errors, f"{path.relative_to(ROOT)}: unterminated frontmatter")
         return {}
-    values: dict[str, str] = {}
-    for line in frontmatter.splitlines():
-        if ":" in line:
-            key, value = line.split(":", 1)
-            values[key.strip()] = value.strip()
+    frontmatter_source = "\n".join(lines[1:closing_line])
+    if (
+        "\r" in frontmatter_source
+        or contains_unsupported_yaml_structure_separator(frontmatter_source)
+        or contains_literal_yaml_control(frontmatter_source)
+        or contains_unsupported_yaml_line_separator(frontmatter_source)
+    ):
+        fail(
+            errors,
+            f"{path.relative_to(ROOT)}: frontmatter contains an unsupported control "
+            "or line separator",
+        )
+        return {}
+    values: dict[str, str | bool] = {}
+    for line_number, line in enumerate(lines[1:closing_line], 2):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if line[:1].isspace():
+            fail(
+                errors,
+                f"{path.relative_to(ROOT)}: line {line_number}: "
+                "nested frontmatter fields are not supported",
+            )
+            continue
+        key, separator, value = line.partition(":")
+        key = key.strip()
+        if separator != ":" or re.fullmatch(r"[a-z][a-z0-9-]*", key) is None:
+            fail(
+                errors,
+                f"{path.relative_to(ROOT)}: line {line_number}: invalid root frontmatter field",
+            )
+            continue
+        if value and not value.startswith(YAML_SEPARATOR_SPACE):
+            fail(
+                errors,
+                f"{path.relative_to(ROOT)}: line {line_number}: "
+                f"frontmatter field {key!r} must use YAML separation space after ':'",
+            )
+            continue
+        parsed_value, scalar_error = parse_frontmatter_scalar(value, line_number)
+        if scalar_error is not None:
+            fail(errors, f"{path.relative_to(ROOT)}: {scalar_error}")
+            continue
+        if key == "disable-model-invocation" and not isinstance(parsed_value, bool):
+            fail(
+                errors,
+                f"{path.relative_to(ROOT)}: line {line_number}: "
+                "disable-model-invocation must be boolean",
+            )
+            continue
+        if key in values:
+            if key == "name":
+                message = "expected exactly one root frontmatter name"
+            else:
+                message = f"duplicate root frontmatter field {key!r}"
+            fail(errors, f"{path.relative_to(ROOT)}: {message}")
+            continue
+        if parsed_value is not None:
+            values[key] = parsed_value
     return values
 
 
@@ -695,7 +755,7 @@ def parse_yaml_string_scalar(value: str, line_number: int) -> tuple[str | None, 
         len(plain) == 1 or plain[1] == YAML_SEPARATOR_SPACE
     ):
         return None, f"line {line_number}: {INTERFACE_METADATA_SCALAR_ERROR}"
-    if re.search(r":[ \t]", plain):
+    if re.search(r":(?:[ \t]|$)", plain):
         return None, f"line {line_number}: {INTERFACE_METADATA_SCALAR_ERROR}"
     if plain.lower() in {"null", "true", "false", "yes", "no", "on", "off", "~"}:
         return None, f"line {line_number}: {INTERFACE_METADATA_SCALAR_ERROR}"
@@ -709,6 +769,21 @@ def parse_yaml_string_scalar(value: str, line_number: int) -> tuple[str | None, 
     if re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}(?:[Tt ].*)?", plain):
         return None, f"line {line_number}: {INTERFACE_METADATA_SCALAR_ERROR}"
     return plain, None
+
+
+def parse_frontmatter_scalar(
+    value: str, line_number: int
+) -> tuple[str | bool | None, str | None]:
+    """Parse a scalar in the supported SKILL.md frontmatter subset."""
+    stripped = value.strip(YAML_SEPARATOR_SPACE)
+    if stripped in {"true", "false"}:
+        return stripped == "true", None
+    parsed, error = parse_yaml_string_scalar(value, line_number)
+    if error is not None:
+        return None, error.replace("interface metadata", "frontmatter")
+    if parsed is None:
+        return None, f"line {line_number}: frontmatter values must be non-empty scalars"
+    return parsed, None
 
 
 def validate_skill_interface_metadata(text: str, skill_name: str) -> list[str]:
@@ -860,7 +935,7 @@ def check_entries_and_assets(errors: list[str]) -> None:
     for skill_name in ("take-ticket", "prepare-backlog"):
         path = ROOT / ".agents" / "skills" / skill_name / "SKILL.md"
         values = parse_frontmatter(path, errors)
-        if values.get("disable-model-invocation") != "true":
+        if values.get("disable-model-invocation") is not True:
             fail(errors, f"{path.relative_to(ROOT)}: entry must be hidden from model invocation")
         try:
             text = path.read_text()
@@ -889,7 +964,7 @@ def check_entries_and_assets(errors: list[str]) -> None:
 
     gatekeeper = ROOT / ".agents" / "skills" / "merge-gatekeeper" / "SKILL.md"
     values = parse_frontmatter(gatekeeper, errors)
-    if values.get("disable-model-invocation") != "true":
+    if values.get("disable-model-invocation") is not True:
         fail(errors, f"{gatekeeper.relative_to(ROOT)}: entry must be hidden from model invocation")
     try:
         text = gatekeeper.read_text()

--- a/scripts/check-agent-organization.py
+++ b/scripts/check-agent-organization.py
@@ -81,6 +81,18 @@ FORBIDDEN_REFERENCES = (
     "pr-checklist-updater",
     "watch-codex-review.sh",
 )
+EXPECTED_SKILL_INVOCATION_POLICY = {
+    "fixture-governance": True,
+    "merge-gatekeeper": False,
+    "open-pr-review-batch": False,
+    "pr-resolution-loop": False,
+    "pr-review-resolution": False,
+    "prepare-backlog": False,
+    "rust-analyzer": True,
+    "safe-direct-merge": False,
+    "spec-governance": True,
+    "take-ticket": False,
+}
 EXPECTED_TRANSITIONS = {
     "untracked": ["research"],
     "research": ["research", "ready", "blocked"],
@@ -313,6 +325,97 @@ def parse_frontmatter(path: Path, errors: list[str]) -> dict[str, str]:
             key, value = line.split(":", 1)
             values[key.strip()] = value.strip()
     return values
+
+
+def parse_skill_invocation_policy(text: str) -> tuple[bool | None, str | None]:
+    """Parse the deliberately small policy mapping in an openai.yaml file.
+
+    A full YAML dependency is unnecessary here. The supported policy shape is
+    intentionally strict: one root ``policy:`` mapping with one direct child.
+    """
+    blocks: list[list[tuple[int, str, int]]] = []
+    current: list[tuple[int, str, int]] | None = None
+    for line_number, raw_line in enumerate(text.splitlines(), 1):
+        leading = raw_line[: len(raw_line) - len(raw_line.lstrip(" \t"))]
+        if "\t" in leading:
+            return None, f"line {line_number}: tabs are not allowed for policy indentation"
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if indent == 0:
+            if re.match(r"^policy\s*:", stripped):
+                if stripped != "policy:":
+                    return None, f"line {line_number}: policy must be a root mapping"
+                blocks.append([])
+                current = blocks[-1]
+            else:
+                current = None
+            continue
+        if current is not None:
+            current.append((indent, stripped, line_number))
+
+    if len(blocks) != 1:
+        return None, "expected exactly one root policy mapping"
+    children = blocks[0]
+    if len(children) != 1:
+        return None, "expected exactly one direct policy child"
+    indent, child, line_number = children[0]
+    if indent != 2:
+        return None, f"line {line_number}: policy child must be directly indented by two spaces"
+    key, separator, value = child.partition(":")
+    if separator != ":" or key.strip() != "allow_implicit_invocation":
+        return None, f"line {line_number}: unexpected policy child"
+    if value.strip() not in {"true", "false"}:
+        return None, f"line {line_number}: allow_implicit_invocation must be boolean"
+    return value.strip() == "true", None
+
+
+def check_skill_inventory(errors: list[str]) -> None:
+    skills_dir = ROOT / ".agents" / "skills"
+    if not skills_dir.is_dir():
+        fail(errors, f"{skills_dir.relative_to(ROOT)}: skill directory is missing")
+        return
+
+    actual = {path.name for path in skills_dir.iterdir() if path.is_dir()}
+    expected = set(EXPECTED_SKILL_INVOCATION_POLICY)
+    for missing in sorted(expected - actual):
+        fail(errors, f".agents/skills/{missing}: inventory entry is missing")
+    for unexpected in sorted(actual - expected):
+        fail(errors, f".agents/skills/{unexpected}: unregistered skill directory")
+
+    for skill_name, allow_implicit in EXPECTED_SKILL_INVOCATION_POLICY.items():
+        metadata_path = skills_dir / skill_name / "agents" / "openai.yaml"
+        if not metadata_path.is_file():
+            fail(errors, f"{metadata_path.relative_to(ROOT)}: metadata is missing")
+            continue
+        try:
+            text = metadata_path.read_text()
+        except OSError as error:
+            fail(errors, f"{metadata_path.relative_to(ROOT)}: cannot read: {error}")
+            continue
+        if not re.search(r"(?m)^interface:\s*$", text):
+            fail(errors, f"{metadata_path.relative_to(ROOT)}: interface block is missing")
+        if not re.search(r"(?m)^\s+display_name:\s*\S+", text):
+            fail(errors, f"{metadata_path.relative_to(ROOT)}: display_name is missing")
+        if not re.search(r"(?m)^\s+short_description:\s*\S+", text):
+            fail(errors, f"{metadata_path.relative_to(ROOT)}: short_description is missing")
+        if not re.search(
+            rf"(?m)^\s+default_prompt:\s*.*\${re.escape(skill_name)}",
+            text,
+        ):
+            fail(errors, f"{metadata_path.relative_to(ROOT)}: default_prompt must mention ${skill_name}")
+        value, policy_error = parse_skill_invocation_policy(text)
+        if policy_error is not None:
+            fail(
+                errors,
+                f"{metadata_path.relative_to(ROOT)}: invalid invocation policy: {policy_error}",
+            )
+        elif value != allow_implicit:
+            fail(
+                errors,
+                f"{metadata_path.relative_to(ROOT)}: allow_implicit_invocation must be {str(allow_implicit).lower()}",
+            )
 
 
 def check_entries_and_assets(errors: list[str]) -> None:
@@ -565,6 +668,7 @@ def main() -> int:
     agents = load_agents(errors)
     check_policy(errors)
     check_role_contracts(agents, errors)
+    check_skill_inventory(errors)
     check_entries_and_assets(errors)
     check_deterministic_assets(errors)
     check_tool_policy_runtime(errors)

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -1195,6 +1195,35 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
             f"errors={frontmatter_errors!r}"
         )
 
+    crlf_frontmatter_fixtures = {
+        "simple": (
+            "---\r\n"
+            "name: fixture-governance\r\n"
+            "description: A CRLF frontmatter fixture.\r\n"
+            "---\r\n",
+            "A CRLF frontmatter fixture.",
+        ),
+        "block": (
+            "---\r\n"
+            "name: fixture-governance\r\n"
+            "description: >-\r\n"
+            "  First line\r\n"
+            "  second line.\r\n"
+            "---\r\n",
+            "First line second line.",
+        ),
+    }
+    for name, (text, expected_description) in crlf_frontmatter_fixtures.items():
+        crlf_path = pathlib.Path(temp_dir) / f"crlf-{name}-SKILL.md"
+        crlf_path.write_bytes(text.encode("utf-8"))
+        frontmatter_errors = []
+        crlf_values = checker.parse_frontmatter(crlf_path, frontmatter_errors)
+        if frontmatter_errors or crlf_values.get("description") != expected_description:
+            raise SystemExit(
+                f"valid CRLF {name} frontmatter was rejected or decoded incorrectly: "
+                f"values={crlf_values!r}, errors={frontmatter_errors!r}"
+            )
+
     malformed_frontmatter = {
         "nested-only-name": (
             "---\n"
@@ -1492,6 +1521,22 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
             "---\n",
             "frontmatter contains an unsupported control or line separator",
         ),
+        "bare-carriage-return": (
+            "---\r\n"
+            "name: fixture-governance\r\n"
+            "description: A valid temporary skill fixture.\r\n"
+            "# bare\rname: other-skill\r\n"
+            "---\r\n",
+            "frontmatter contains an unsupported control or line separator",
+        ),
+        "mixed-line-endings-with-bare-carriage-return": (
+            "---\r\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\r\n"
+            "# bare\rname: other-skill\r\n"
+            "---\r\n",
+            "frontmatter contains an unsupported control or line separator",
+        ),
         "unterminated": (
             "---\n"
             "name: fixture-governance\n",
@@ -1500,7 +1545,7 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
     }
     for name, (text, expected_error) in malformed_frontmatter.items():
         malformed_skill_path = pathlib.Path(temp_dir) / f"{name}.md"
-        malformed_skill_path.write_text(text)
+        malformed_skill_path.write_bytes(text.encode("utf-8"))
         frontmatter_errors = []
         checker.validate_skill_frontmatter_name(
             "fixture-governance",

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -454,6 +454,41 @@ if len(interface_errors) != 1 or unsupported_root_error not in interface_errors[
         f"misplaced interface metadata was accepted: errors={interface_errors!r}"
     )
 
+unknown_interface_child = """\
+interface:
+  display_nmae: Fixture Governance
+  short_description: Create deterministic fixtures.
+  default_prompt: Use $fixture-governance.
+"""
+interface_errors = checker.validate_skill_interface_metadata(
+    unknown_interface_child,
+    "fixture-governance",
+)
+if interface_errors != ["line 2: unsupported interface child 'display_nmae'"]:
+    raise SystemExit(
+        "unknown interface child was accepted: "
+        f"errors={interface_errors!r}"
+    )
+
+optional_interface_fields = """\
+interface:
+  display_name: Fixture Governance
+  short_description: Create deterministic fixtures.
+  icon_small: "icon-small"
+  icon_large: "icon-large"
+  brand_color: "#123456"
+  default_prompt: Use $fixture-governance.
+"""
+interface_errors = checker.validate_skill_interface_metadata(
+    optional_interface_fields,
+    "fixture-governance",
+)
+if interface_errors:
+    raise SystemExit(
+        "supported optional interface fields were rejected: "
+        f"errors={interface_errors!r}"
+    )
+
 invalid_interface_scalars = {
     "empty-display-name": ("display_name", '""', "display_name is missing", False),
     "null-display-name": (
@@ -857,6 +892,28 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
             f"values={commented_values!r}, errors={frontmatter_errors!r}"
         )
 
+    scalar_root_fields_path = pathlib.Path(temp_dir) / "scalar-root-fields-SKILL.md"
+    scalar_root_fields_path.write_text(
+        "---\n"
+        "name: fixture-governance\n"
+        "description: A valid temporary skill fixture.\n"
+        "license: MIT\n"
+        "argument-hint: \"--workspace <path>\"\n"
+        "allowed-tools: \"Read, Bash\"\n"
+        "---\n"
+    )
+    frontmatter_errors = []
+    checker.validate_skill_frontmatter_name(
+        "fixture-governance",
+        scalar_root_fields_path,
+        frontmatter_errors,
+    )
+    if frontmatter_errors:
+        raise SystemExit(
+            "valid scalar root frontmatter fields were rejected: "
+            f"errors={frontmatter_errors!r}"
+        )
+
     malformed_frontmatter = {
         "nested-only-name": (
             "---\n"
@@ -1015,6 +1072,94 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
             "description: [unterminated\n"
             "---\n",
             "frontmatter must be a non-empty YAML string scalar",
+        ),
+        "unsupported-root-field": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "argument-hnit: typo\n"
+            "---\n",
+            "unsupported root frontmatter field 'argument-hnit'",
+        ),
+        "allowed-tools-collection-deferred": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "allowed-tools: [Read, Bash]\n"
+            "---\n",
+            "frontmatter field 'allowed-tools' must be a non-empty string",
+        ),
+        "license-null": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "license: null\n"
+            "---\n",
+            "frontmatter field 'license' must be a non-empty string",
+        ),
+        "license-empty": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "license: \"\"\n"
+            "---\n",
+            "frontmatter field 'license' must be a non-empty string",
+        ),
+        "license-boolean": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "license: true\n"
+            "---\n",
+            "frontmatter field 'license' must be a non-empty string",
+        ),
+        "argument-hint-null": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "argument-hint: null\n"
+            "---\n",
+            "frontmatter field 'argument-hint' must be a non-empty string",
+        ),
+        "argument-hint-empty": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "argument-hint: \"\"\n"
+            "---\n",
+            "frontmatter field 'argument-hint' must be a non-empty string",
+        ),
+        "argument-hint-boolean": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "argument-hint: false\n"
+            "---\n",
+            "frontmatter field 'argument-hint' must be a non-empty string",
+        ),
+        "allowed-tools-null": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "allowed-tools: null\n"
+            "---\n",
+            "frontmatter field 'allowed-tools' must be a non-empty string",
+        ),
+        "allowed-tools-empty": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "allowed-tools: \"\"\n"
+            "---\n",
+            "frontmatter field 'allowed-tools' must be a non-empty string",
+        ),
+        "allowed-tools-boolean": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "allowed-tools: true\n"
+            "---\n",
+            "frontmatter field 'allowed-tools' must be a non-empty string",
         ),
         "control-in-comment": (
             "---\n"

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -166,6 +166,96 @@ for name, child_value in {
             f"value={policy_value!r}, error={policy_error!r}"
         )
 
+nested_policy = (
+    "policy:\n"
+    "  allow_implicit_invocation: false\n"
+    "    unexpected: value\n"
+)
+policy_value, policy_error = checker.parse_skill_invocation_policy(nested_policy)
+if (
+    policy_value is not None
+    or policy_error is None
+    or "policy descendants must be direct children" not in policy_error
+):
+    raise SystemExit(
+        "over-indented policy descendant was accepted: "
+        f"value={policy_value!r}, error={policy_error!r}"
+    )
+
+nested_interface = (
+    "interface:\n"
+    "  display_name: Fixture Governance\n"
+    "    unexpected: value\n"
+    "  short_description: Create deterministic fixtures.\n"
+    "  default_prompt: Use $fixture-governance.\n"
+)
+interface_errors = checker.validate_skill_interface_metadata(
+    nested_interface,
+    "fixture-governance",
+)
+if (
+    len(interface_errors) != 1
+    or "interface descendants must be direct children" not in interface_errors[0]
+):
+    raise SystemExit(
+        "over-indented interface descendant was accepted: "
+        f"errors={interface_errors!r}"
+    )
+
+policy_parser_nested_interface = (
+    "interface:\n"
+    "  display_name: Fixture Governance\n"
+    "    unexpected: value\n"
+    "policy:\n"
+    "  allow_implicit_invocation: false\n"
+)
+policy_value, policy_error = checker.parse_skill_invocation_policy(
+    policy_parser_nested_interface
+)
+if (
+    policy_value is not None
+    or policy_error is None
+    or "interface descendants must be direct children" not in policy_error
+):
+    raise SystemExit(
+        "policy parser accepted an over-indented interface descendant: "
+        f"value={policy_value!r}, error={policy_error!r}"
+    )
+
+interface_parser_nested_policy = (
+    "policy:\n"
+    "  allow_implicit_invocation: false\n"
+    "    unexpected: value\n"
+    "interface:\n"
+    "  display_name: Fixture Governance\n"
+    "  short_description: Create deterministic fixtures.\n"
+    "  default_prompt: Use $fixture-governance.\n"
+)
+interface_errors = checker.validate_skill_interface_metadata(
+    interface_parser_nested_policy,
+    "fixture-governance",
+)
+if (
+    len(interface_errors) != 1
+    or "policy descendants must be direct children" not in interface_errors[0]
+):
+    raise SystemExit(
+        "interface parser accepted an over-indented policy descendant: "
+        f"errors={interface_errors!r}"
+    )
+
+nested_comment_policy = (
+    "policy:\n"
+    "  allow_implicit_invocation: false\n"
+    "    # nested comments remain comments\n"
+)
+policy_value, policy_error = checker.parse_skill_invocation_policy(nested_comment_policy)
+if policy_value is not False or policy_error is not None:
+    raise SystemExit(
+        "valid indented policy comment was rejected: "
+        f"value={policy_value!r}, error={policy_error!r}"
+    )
+
 root_mapping_error = "root-level YAML nodes must be supported mappings"
 for root_line in ("policy:\u00a0# comment", "interface:\u00a0# comment"):
     policy_value, policy_error = checker.parse_skill_invocation_policy(
@@ -187,6 +277,33 @@ for root_line in ("policy:\u00a0# comment", "interface:\u00a0# comment"):
         raise SystemExit(
             f"non-ASCII interface root comment separator was accepted: "
             f"line={root_line!r}, errors={interface_errors!r}"
+        )
+
+unsupported_structure_separator_error = (
+    "U+000B, U+000C, U+001C, U+001D, and U+001E are not supported "
+    "as YAML line separators in openai.yaml"
+)
+for separator in ("\u000B", "\u000C", "\u001C", "\u001D", "\u001E"):
+    policy_value, policy_error = checker.parse_skill_invocation_policy(
+        "policy:"
+        f"{separator}  allow_implicit_invocation: false\n"
+    )
+    if policy_value is not None or policy_error != unsupported_structure_separator_error:
+        raise SystemExit(
+            f"policy structure separator U+{ord(separator):04X} was accepted: "
+            f"value={policy_value!r}, error={policy_error!r}"
+        )
+    interface_errors = checker.validate_skill_interface_metadata(
+        "interface:"
+        f"{separator}  display_name: Fixture Governance\n"
+        "  short_description: Create deterministic fixtures.\n"
+        "  default_prompt: Use $fixture-governance.\n",
+        "fixture-governance",
+    )
+    if interface_errors != [unsupported_structure_separator_error]:
+        raise SystemExit(
+            f"interface structure separator U+{ord(separator):04X} was accepted: "
+            f"errors={interface_errors!r}"
         )
 
 for marker in ("---", "..."):
@@ -454,6 +571,13 @@ interface: # interface mapping comment
   default_prompt: Use $fixture-governance.
 policy: # policy mapping comment
 """,
+    "indented-comment": """\
+interface:
+  display_name: Fixture Governance
+    # nested comments remain comments
+  short_description: Create safe fixtures.
+  default_prompt: Use $fixture-governance.
+""",
     "bom-prefix": "\ufeffinterface:\n"
     "  display_name: Fixture Governance\n"
     "  short_description: Create deterministic fixtures.\n"
@@ -543,6 +667,30 @@ for scalar in (
             f"escaped line separator {scalar!r} was not rejected: "
             f"parsed={parsed!r}, error={parse_error!r}"
         )
+
+for separator in ("\u000B", "\u000C", "\u001C", "\u001D", "\u001E"):
+    parsed, parse_error = checker.parse_yaml_string_scalar(
+        f"Fixture{separator}Governance",
+        1,
+    )
+    if (
+        parsed is not None
+        or parse_error is None
+        or checker.LITERAL_SCALAR_CONTROL_ERROR not in parse_error
+        or unsupported_structure_separator_error in parse_error
+    ):
+        raise SystemExit(
+            f"literal scalar separator U+{ord(separator):04X} used the wrong contract: "
+            f"parsed={parsed!r}, error={parse_error!r}"
+        )
+
+escaped_structure_separator = r'"Fixture\u000bGovernance"'
+parsed, parse_error = checker.parse_yaml_string_scalar(escaped_structure_separator, 1)
+if parse_error is not None or parsed != "Fixture\u000bGovernance":
+    raise SystemExit(
+        "escaped structure separator was not decoded as a scalar escape: "
+        f"parsed={parsed!r}, error={parse_error!r}"
+    )
 
 escaped_control = '"Fixture ' + chr(92) + "u0001Governance\""
 parsed, parse_error = checker.parse_yaml_string_scalar(escaped_control, 1)

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -73,6 +73,7 @@ check_skill_policy_structure_negative() {
   PYTHONDONTWRITEBYTECODE=1 python3 - <<'PY'
 import importlib.util
 import pathlib
+import tempfile
 
 checker_path = pathlib.Path("scripts/check-agent-organization.py")
 spec = importlib.util.spec_from_file_location("rpm_agent_organization", checker_path)
@@ -164,6 +165,32 @@ for name, child_value in {
         raise SystemExit(
             f"invalid boolean comment {name} was accepted: child={child_value!r}, "
             f"value={policy_value!r}, error={policy_error!r}"
+        )
+
+literal_yaml_control_error = checker.YAML_LITERAL_CONTROL_ERROR
+for control in ("\x00", "\x01", "\x1f", "\x7f"):
+    policy_value, policy_error = checker.parse_skill_invocation_policy(
+        "policy:\n"
+        "  allow_implicit_invocation: false # comment"
+        f"{control}\n"
+    )
+    if policy_value is not None or policy_error != literal_yaml_control_error:
+        raise SystemExit(
+            f"policy control U+{ord(control):04X} was accepted after comment stripping: "
+            f"value={policy_value!r}, error={policy_error!r}"
+        )
+    interface_errors = checker.validate_skill_interface_metadata(
+        "interface:\n"
+        "  display_name: Fixture Governance\n"
+        "  short_description: Create safe fixtures.\n"
+        "  default_prompt: Use $fixture-governance. # comment"
+        f"{control}\n",
+        "fixture-governance",
+    )
+    if interface_errors != [literal_yaml_control_error]:
+        raise SystemExit(
+            f"interface control U+{ord(control):04X} was accepted in a comment: "
+            f"errors={interface_errors!r}"
         )
 
 nested_policy = (
@@ -590,6 +617,26 @@ for name, text in valid_interface_scalars.items():
     )
     if interface_errors:
         raise SystemExit(f"{name} was rejected: errors={interface_errors!r}")
+
+with tempfile.TemporaryDirectory(dir=".") as temp_dir:
+    mismatched_skill_path = pathlib.Path(temp_dir) / "SKILL.md"
+    mismatched_skill_path.write_text(
+        "---\n"
+        "name: other-skill\n"
+        "description: A valid temporary skill fixture.\n"
+        "---\n"
+    )
+    frontmatter_errors = []
+    checker.validate_skill_frontmatter_name(
+        "fixture-governance",
+        mismatched_skill_path,
+        frontmatter_errors,
+    )
+    if len(frontmatter_errors) != 1 or "does not match inventory entry" not in frontmatter_errors[0]:
+        raise SystemExit(
+            "mismatched SKILL.md name was accepted: "
+            f"errors={frontmatter_errors!r}"
+        )
 
 nbspace_value = "Fixture" + chr(0xA0) + "#Governance"
 parsed, parse_error = checker.parse_yaml_string_scalar(nbspace_value, 1)

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -522,6 +522,12 @@ invalid_interface_scalars = {
         "literal tabs are not supported in interface metadata",
         False,
     ),
+    "plain-trailing-colon": (
+        "display_name",
+        "Fixture Governance:",
+        "interface metadata must be a non-empty YAML string scalar",
+        False,
+    ),
     **{
         f"plain-{name}-indicator": (
             "display_name",
@@ -637,6 +643,86 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
             "mismatched SKILL.md name was accepted: "
             f"errors={frontmatter_errors!r}"
         )
+
+    malformed_frontmatter = {
+        "nested-only-name": (
+            "---\n"
+            "metadata:\n"
+            "  name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "---\n",
+            "frontmatter name is missing",
+        ),
+        "duplicate-root-name": (
+            "---\n"
+            "name: fixture-governance\n"
+            "name: fixture-governance\n"
+            "---\n",
+            "expected exactly one root frontmatter name",
+        ),
+        "duplicate-invocation-control": (
+            "---\n"
+            "name: fixture-governance\n"
+            "disable-model-invocation: false\n"
+            "disable-model-invocation: true\n"
+            "---\n",
+            "duplicate root frontmatter field 'disable-model-invocation'",
+        ),
+        "quoted-invocation-control": (
+            "---\n"
+            "name: fixture-governance\n"
+            'disable-model-invocation: "true"\n'
+            "---\n",
+            "disable-model-invocation must be boolean",
+        ),
+        "quoted-duplicate-root-name": (
+            "---\n"
+            '"name": other-skill\n'
+            "name: fixture-governance\n"
+            "---\n",
+            "invalid root frontmatter field",
+        ),
+        "unterminated-collection": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: [unterminated\n"
+            "---\n",
+            "frontmatter must be a non-empty YAML string scalar",
+        ),
+        "control-in-comment": (
+            "---\n"
+            "name: fixture-governance\n"
+            "# first\u000b# second\n"
+            "---\n",
+            "frontmatter contains an unsupported control or line separator",
+        ),
+        "carriage-return-in-comment": (
+            "---\n"
+            "name: fixture-governance\n"
+            "# first\rname: other-skill\n"
+            "---\n",
+            "frontmatter contains an unsupported control or line separator",
+        ),
+        "unterminated": (
+            "---\n"
+            "name: fixture-governance\n",
+            "unterminated frontmatter",
+        ),
+    }
+    for name, (text, expected_error) in malformed_frontmatter.items():
+        malformed_skill_path = pathlib.Path(temp_dir) / f"{name}.md"
+        malformed_skill_path.write_text(text)
+        frontmatter_errors = []
+        checker.validate_skill_frontmatter_name(
+            "fixture-governance",
+            malformed_skill_path,
+            frontmatter_errors,
+        )
+        if not any(expected_error in error for error in frontmatter_errors):
+            raise SystemExit(
+                f"{name} SKILL.md frontmatter was accepted: "
+                f"errors={frontmatter_errors!r}"
+            )
 
 nbspace_value = "Fixture" + chr(0xA0) + "#Governance"
 parsed, parse_error = checker.parse_yaml_string_scalar(nbspace_value, 1)

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -69,6 +69,33 @@ check() {
   fi
 }
 
+check_skill_policy_structure_negative() {
+  PYTHONDONTWRITEBYTECODE=1 python3 - <<'PY'
+import importlib.util
+import pathlib
+
+checker_path = pathlib.Path("scripts/check-agent-organization.py")
+spec = importlib.util.spec_from_file_location("rpm_agent_organization", checker_path)
+checker = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(checker)
+
+malformed = {
+    "empty-policy": "policy:\n",
+    "relocated-child": "policy:\nallow_implicit_invocation: false\n",
+    "interface-child": "interface:\n  allow_implicit_invocation: false\npolicy:\n",
+    "nested-child": "policy:\n    allow_implicit_invocation: false\n",
+    "duplicate-policy": "policy:\n  allow_implicit_invocation: false\npolicy:\n  allow_implicit_invocation: false\n",
+    "duplicate-child": "policy:\n  allow_implicit_invocation: false\n  allow_implicit_invocation: false\n",
+    "non-boolean": "policy:\n  allow_implicit_invocation: \"false\"\n",
+}
+for name, text in malformed.items():
+    value, error = checker.parse_skill_invocation_policy(text)
+    if error is None:
+        raise SystemExit(f"{name} was accepted: value={value!r}")
+PY
+}
+
 if [ "${RPM_VALIDATE_AGENT_WORKFLOW_ASSETS_REGRESSION:-}" = "1" ]; then
   check_summary_formatter() {
     local output
@@ -86,6 +113,7 @@ if [ "${RPM_VALIDATE_AGENT_WORKFLOW_ASSETS_REGRESSION:-}" = "1" ]; then
   }
 
   check "summary_formatter" check_summary_formatter
+  check "skill_policy_structure_negative" check_skill_policy_structure_negative
   printf 'agent_assets.status=%s\n' "${status}"
   [ "${status}" = "ok" ] || exit 1
   exit 0
@@ -722,6 +750,7 @@ check "script_validate_agent_workflow_assets_syntax" \
   bash -n scripts/validate-agent-workflow-assets.sh
 
 check "summary_suppresses_skips" check_summary_suppresses_skips
+check "skill_policy_structure_negative" check_skill_policy_structure_negative
 check "just_test_verbosity" check_just_test_verbosity
 
 check "collect_pr_review_context_paginates" check_collect_paginates_comments_and_reviews

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -118,6 +118,196 @@ if not expected_errors.issubset(interface_errors):
     raise SystemExit(
         f"misplaced interface metadata was accepted: errors={sorted(interface_errors)!r}"
     )
+
+invalid_interface_scalars = {
+    "empty-display-name": ("display_name", '""', "display_name is missing", False),
+    "null-display-name": (
+        "display_name",
+        "null",
+        "interface metadata must be a non-empty YAML string scalar",
+        False,
+    ),
+    "empty-prompt-comment": (
+        "default_prompt",
+        '"" # $fixture-governance',
+        "default_prompt is missing",
+        False,
+    ),
+    "unmatched-quote": (
+        "display_name",
+        '"Fixture Governance',
+        "unterminated double-quoted scalar",
+        False,
+    ),
+    "literal-c0-control": (
+        "display_name",
+        '"Fixture ' + chr(1) + 'Governance"',
+        "literal C0 and DEL control characters",
+        False,
+    ),
+    "literal-del-control": (
+        "display_name",
+        '"Fixture ' + chr(127) + 'Governance"',
+        "literal C0 and DEL control characters",
+        False,
+    ),
+    "literal-single-c0-control": (
+        "short_description",
+        "'Create " + chr(1) + " fixtures.'",
+        "literal C0 and DEL control characters",
+        False,
+    ),
+    "literal-single-del-control": (
+        "short_description",
+        "'Create " + chr(127) + " fixtures.'",
+        "literal C0 and DEL control characters",
+        False,
+    ),
+    "literal-plain-c0-control": (
+        "short_description",
+        "Create" + chr(1) + " fixtures.",
+        "literal C0 and DEL control characters",
+        False,
+    ),
+    "literal-plain-del-control": (
+        "short_description",
+        "Create" + chr(127) + " fixtures.",
+        "literal C0 and DEL control characters",
+        False,
+    ),
+    "tab-separation": (
+        "display_name",
+        chr(9) + "Fixture Governance",
+        "literal tabs are not supported in interface metadata",
+        True,
+    ),
+    "quoted-trailing-tab": (
+        "display_name",
+        '"Fixture Governance"' + chr(9),
+        "literal tabs are not supported in interface metadata",
+        False,
+    ),
+    "plain-trailing-tab": (
+        "short_description",
+        "Create fixtures." + chr(9),
+        "literal tabs are not supported in interface metadata",
+        False,
+    ),
+    **{
+        f"plain-{name}-indicator": (
+            "display_name",
+            value,
+            "interface metadata must be a non-empty YAML string scalar",
+            False,
+        )
+        for name, value in {
+            "dash": "- value",
+            "question": "? value",
+            "colon": ": value",
+            "comma": ",value",
+            "at": "@value",
+            "percent": "%value",
+            "backtick": "`value`",
+        }.items()
+    },
+    "missing-separation-space": (
+        "display_name",
+        "Fixture Governance",
+        "must use YAML separation space",
+        True,
+    ),
+}
+for name, (field, value, expected_error, omit_space) in invalid_interface_scalars.items():
+    fields = {
+        "display_name": '"Fixture Governance"',
+        "short_description": '"Create deterministic fixtures."',
+        "default_prompt": '"Use $fixture-governance for fixtures."',
+    }
+    fields[field] = value
+    text = "interface:\n" + "\n".join(
+        f"  {key}:{'' if omit_space and key == field else ' '}{value}"
+        for key, value in fields.items()
+    ) + "\n"
+    interface_errors = checker.validate_skill_interface_metadata(
+        text,
+        "fixture-governance",
+    )
+    if len(interface_errors) != 1 or expected_error not in interface_errors[0]:
+        raise SystemExit(
+            f"{name} did not report {expected_error!r}: errors={interface_errors!r}"
+        )
+
+valid_interface_scalars = {
+    "double-quoted-escape": """\
+interface:
+  display_name: "Fixture \\u0047overnance"
+  short_description: "Create deterministic fixtures."
+  default_prompt: "Use $fixture-governance."
+""",
+    "single-quoted-doubled-apostrophe": """\
+interface:
+  display_name: Fixture Governance
+  short_description: 'Create ''safe'' fixtures.'
+  default_prompt: "Use $fixture-governance."
+""",
+    "inline-comment": """\
+interface:
+  display_name: Fixture Governance
+  short_description: Create safe fixtures.
+  default_prompt: Use $fixture-governance # trailing comment
+""",
+    "hash-without-space": """\
+interface:
+  display_name: Fixture#Governance
+  short_description: Create safe# fixtures.
+  default_prompt: Use $fixture-governance.
+""",
+}
+for name, text in valid_interface_scalars.items():
+    interface_errors = checker.validate_skill_interface_metadata(
+        text,
+        "fixture-governance",
+    )
+    if interface_errors:
+        raise SystemExit(f"{name} was rejected: errors={interface_errors!r}")
+
+nbspace_value = "Fixture" + chr(0xA0) + "#Governance"
+parsed, parse_error = checker.parse_yaml_string_scalar(nbspace_value, 1)
+if parse_error is not None or parsed != nbspace_value:
+    raise SystemExit(
+        f"NBSP before # was not preserved: parsed={parsed!r}, error={parse_error!r}"
+    )
+nbspace_interface = (
+    "interface:\n"
+    f"  display_name: {nbspace_value}\n"
+    "  short_description: Create safe fixtures.\n"
+    "  default_prompt: Use $fixture-governance.\n"
+)
+interface_errors = checker.validate_skill_interface_metadata(
+    nbspace_interface,
+    "fixture-governance",
+)
+if interface_errors:
+    raise SystemExit(f"NBSP interface value was rejected: errors={interface_errors!r}")
+
+escaped_control = '"Fixture ' + chr(92) + "u0001Governance\""
+parsed, parse_error = checker.parse_yaml_string_scalar(escaped_control, 1)
+if parse_error is not None or parsed != "Fixture \x01Governance":
+    raise SystemExit(
+        f"escaped control was not decoded: parsed={parsed!r}, error={parse_error!r}"
+    )
+
+literal_escape = chr(92) + "u0001"
+for name, scalar in {
+    "single-quoted-literal-escape": "'" + literal_escape + "'",
+    "plain-literal-escape": literal_escape,
+}.items():
+    parsed, parse_error = checker.parse_yaml_string_scalar(scalar, 1)
+    if parse_error is not None or parsed != literal_escape:
+        raise SystemExit(
+            f"{name} was decoded outside double quotes: "
+            f"parsed={parsed!r}, error={parse_error!r}"
+        )
 PY
 }
 

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -89,6 +89,7 @@ malformed = {
     "duplicate-policy": "policy:\n  allow_implicit_invocation: false\npolicy:\n  allow_implicit_invocation: false\n",
     "duplicate-child": "policy:\n  allow_implicit_invocation: false\n  allow_implicit_invocation: false\n",
     "non-boolean": "policy:\n  allow_implicit_invocation: \"false\"\n",
+    "missing-separation-space": "policy:\n  allow_implicit_invocation:false\n",
     "document-start": "---\npolicy:\n  allow_implicit_invocation: false\n",
     "document-end": "policy:\n  allow_implicit_invocation: false\n...\n",
     "multiple-documents": "policy:\n  allow_implicit_invocation: false\n---\npolicy:\n  allow_implicit_invocation: true\n",
@@ -151,7 +152,6 @@ for expected, child_value in (
 
 boolean_error = "allow_implicit_invocation must be boolean"
 for name, child_value in {
-    "no-space-comment": "false#comment",
     "nbsp-comment": "false\u00a0#comment",
     "quoted-boolean-comment": '"false" # comment',
     "quoted-hash-content": '"false # comment"',
@@ -164,6 +164,25 @@ for name, child_value in {
     if policy_value is not None or policy_error is None or boolean_error not in policy_error:
         raise SystemExit(
             f"invalid boolean comment {name} was accepted: child={child_value!r}, "
+            f"value={policy_value!r}, error={policy_error!r}"
+        )
+
+separation_space_error = "policy child 'allow_implicit_invocation' must use YAML separation space"
+for name, child_value in {
+    "missing-separation-space": "false",
+    "no-space-comment": "false#comment",
+}.items():
+    policy_value, policy_error = checker.parse_skill_invocation_policy(
+        "policy:\n"
+        f"  allow_implicit_invocation:{child_value}\n"
+    )
+    if (
+        policy_value is not None
+        or policy_error is None
+        or separation_space_error not in policy_error
+    ):
+        raise SystemExit(
+            f"invalid policy separation space {name} was accepted: child={child_value!r}, "
             f"value={policy_value!r}, error={policy_error!r}"
         )
 
@@ -763,6 +782,18 @@ invalid_dependencies = {
         ),
         checker.YAML_DEPENDENCY_ERROR,
     ),
+    "null-tools": (
+        valid_interface_scalars["dependencies-tools"].replace(
+            "  tools:\n"
+            "    - type: \"mcp\"\n"
+            "      value: \"github\"\n"
+            "      description: \"GitHub MCP server\"\n"
+            "      transport: \"streamable_http\"\n"
+            "      url: \"https://api.githubcopilot.com/mcp/\"\n",
+            "  tools:\n",
+        ),
+        checker.YAML_DEPENDENCY_ERROR,
+    ),
 }
 for name, (text, expected_error) in invalid_dependencies.items():
     dependency_error = checker.validate_supported_dependencies(text)
@@ -805,6 +836,25 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
         raise SystemExit(
             "mismatched SKILL.md name was accepted: "
             f"errors={frontmatter_errors!r}"
+        )
+
+    commented_invocation_path = pathlib.Path(temp_dir) / "commented-SKILL.md"
+    commented_invocation_path.write_text(
+        "---\n"
+        "name: fixture-governance\n"
+        "disable-model-invocation: true # explicit-only entry\n"
+        "description: A valid temporary skill fixture.\n"
+        "---\n"
+    )
+    frontmatter_errors = []
+    commented_values = checker.parse_frontmatter(
+        commented_invocation_path,
+        frontmatter_errors,
+    )
+    if frontmatter_errors or commented_values.get("disable-model-invocation") is not True:
+        raise SystemExit(
+            "commented boolean frontmatter was rejected: "
+            f"values={commented_values!r}, errors={frontmatter_errors!r}"
         )
 
     malformed_frontmatter = {

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -93,6 +93,31 @@ for name, text in malformed.items():
     value, error = checker.parse_skill_invocation_policy(text)
     if error is None:
         raise SystemExit(f"{name} was accepted: value={value!r}")
+
+misplaced_interface = """\
+interface:
+other:
+  display_name: "Fixture Governance"
+  short_description: "Create deterministic fixtures."
+  default_prompt: "Use $fixture-governance for fixtures."
+policy:
+  allow_implicit_invocation: true
+"""
+interface_errors = set(
+    checker.validate_skill_interface_metadata(
+        misplaced_interface,
+        "fixture-governance",
+    )
+)
+expected_errors = {
+    "display_name is missing",
+    "short_description is missing",
+    "default_prompt is missing",
+}
+if not expected_errors.issubset(interface_errors):
+    raise SystemExit(
+        f"misplaced interface metadata was accepted: errors={sorted(interface_errors)!r}"
+    )
 PY
 }
 

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -866,6 +866,33 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
             "---\n",
             "frontmatter name is missing",
         ),
+        "missing-description": (
+            "---\n"
+            "name: fixture-governance\n"
+            "---\n",
+            "frontmatter description is missing",
+        ),
+        "null-description": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: null\n"
+            "---\n",
+            "frontmatter must be a non-empty YAML string scalar",
+        ),
+        "empty-description": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: \"\"\n"
+            "---\n",
+            "frontmatter description must be a non-empty string",
+        ),
+        "non-string-description": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: true\n"
+            "---\n",
+            "frontmatter description must be a non-empty string",
+        ),
         "unsupported-metadata-child": (
             "---\n"
             "name: fixture-governance\n"

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -1042,6 +1042,159 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
             f"errors={frontmatter_errors!r}"
         )
 
+    def block_skill(header, body):
+        return (
+            "---\n"
+            "name: fixture-governance\n"
+            f"description: {header}\n"
+            f"{body}"
+            "---\n"
+        )
+
+    block_description_fixtures = {
+        "folded": (
+            ">",
+            "  First line\n  second line.\n",
+            "First line second line.\n",
+        ),
+        "literal": (
+            "|",
+            "  First line\n  second line.\n",
+            "First line\nsecond line.\n",
+        ),
+        "folded-strip": (
+            ">- # strip the final line break",
+            "  First line\n  second line.\n",
+            "First line second line.",
+        ),
+        "literal-keep": (
+            "|+",
+            "  First line\n  second line.\n\n",
+            "First line\nsecond line.\n\n",
+        ),
+        "explicit-indent": (
+            "|2-",
+            "    First line\n    second line.\n",
+            "  First line\n  second line.",
+        ),
+        "reversed-indicators": (
+            ">-2",
+            "  First line\n  second line.\n",
+            "First line second line.",
+        ),
+        "more-indented-line": (
+            ">",
+            "  First line\n    indented line\n  second line.\n",
+            "First line\n  indented line\nsecond line.\n",
+        ),
+        "tab-in-header-comment": (
+            "| #\tcomment",
+            "  First line\n",
+            "First line\n",
+        ),
+        "tab-in-content": (
+            "|",
+            "  First line\n  \tsecond\n",
+            "First line\n\tsecond\n",
+        ),
+    }
+    for name, (header, body, expected_description) in block_description_fixtures.items():
+        text = block_skill(header, body)
+        block_path = pathlib.Path(temp_dir) / f"{name}-block-SKILL.md"
+        block_path.write_text(text)
+        frontmatter_errors = []
+        block_values = checker.parse_frontmatter(block_path, frontmatter_errors)
+        if frontmatter_errors or block_values.get("description") != expected_description:
+            raise SystemExit(
+                f"valid {name} description block was rejected or decoded incorrectly: "
+                f"values={block_values!r}, errors={frontmatter_errors!r}"
+            )
+
+    invalid_block_descriptions = {
+        "empty": ("|", "", "frontmatter description must be a non-empty string"),
+        "invalid-header": (
+            ">0",
+            "  body\n",
+            "frontmatter description block scalar header must use",
+        ),
+        "tab-in-header-structure": (
+            "| \t#comment",
+            "  body\n",
+            "frontmatter description block scalar header must use",
+        ),
+        "tab-indentation": (
+            "|",
+            "  first line\n\tsecond\n",
+            "frontmatter indentation must use ASCII spaces",
+        ),
+        "invalid-indentation": (
+            ">",
+            "    first line\n  second line\n",
+            "frontmatter description block scalar content must be indented consistently",
+        ),
+        "leading-blank-indentation": (
+            "|",
+            "   \n  first line\n",
+            "frontmatter description block scalar content must be indented consistently",
+        ),
+        "todo": (
+            ">",
+            "  [TODO: fill this in]\n",
+            "frontmatter description contains an unfinished TODO placeholder",
+        ),
+        "angle-bracket": (
+            "|",
+            "  Use <path> safely.\n",
+            "frontmatter description cannot contain angle brackets (< or >)",
+        ),
+        "long": (
+            "|",
+            "  " + ("a" * 1025) + "\n",
+            "frontmatter description is too long",
+        ),
+    }
+    for name, (header, body, expected_error) in invalid_block_descriptions.items():
+        text = block_skill(header, body)
+        block_path = pathlib.Path(temp_dir) / f"invalid-{name}-block-SKILL.md"
+        block_path.write_text(text)
+        frontmatter_errors = []
+        checker.validate_skill_frontmatter_name(
+            "fixture-governance",
+            block_path,
+            frontmatter_errors,
+        )
+        if not any(expected_error in error for error in frontmatter_errors):
+            raise SystemExit(
+                f"invalid {name} description block was accepted: "
+                f"errors={frontmatter_errors!r}"
+            )
+
+    non_description_block_path = (
+        pathlib.Path(temp_dir) / "non-description-block-SKILL.md"
+    )
+    non_description_block_path.write_text(
+        "---\n"
+        "name: fixture-governance\n"
+        "description: A valid temporary skill fixture.\n"
+        "license: |\n"
+        "  MIT\n"
+        "---\n"
+    )
+    frontmatter_errors = []
+    checker.validate_skill_frontmatter_name(
+        "fixture-governance",
+        non_description_block_path,
+        frontmatter_errors,
+    )
+    if not any(
+        "frontmatter field 'license' must be a non-empty string" in error
+        for error in frontmatter_errors
+    ):
+        raise SystemExit(
+            "non-description block scalar crossed the documented boundary: "
+            f"errors={frontmatter_errors!r}"
+        )
+
     malformed_frontmatter = {
         "nested-only-name": (
             "---\n"

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -88,11 +88,179 @@ malformed = {
     "duplicate-policy": "policy:\n  allow_implicit_invocation: false\npolicy:\n  allow_implicit_invocation: false\n",
     "duplicate-child": "policy:\n  allow_implicit_invocation: false\n  allow_implicit_invocation: false\n",
     "non-boolean": "policy:\n  allow_implicit_invocation: \"false\"\n",
+    "document-start": "---\npolicy:\n  allow_implicit_invocation: false\n",
+    "document-end": "policy:\n  allow_implicit_invocation: false\n...\n",
+    "multiple-documents": "policy:\n  allow_implicit_invocation: false\n---\npolicy:\n  allow_implicit_invocation: true\n",
+    "bom-document-start": "\ufeff---\npolicy:\n  allow_implicit_invocation: false\n",
+    "bom-document-end": "\ufeff...\npolicy:\n  allow_implicit_invocation: false\n",
+    "bom-document-end-after-policy": "policy:\n  allow_implicit_invocation: false\n\ufeff...\n",
 }
 for name, text in malformed.items():
     value, error = checker.parse_skill_invocation_policy(text)
     if error is None:
         raise SystemExit(f"{name} was accepted: value={value!r}")
+
+document_marker_error = "YAML document markers are not supported in openai.yaml"
+for name in (
+    "document-start",
+    "document-end",
+    "multiple-documents",
+    "bom-document-start",
+    "bom-document-end",
+    "bom-document-end-after-policy",
+):
+    _, error = checker.parse_skill_invocation_policy(malformed[name])
+    if error is None or document_marker_error not in error:
+        raise SystemExit(f"{name} did not report a document marker error: {error!r}")
+
+bom_policy_value, bom_policy_error = checker.parse_skill_invocation_policy(
+    "\ufeffpolicy:\n  allow_implicit_invocation: false\n"
+)
+if bom_policy_value is not False or bom_policy_error is not None:
+    raise SystemExit(
+        "valid BOM-prefixed policy was rejected: "
+        f"value={bom_policy_value!r}, error={bom_policy_error!r}"
+    )
+
+policy_comment_value, policy_comment_error = checker.parse_skill_invocation_policy(
+    "interface: # interface mapping comment\n"
+    "policy: # policy mapping comment\n"
+    "  allow_implicit_invocation: false\n"
+)
+if policy_comment_value is not False or policy_comment_error is not None:
+    raise SystemExit(
+        "valid root mapping comments were rejected by policy parser: "
+        f"value={policy_comment_value!r}, error={policy_comment_error!r}"
+    )
+
+for expected, child_value in (
+    (False, "false # comment"),
+    (True, "true  # comment"),
+    (False, "false #comment # trailing"),
+):
+    policy_value, policy_error = checker.parse_skill_invocation_policy(
+        "policy:\n"
+        f"  allow_implicit_invocation: {child_value}\n"
+    )
+    if policy_value is not expected or policy_error is not None:
+        raise SystemExit(
+            f"valid boolean comment was rejected: child={child_value!r}, "
+            f"value={policy_value!r}, error={policy_error!r}"
+        )
+
+boolean_error = "allow_implicit_invocation must be boolean"
+for name, child_value in {
+    "no-space-comment": "false#comment",
+    "nbsp-comment": "false\u00a0#comment",
+    "quoted-boolean-comment": '"false" # comment',
+    "quoted-hash-content": '"false # comment"',
+    "tab-comment": "false\t# comment",
+}.items():
+    policy_value, policy_error = checker.parse_skill_invocation_policy(
+        "policy:\n"
+        f"  allow_implicit_invocation: {child_value}\n"
+    )
+    if policy_value is not None or policy_error is None or boolean_error not in policy_error:
+        raise SystemExit(
+            f"invalid boolean comment {name} was accepted: child={child_value!r}, "
+            f"value={policy_value!r}, error={policy_error!r}"
+        )
+
+root_mapping_error = "root-level YAML nodes must be supported mappings"
+for root_line in ("policy:\u00a0# comment", "interface:\u00a0# comment"):
+    policy_value, policy_error = checker.parse_skill_invocation_policy(
+        f"{root_line}\n  allow_implicit_invocation: false\n"
+    )
+    if policy_value is not None or policy_error is None or root_mapping_error not in policy_error:
+        raise SystemExit(
+            f"non-ASCII policy root comment separator was accepted: "
+            f"line={root_line!r}, value={policy_value!r}, error={policy_error!r}"
+        )
+    interface_errors = checker.validate_skill_interface_metadata(
+        f"{root_line}\n"
+        "  display_name: Fixture Governance\n"
+        "  short_description: Create deterministic fixtures.\n"
+        "  default_prompt: Use $fixture-governance.\n",
+        "fixture-governance",
+    )
+    if len(interface_errors) != 1 or root_mapping_error not in interface_errors[0]:
+        raise SystemExit(
+            f"non-ASCII interface root comment separator was accepted: "
+            f"line={root_line!r}, errors={interface_errors!r}"
+        )
+
+for marker in ("---", "..."):
+    for prefix in ("", "\ufeff"):
+        for interface_with_marker in (
+            f"{prefix}{marker}\ninterface:\n",
+            "interface:\n"
+            "  display_name: Fixture Governance\n"
+            "  short_description: Create deterministic fixtures.\n"
+            "  default_prompt: Use $fixture-governance.\n"
+            f"{prefix}{marker}\n",
+        ):
+            interface_errors = checker.validate_skill_interface_metadata(
+                interface_with_marker,
+                "fixture-governance",
+            )
+            if len(interface_errors) != 1 or document_marker_error not in interface_errors[0]:
+                raise SystemExit(
+                    f"interface {prefix + marker!r} marker was accepted: "
+                    f"errors={interface_errors!r}"
+                )
+
+root_scalars = (
+    '"---"',
+    "---#comment",
+    "...foo",
+    "\u00a0\"---\"",
+    "\u00a0...foo",
+    "\u00a0#comment",
+)
+for root_scalar in root_scalars:
+    policy_text = (
+        "policy:\n"
+        "  allow_implicit_invocation: false\n"
+        f"{root_scalar}\n"
+    )
+    policy_value, policy_error = checker.parse_skill_invocation_policy(policy_text)
+    if policy_error is None or root_mapping_error not in policy_error:
+        raise SystemExit(
+            f"policy root scalar {root_scalar!r} was accepted: "
+            f"value={policy_value!r}, error={policy_error!r}"
+        )
+    interface_text = (
+        "interface:\n"
+        "  display_name: Fixture Governance\n"
+        "  short_description: Create deterministic fixtures.\n"
+        "  default_prompt: Use $fixture-governance.\n"
+        f"{root_scalar}\n"
+    )
+    interface_errors = checker.validate_skill_interface_metadata(
+        interface_text,
+        "fixture-governance",
+    )
+    if len(interface_errors) != 1 or root_mapping_error not in interface_errors[0]:
+        raise SystemExit(
+            f"interface root scalar {root_scalar!r} was accepted: "
+            f"errors={interface_errors!r}"
+        )
+
+unsupported_root_error = "only interface and policy root mappings are supported"
+for unknown_value in ("value", "[unclosed", '"unmatched', "{unclosed"):
+    policy_with_unknown_root = (
+        f"extra: {unknown_value}\n"
+        "policy:\n"
+        "  allow_implicit_invocation: false\n"
+    )
+    policy_value, policy_error = checker.parse_skill_invocation_policy(
+        policy_with_unknown_root
+    )
+    if policy_value is not None or policy_error is None or unsupported_root_error not in policy_error:
+        raise SystemExit(
+            f"unknown policy root value {unknown_value!r} was accepted: "
+            f"value={policy_value!r}, error={policy_error!r}"
+        )
 
 misplaced_interface = """\
 interface:
@@ -103,20 +271,13 @@ other:
 policy:
   allow_implicit_invocation: true
 """
-interface_errors = set(
-    checker.validate_skill_interface_metadata(
-        misplaced_interface,
-        "fixture-governance",
-    )
+interface_errors = checker.validate_skill_interface_metadata(
+    misplaced_interface,
+    "fixture-governance",
 )
-expected_errors = {
-    "display_name is missing",
-    "short_description is missing",
-    "default_prompt is missing",
-}
-if not expected_errors.issubset(interface_errors):
+if len(interface_errors) != 1 or unsupported_root_error not in interface_errors[0]:
     raise SystemExit(
-        f"misplaced interface metadata was accepted: errors={sorted(interface_errors)!r}"
+        f"misplaced interface metadata was accepted: errors={interface_errors!r}"
     )
 
 invalid_interface_scalars = {
@@ -131,6 +292,30 @@ invalid_interface_scalars = {
         "default_prompt",
         '"" # $fixture-governance',
         "default_prompt is missing",
+        False,
+    ),
+    "longer-skill-prefix": (
+        "default_prompt",
+        '"Use $fixture-governance-extra."',
+        "default_prompt must mention $fixture-governance",
+        False,
+    ),
+    "combining-mark-skill-suffix": (
+        "default_prompt",
+        '"Use $fixture-governance\u0301."',
+        "default_prompt must mention $fixture-governance",
+        False,
+    ),
+    "zero-width-joiner-skill-suffix": (
+        "default_prompt",
+        '"Use $fixture-governance\u200dfoo."',
+        "default_prompt must mention $fixture-governance",
+        False,
+    ),
+    "variation-selector-skill-suffix": (
+        "default_prompt",
+        '"Use $fixture-governance\ufe0f."',
+        "default_prompt must mention $fixture-governance",
         False,
     ),
     "unmatched-quote": (
@@ -262,6 +447,17 @@ interface:
   short_description: Create safe# fixtures.
   default_prompt: Use $fixture-governance.
 """,
+    "root-mapping-comment": """\
+interface: # interface mapping comment
+  display_name: Fixture Governance
+  short_description: Create safe fixtures.
+  default_prompt: Use $fixture-governance.
+policy: # policy mapping comment
+""",
+    "bom-prefix": "\ufeffinterface:\n"
+    "  display_name: Fixture Governance\n"
+    "  short_description: Create deterministic fixtures.\n"
+    "  default_prompt: Use $fixture-governance.\n",
 }
 for name, text in valid_interface_scalars.items():
     interface_errors = checker.validate_skill_interface_metadata(
@@ -290,11 +486,76 @@ interface_errors = checker.validate_skill_interface_metadata(
 if interface_errors:
     raise SystemExit(f"NBSP interface value was rejected: errors={interface_errors!r}")
 
+for unknown_value in ("value", "[unclosed", '"unmatched', "{unclosed"):
+    interface_with_unknown_root = (
+        f"extra: {unknown_value}\n"
+        "interface:\n"
+        "  display_name: Fixture Governance\n"
+        "  short_description: Create deterministic fixtures.\n"
+        "  default_prompt: Use $fixture-governance.\n"
+    )
+    interface_errors = checker.validate_skill_interface_metadata(
+        interface_with_unknown_root,
+        "fixture-governance",
+    )
+    if len(interface_errors) != 1 or unsupported_root_error not in interface_errors[0]:
+        raise SystemExit(
+            f"unknown interface root value {unknown_value!r} was accepted: "
+            f"errors={interface_errors!r}"
+        )
+
+unsupported_line_separator_error = (
+    "U+0085, U+2028, and U+2029 are not supported in openai.yaml"
+)
+for separator in ("\u0085", "\u2028", "\u2029"):
+    policy_value, policy_error = checker.parse_skill_invocation_policy(
+        "policy:\n"
+        "  allow_implicit_invocation: false"
+        f"{separator}\n"
+    )
+    if policy_value is not None or policy_error != unsupported_line_separator_error:
+        raise SystemExit(
+            f"policy line separator U+{ord(separator):04X} was not rejected: "
+            f"value={policy_value!r}, error={policy_error!r}"
+        )
+    interface_errors = checker.validate_skill_interface_metadata(
+        "interface:\n"
+        f"  display_name: Fixture{separator}Governance\n"
+        "  short_description: Create deterministic fixtures.\n"
+        "  default_prompt: Use $fixture-governance.\n",
+        "fixture-governance",
+    )
+    if interface_errors != [unsupported_line_separator_error]:
+        raise SystemExit(
+            f"interface line separator U+{ord(separator):04X} was not rejected: "
+            f"errors={interface_errors!r}"
+        )
+
+for scalar in (
+    r'"Fixture\u2028Governance"',
+    r'"Fixture\u2029Governance"',
+    r'"Fixture\x85Governance"',
+):
+    parsed, parse_error = checker.parse_yaml_string_scalar(scalar, 1)
+    expected_scalar_error = f"line 1: {unsupported_line_separator_error}"
+    if parsed is not None or parse_error != expected_scalar_error:
+        raise SystemExit(
+            f"escaped line separator {scalar!r} was not rejected: "
+            f"parsed={parsed!r}, error={parse_error!r}"
+        )
+
 escaped_control = '"Fixture ' + chr(92) + "u0001Governance\""
 parsed, parse_error = checker.parse_yaml_string_scalar(escaped_control, 1)
 if parse_error is not None or parsed != "Fixture \x01Governance":
     raise SystemExit(
         f"escaped control was not decoded: parsed={parsed!r}, error={parse_error!r}"
+    )
+
+escaped_del_control = '"Fixture ' + chr(92) + "u007fGovernance\""
+parsed, parse_error = checker.parse_yaml_string_scalar(escaped_del_control, 1)
+if parse_error is not None or parsed != "Fixture \x7fGovernance":
+    raise SystemExit(
+        f"escaped DEL control was not decoded: parsed={parsed!r}, error={parse_error!r}"
     )
 
 literal_escape = chr(92) + "u0001"
@@ -307,6 +568,36 @@ for name, scalar in {
         raise SystemExit(
             f"{name} was decoded outside double quotes: "
             f"parsed={parsed!r}, error={parse_error!r}"
+        )
+
+skill_name = "fixture-governance"
+token = f"${skill_name}"
+token_boundary_cases = {
+    "at-end": (token, True),
+    "space": (token + " next", True),
+    "nbsp": (token + "\u00a0next", True),
+    "period": (token + ".", True),
+    "comma": (token + ",", True),
+    "exclamation": (token + "!", True),
+    "question": (token + "?", True),
+    "colon": (token + ":", True),
+    "hash": (token + "#note", True),
+    "ascii-name-continuation": (token + "extra", False),
+    "ascii-hyphen-continuation": (token + "-extra", False),
+    "leading-ascii-name-continuation": ("x" + token, False),
+    "unicode-letter-continuation": (token + "é", False),
+    "unicode-number-continuation": (token + "²", False),
+    "combining-mark": (token + "\u0301", False),
+    "zero-width-joiner": (token + "\u200dfoo", False),
+    "variation-selector": (token + "\ufe0f", False),
+    "format-character": (token + "\u2060", False),
+}
+for name, (prompt, expected) in token_boundary_cases.items():
+    actual = checker.has_complete_skill_token(prompt, skill_name)
+    if actual != expected:
+        raise SystemExit(
+            f"token boundary {name} disagreed: prompt={prompt!r}, "
+            f"expected={expected!r}, actual={actual!r}"
         )
 PY
 }

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -474,8 +474,8 @@ optional_interface_fields = """\
 interface:
   display_name: Fixture Governance
   short_description: Create deterministic fixtures.
-  icon_small: "icon-small"
-  icon_large: "icon-large"
+  icon_small: "assets/icon-small.svg"
+  icon_large: "assets/icon-large.png"
   brand_color: "#123456"
   default_prompt: Use $fixture-governance.
 """
@@ -488,6 +488,114 @@ if interface_errors:
         "supported optional interface fields were rejected: "
         f"errors={interface_errors!r}"
     )
+
+with tempfile.TemporaryDirectory(dir=".") as temp_dir:
+    skill_root = pathlib.Path(temp_dir) / "fixture-governance"
+    assets_dir = skill_root / "assets"
+    assets_dir.mkdir(parents=True)
+    (assets_dir / "icon-small.svg").write_text("<svg />")
+    (assets_dir / "icon-large.png").write_bytes(b"fixture")
+    outside_asset = pathlib.Path(temp_dir) / "outside.svg"
+    outside_asset.write_text("<svg />")
+    external_link = assets_dir / "external-link.svg"
+    try:
+        external_link.symlink_to(outside_asset)
+    except OSError as error:
+        raise SystemExit(f"could not create external icon symlink fixture: {error}")
+    valid_interface_asset_paths = """\
+interface:
+  display_name: Fixture Governance
+  short_description: Create deterministic fixtures.
+  icon_small: "./assets/icon-small.svg"
+  icon_large: "./assets/icon-large.png"
+  brand_color: "#123456"
+  default_prompt: Use $fixture-governance.
+"""
+    interface_errors = checker.validate_skill_interface_metadata(
+        valid_interface_asset_paths,
+        "fixture-governance",
+        skill_root,
+    )
+    if interface_errors:
+        raise SystemExit(
+            "valid interface asset paths were rejected: "
+            f"errors={interface_errors!r}"
+        )
+
+    invalid_interface_values = {
+        "icon-traversal": (
+            '  icon_small: "./assets/icon-small.svg"',
+            '  icon_small: "../../outside.png"',
+            "must stay inside the skill directory",
+        ),
+        "icon-missing": (
+            '  icon_large: "./assets/icon-large.png"',
+            '  icon_large: "./assets/missing.png"',
+            "points to a missing file",
+        ),
+        "icon-skill-file": (
+            '  icon_small: "./assets/icon-small.svg"',
+            '  icon_small: "./SKILL.md"',
+            "must stay inside the skill directory",
+        ),
+        "icon-absolute": (
+            '  icon_small: "./assets/icon-small.svg"',
+            '  icon_small: "/assets/icon-small.svg"',
+            "must stay inside the skill directory",
+        ),
+        "icon-unc": (
+            '  icon_small: "./assets/icon-small.svg"',
+            '  icon_small: "//server/share/icon.svg"',
+            "must stay inside the skill directory",
+        ),
+        "icon-windows-drive": (
+            '  icon_small: "./assets/icon-small.svg"',
+            '  icon_small: "C:/assets/icon-small.svg"',
+            "skill-relative POSIX path under 'assets'",
+        ),
+        "icon-windows-drive-backslash": (
+            '  icon_small: "./assets/icon-small.svg"',
+            r"  icon_small: 'C:\assets\icon-small.svg'",
+            "skill-relative POSIX path under 'assets'",
+        ),
+        "icon-unc-backslash": (
+            '  icon_small: "./assets/icon-small.svg"',
+            r"  icon_small: '\\server\share\icon.svg'",
+            "skill-relative POSIX path under 'assets'",
+        ),
+        "icon-backslash-traversal": (
+            '  icon_small: "./assets/icon-small.svg"',
+            r"  icon_small: 'assets\..\outside.svg'",
+            "skill-relative POSIX path under 'assets'",
+        ),
+        "icon-case-mismatch": (
+            '  icon_small: "./assets/icon-small.svg"',
+            '  icon_small: "./assets/ICON-small.svg"',
+            "path component spelling must match the on-disk name exactly",
+        ),
+        "icon-external-symlink": (
+            '  icon_small: "./assets/icon-small.svg"',
+            '  icon_small: "./assets/external-link.svg"',
+            "must resolve to a file inside skill assets",
+        ),
+        "invalid-brand-color": (
+            '  brand_color: "#123456"',
+            "  brand_color: not-a-color",
+            "interface field 'brand_color' must use #RRGGBB",
+        ),
+    }
+    for name, (needle, replacement, expected_error) in invalid_interface_values.items():
+        invalid_text = valid_interface_asset_paths.replace(needle, replacement)
+        interface_errors = checker.validate_skill_interface_metadata(
+            invalid_text,
+            "fixture-governance",
+            skill_root,
+        )
+        if len(interface_errors) != 1 or expected_error not in interface_errors[0]:
+            raise SystemExit(
+                f"invalid interface value {name} was accepted: "
+                f"errors={interface_errors!r}"
+            )
 
 invalid_interface_scalars = {
     "empty-display-name": ("display_name", '""', "display_name is missing", False),
@@ -914,6 +1022,26 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
             f"errors={frontmatter_errors!r}"
         )
 
+    description_limit_path = pathlib.Path(temp_dir) / "description-limit-SKILL.md"
+    description_limit_path.write_text(
+        "---\n"
+        "name: fixture-governance\n"
+        "description: "
+        + ("a" * 1024)
+        + "\n---\n"
+    )
+    frontmatter_errors = []
+    checker.validate_skill_frontmatter_name(
+        "fixture-governance",
+        description_limit_path,
+        frontmatter_errors,
+    )
+    if frontmatter_errors:
+        raise SystemExit(
+            "description at the 1024-character limit was rejected: "
+            f"errors={frontmatter_errors!r}"
+        )
+
     malformed_frontmatter = {
         "nested-only-name": (
             "---\n"
@@ -949,6 +1077,28 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
             "description: true\n"
             "---\n",
             "frontmatter description must be a non-empty string",
+        ),
+        "todo-description": (
+            "---\n"
+            "name: fixture-governance\n"
+            'description: "[TODO: fill this in]"\n'
+            "---\n",
+            "frontmatter description contains an unfinished TODO placeholder",
+        ),
+        "angle-bracket-description": (
+            "---\n"
+            "name: fixture-governance\n"
+            'description: "Use <path> safely."\n'
+            "---\n",
+            "frontmatter description cannot contain angle brackets (< or >)",
+        ),
+        "long-description": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: "
+            + ("a" * 1025)
+            + "\n---\n",
+            "frontmatter description is too long",
         ),
         "unsupported-metadata-child": (
             "---\n"

--- a/scripts/validate-agent-workflow-assets.sh
+++ b/scripts/validate-agent-workflow-assets.sh
@@ -168,7 +168,18 @@ for name, child_value in {
         )
 
 literal_yaml_control_error = checker.YAML_LITERAL_CONTROL_ERROR
-for control in ("\x00", "\x01", "\x1f", "\x7f"):
+for control in (
+    "\x00",
+    "\x01",
+    "\x1f",
+    "\x7f",
+    "\x80",
+    "\x84",
+    "\x86",
+    "\x9f",
+    "\ufffe",
+    "\uffff",
+):
     policy_value, policy_error = checker.parse_skill_invocation_policy(
         "policy:\n"
         "  allow_implicit_invocation: false # comment"
@@ -390,7 +401,7 @@ for root_scalar in root_scalars:
             f"errors={interface_errors!r}"
         )
 
-unsupported_root_error = "only interface and policy root mappings are supported"
+unsupported_root_error = "only interface, dependencies, and policy root mappings are supported"
 for unknown_value in ("value", "[unclosed", '"unmatched', "{unclosed"):
     policy_with_unknown_root = (
         f"extra: {unknown_value}\n"
@@ -466,6 +477,18 @@ invalid_interface_scalars = {
         "display_name",
         '"Fixture Governance',
         "unterminated double-quoted scalar",
+        False,
+    ),
+    "surrogate-short-escape": (
+        "display_name",
+        r'"Fixture\uD800Governance"',
+        "surrogate Unicode code points are not allowed in YAML scalars",
+        False,
+    ),
+    "surrogate-long-escape": (
+        "display_name",
+        r'"Fixture\U0000D800Governance"',
+        "surrogate Unicode code points are not allowed in YAML scalars",
         False,
     ),
     "literal-c0-control": (
@@ -604,6 +627,21 @@ interface: # interface mapping comment
   default_prompt: Use $fixture-governance.
 policy: # policy mapping comment
 """,
+    "dependencies-tools": """\
+interface:
+  display_name: Fixture Governance
+  short_description: Create safe fixtures.
+  default_prompt: Use $fixture-governance.
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "github"
+      description: "GitHub MCP server"
+      transport: "streamable_http"
+      url: "https://api.githubcopilot.com/mcp/"
+policy:
+  allow_implicit_invocation: false
+""",
     "indented-comment": """\
 interface:
   display_name: Fixture Governance
@@ -623,6 +661,131 @@ for name, text in valid_interface_scalars.items():
     )
     if interface_errors:
         raise SystemExit(f"{name} was rejected: errors={interface_errors!r}")
+
+dependencies_policy_value, dependencies_policy_error = checker.parse_skill_invocation_policy(
+    valid_interface_scalars["dependencies-tools"]
+)
+if dependencies_policy_value is not False or dependencies_policy_error is not None:
+    raise SystemExit(
+        "supported dependencies.tools declaration was rejected by policy parser: "
+        f"value={dependencies_policy_value!r}, error={dependencies_policy_error!r}"
+    )
+
+figma_dependencies = valid_interface_scalars["dependencies-tools"].replace(
+    'value: "github"',
+    'value: "figma"',
+)
+figma_interface_errors = checker.validate_skill_interface_metadata(
+    figma_dependencies,
+    "fixture-governance",
+)
+if figma_interface_errors:
+    raise SystemExit(
+        "Figma-style dependencies.tools declaration was rejected by interface parser: "
+        f"errors={figma_interface_errors!r}"
+    )
+figma_policy_value, figma_policy_error = checker.parse_skill_invocation_policy(
+    figma_dependencies
+)
+if figma_policy_value is not False or figma_policy_error is not None:
+    raise SystemExit(
+        "Figma-style dependencies.tools declaration was rejected by policy parser: "
+        f"value={figma_policy_value!r}, error={figma_policy_error!r}"
+    )
+
+empty_tools_dependencies = valid_interface_scalars["dependencies-tools"].replace(
+    "  tools:\n"
+    "    - type: \"mcp\"\n"
+    "      value: \"github\"\n"
+    "      description: \"GitHub MCP server\"\n"
+    "      transport: \"streamable_http\"\n"
+    "      url: \"https://api.githubcopilot.com/mcp/\"\n",
+    "  tools: []\n",
+)
+empty_tools_interface_errors = checker.validate_skill_interface_metadata(
+    empty_tools_dependencies,
+    "fixture-governance",
+)
+if empty_tools_interface_errors:
+    raise SystemExit(
+        "empty dependencies.tools sequence was rejected by interface parser: "
+        f"errors={empty_tools_interface_errors!r}"
+    )
+empty_tools_policy_value, empty_tools_policy_error = checker.parse_skill_invocation_policy(
+    empty_tools_dependencies
+)
+if empty_tools_policy_value is not False or empty_tools_policy_error is not None:
+    raise SystemExit(
+        "empty dependencies.tools sequence was rejected by policy parser: "
+        f"value={empty_tools_policy_value!r}, error={empty_tools_policy_error!r}"
+    )
+
+invalid_dependencies = {
+    "shell-type": (
+        valid_interface_scalars["dependencies-tools"].replace(
+            'type: "mcp"',
+            'type: "shell"',
+        ),
+        "dependency tool type must be 'mcp'",
+    ),
+    "command-field": (
+        valid_interface_scalars["dependencies-tools"].replace(
+            '      value: "github"\n',
+            '      value: "github"\n      command: "npx"\n',
+        ),
+        checker.YAML_DEPENDENCY_ERROR,
+    ),
+    "unknown-field": (
+        valid_interface_scalars["dependencies-tools"].replace(
+            '      value: "github"\n',
+            '      value: "github"\n      executable: "npx"\n',
+        ),
+        checker.YAML_DEPENDENCY_ERROR,
+    ),
+    "empty-value": (
+        valid_interface_scalars["dependencies-tools"].replace(
+            'value: "github"',
+            'value: ""',
+        ),
+        "dependency tool field 'value' must be a non-empty string",
+    ),
+    "missing-value": (
+        valid_interface_scalars["dependencies-tools"].replace(
+            '      value: "github"\n',
+            '',
+        ),
+        "dependency tool requires type and value",
+    ),
+    "flow-sequence": (
+        empty_tools_dependencies.replace(
+            "tools: []",
+            'tools: [{type: "mcp", value: "figma"}]',
+        ),
+        checker.YAML_DEPENDENCY_ERROR,
+    ),
+}
+for name, (text, expected_error) in invalid_dependencies.items():
+    dependency_error = checker.validate_supported_dependencies(text)
+    if dependency_error is None or expected_error not in dependency_error:
+        raise SystemExit(
+            f"invalid dependency fixture {name} was accepted: "
+            f"error={dependency_error!r}"
+        )
+    interface_errors = checker.validate_skill_interface_metadata(
+        text,
+        "fixture-governance",
+    )
+    if len(interface_errors) != 1 or expected_error not in interface_errors[0]:
+        raise SystemExit(
+            f"interface parser accepted invalid dependency fixture {name}: "
+            f"errors={interface_errors!r}"
+        )
+    policy_value, policy_error = checker.parse_skill_invocation_policy(text)
+    if policy_value is not None or policy_error is None or expected_error not in policy_error:
+        raise SystemExit(
+            f"policy parser accepted invalid dependency fixture {name}: "
+            f"value={policy_value!r}, error={policy_error!r}"
+        )
 
 with tempfile.TemporaryDirectory(dir=".") as temp_dir:
     mismatched_skill_path = pathlib.Path(temp_dir) / "SKILL.md"
@@ -652,6 +815,93 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
             "description: A valid temporary skill fixture.\n"
             "---\n",
             "frontmatter name is missing",
+        ),
+        "unsupported-metadata-child": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "metadata:\n"
+            "  name: fixture-governance\n"
+            "---\n",
+            "unsupported metadata field 'name'",
+        ),
+        "duplicate-metadata-child": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "metadata:\n"
+            "  short-description: first\n"
+            "  short-description: second\n"
+            "---\n",
+            "duplicate metadata field 'short-description'",
+        ),
+        "missing-metadata-short-description": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "metadata:\n"
+            "  short-description:\n"
+            "---\n",
+            "metadata field 'short-description' must be a non-empty string",
+        ),
+        "null-metadata-short-description": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "metadata:\n"
+            "  short-description: null\n"
+            "---\n",
+            "metadata field 'short-description' must be a non-empty string",
+        ),
+        "quoted-empty-metadata-short-description": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "metadata:\n"
+            "  short-description: \"\"\n"
+            "---\n",
+            "metadata field 'short-description' must be a non-empty string",
+        ),
+        "quoted-whitespace-metadata-short-description": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "metadata:\n"
+            "  short-description: \"   \"\n"
+            "---\n",
+            "metadata field 'short-description' must be a non-empty string",
+        ),
+        "flow-metadata-child": (
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "metadata: {}\n"
+            "  short-description: child\n"
+            "---\n",
+            "metadata flow mapping cannot contain indented children",
+        ),
+        "leading-tab": (
+            "---\n"
+            "\tname: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "---\n",
+            "frontmatter indentation must use ASCII spaces",
+        ),
+        "leading-nbsp": (
+            "---\n"
+            + chr(0xA0)
+            + "name: fixture-governance\n"
+            + "description: A valid temporary skill fixture.\n"
+            + "---\n",
+            "frontmatter indentation must use ASCII spaces",
+        ),
+        "leading-unicode-space": (
+            "---\n"
+            + chr(0x2003)
+            + "name: fixture-governance\n"
+            + "description: A valid temporary skill fixture.\n"
+            + "---\n",
+            "frontmatter indentation must use ASCII spaces",
         ),
         "duplicate-root-name": (
             "---\n"
@@ -696,6 +946,20 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
             "---\n",
             "frontmatter contains an unsupported control or line separator",
         ),
+        "c1-control-in-comment": (
+            "---\n"
+            "name: fixture-governance\n"
+            "# first" + chr(0x80) + "# second\n"
+            "---\n",
+            "frontmatter contains an unsupported control or line separator",
+        ),
+        "yaml-noncharacter-in-comment": (
+            "---\n"
+            "name: fixture-governance\n"
+            "# first" + chr(0xFFFE) + "# second\n"
+            "---\n",
+            "frontmatter contains an unsupported control or line separator",
+        ),
         "carriage-return-in-comment": (
             "---\n"
             "name: fixture-governance\n"
@@ -723,6 +987,147 @@ with tempfile.TemporaryDirectory(dir=".") as temp_dir:
                 f"{name} SKILL.md frontmatter was accepted: "
                 f"errors={frontmatter_errors!r}"
             )
+
+    for space_name, space in (
+        ("ascii-space", " "),
+        ("nbsp", "\u00a0"),
+        ("em-space", "\u2003"),
+    ):
+        root_key_path = pathlib.Path(temp_dir) / f"root-key-{space_name}.md"
+        root_key_path.write_text(
+            "---\n"
+            f"name{space}: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "---\n"
+        )
+        frontmatter_errors = []
+        checker.validate_skill_frontmatter_name(
+            "fixture-governance",
+            root_key_path,
+            frontmatter_errors,
+        )
+        if not any("invalid root frontmatter field" in error for error in frontmatter_errors):
+            raise SystemExit(
+                f"root key with {space_name} before ':' was accepted: "
+                f"errors={frontmatter_errors!r}"
+            )
+
+        metadata_key_path = pathlib.Path(temp_dir) / f"metadata-key-{space_name}.md"
+        metadata_key_path.write_text(
+            "---\n"
+            "name: fixture-governance\n"
+            "description: A valid temporary skill fixture.\n"
+            "metadata:\n"
+            f"  short-description{space}: Fixture metadata\n"
+            "---\n"
+        )
+        frontmatter_errors = []
+        checker.validate_skill_frontmatter_name(
+            "fixture-governance",
+            metadata_key_path,
+            frontmatter_errors,
+        )
+        if not any("invalid metadata field" in error for error in frontmatter_errors):
+            raise SystemExit(
+                f"metadata key with {space_name} before ':' was accepted: "
+                f"errors={frontmatter_errors!r}"
+            )
+
+        for dependency_field in ("type", "value"):
+            dependency_text = valid_interface_scalars["dependencies-tools"].replace(
+                f"{dependency_field}: ",
+                f"{dependency_field}{space}: ",
+                1,
+            )
+            dependency_error = checker.validate_supported_dependencies(dependency_text)
+            if dependency_error is None or checker.YAML_DEPENDENCY_ERROR not in dependency_error:
+                raise SystemExit(
+                    f"dependency {dependency_field} key with {space_name} before ':' "
+                    f"was accepted: error={dependency_error!r}"
+                )
+
+    nested_metadata_skill_path = pathlib.Path(temp_dir) / "nested-metadata.md"
+    nested_metadata_skill_path.write_text(
+        "---\n"
+        "name: fixture-governance\n"
+        "description: A valid temporary skill fixture.\n"
+        "metadata:\n"
+        "  short-description: Fixture metadata\n"
+        "---\n"
+    )
+    frontmatter_errors = []
+    checker.validate_skill_frontmatter_name(
+        "fixture-governance",
+        nested_metadata_skill_path,
+        frontmatter_errors,
+    )
+    if frontmatter_errors:
+        raise SystemExit(
+            "supported nested SKILL.md metadata was rejected: "
+            f"errors={frontmatter_errors!r}"
+        )
+
+    empty_flow_metadata_skill_path = pathlib.Path(temp_dir) / "empty-flow-metadata.md"
+    empty_flow_metadata_skill_path.write_text(
+        "---\n"
+        "name: fixture-governance\n"
+        "description: A valid temporary skill fixture.\n"
+        "metadata: {}\n"
+        "---\n"
+    )
+    frontmatter_errors = []
+    checker.validate_skill_frontmatter_name(
+        "fixture-governance",
+        empty_flow_metadata_skill_path,
+        frontmatter_errors,
+    )
+    if frontmatter_errors:
+        raise SystemExit(
+            "empty flow-map SKILL.md metadata was rejected: "
+            f"errors={frontmatter_errors!r}"
+        )
+
+    empty_block_metadata_skill_path = pathlib.Path(temp_dir) / "empty-block-metadata.md"
+    empty_block_metadata_skill_path.write_text(
+        "---\n"
+        "name: fixture-governance\n"
+        "description: A valid temporary skill fixture.\n"
+        "metadata:\n"
+        "---\n"
+    )
+    frontmatter_errors = []
+    checker.validate_skill_frontmatter_name(
+        "fixture-governance",
+        empty_block_metadata_skill_path,
+        frontmatter_errors,
+    )
+    if frontmatter_errors:
+        raise SystemExit(
+            "empty block SKILL.md metadata was rejected: "
+            f"errors={frontmatter_errors!r}"
+        )
+
+    nested_name_metadata_skill_path = pathlib.Path(temp_dir) / "nested-name-metadata.md"
+    nested_name_metadata_skill_path.write_text(
+        "---\n"
+        "metadata:\n"
+        "  name: fixture-governance\n"
+        "description: A valid temporary skill fixture.\n"
+        "---\n"
+    )
+    frontmatter_errors = []
+    checker.validate_skill_frontmatter_name(
+        "fixture-governance",
+        nested_name_metadata_skill_path,
+        frontmatter_errors,
+    )
+    if not any("unsupported metadata field 'name'" in error for error in frontmatter_errors) or not any(
+        "frontmatter name is missing" in error for error in frontmatter_errors
+    ):
+        raise SystemExit(
+            "nested metadata name incorrectly satisfied root skill identity: "
+            f"errors={frontmatter_errors!r}"
+        )
 
 nbspace_value = "Fixture" + chr(0xA0) + "#Governance"
 parsed, parse_error = checker.parse_yaml_string_scalar(nbspace_value, 1)


### PR DESCRIPTION
## Summary
- document the repository skill invocation inventory and authoring rules
- disable implicit invocation for merge and direct-write workflows
- enforce invocation policy through the agent organization and asset validators
- validate official interface/root allowlists, required descriptions, supported scalar field types, confined existing `assets/...` icon paths, exact path spelling, and `#RRGGBB` brand colors
- align root description TODO, angle-bracket, and 1024-character constraints with the bundled quick validator

## Validation
- `python3 scripts/check-agent-organization.py`
- `bash scripts/validate-agent-workflow-assets.sh --format=summary`
- `bash scripts/validate-agent-workflow-assets.sh --format=jsonl`
- `just validate` (228 library tests and 2 binary tests passed)
- pre-push Clippy and tests passed
- final Luna Max adversarial review: P0/P1/P2 = 0

## Stack
- base: `feat/issue-189-codex-operating-model` / PR #214

## Follow-up
- #225 owns `interface.short_description` length enforcement
- #226 owns schema-valid collection-valued SKILL.md frontmatter such as list-valued `allowed-tools`

Closes #192