### PR TITLE
docs(agent): restore review heading referenced by workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ just validate
 
 Report exactly which checks ran and which did not. Do not claim completion without real evidence.
 
-## Code Review Guidelines
+## Code Review Rules
 
 Codex Automatic review findings are candidate evidence. Review each finding
 independently against the issue goal, the owning SPEC, and the current accepted


### PR DESCRIPTION
Restore the Code Review Rules heading in AGENTS.md so five existing workflow references resolve again. The review guidance added in #254 is preserved.

This corrects the post-merge review: https://github.com/nerdchanii/rpm/pull/254#discussion_r3964240956

Validation: one-line diff and all five literal references checked; git diff --check passed. No runtime behavior changed.

Closes #255.
