### PR TITLE
fix(agent): close claim and resolution retry gaps from PR211 review

### DIFF
--- a/.agents/fixtures/backlog/cloud-claim-prepare-closing-pr.json
+++ b/.agents/fixtures/backlog/cloud-claim-prepare-closing-pr.json
@@ -1,0 +1,19 @@
+{
+  "repository": "nerdchanii/rpm",
+  "now": "2026-08-21T12:00:00Z",
+  "runs": [],
+  "issues": [
+    {
+      "number": 3,
+      "state": "OPEN",
+      "labels": ["agent:ready", "priority:high"],
+      "closing_prs": [{"number": 211, "state": "OPEN"}],
+      "execution": {
+        "approval_id": "approval-3",
+        "plan_revision": "plan-3",
+        "scope_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "executor": "cloud"
+      }
+    }
+  ]
+}

--- a/.agents/fixtures/backlog/cloud-claim-ready-closing-pr.json
+++ b/.agents/fixtures/backlog/cloud-claim-ready-closing-pr.json
@@ -1,0 +1,43 @@
+{
+  "repository": "nerdchanii/rpm",
+  "now": "2026-08-21T12:00:00Z",
+  "runs": [
+    {
+      "repository": "nerdchanii/rpm",
+      "issue": 3,
+      "run_id": "run-3",
+      "event_id": "delivery-3",
+      "executor": "cloud",
+      "plan_revision": "plan-3",
+      "scope_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "idempotency_key": "sha256:0ebb451daf89062a9f7314eec90cb39f62d5aae73bcdf47f7dd89e2e70f74cb1",
+      "lease": {
+        "run_id": "run-3",
+        "owner": "cloud:executor",
+        "started_at": "2026-08-21T12:00:00Z",
+        "expires_at": "2026-08-21T13:00:00Z"
+      },
+      "started_at": "2026-08-21T12:00:00Z",
+      "expires_at": "2026-08-21T13:00:00Z"
+    }
+  ],
+  "comments": [
+    {
+      "body": "<!-- rpm-agent-claim: {\"event_id\":\"delivery-3\",\"executor\":\"cloud\",\"expires_at\":\"2026-08-21T13:00:00Z\",\"idempotency_key\":\"sha256:0ebb451daf89062a9f7314eec90cb39f62d5aae73bcdf47f7dd89e2e70f74cb1\",\"issue\":3,\"lease\":{\"expires_at\":\"2026-08-21T13:00:00Z\",\"owner\":\"cloud:executor\",\"run_id\":\"run-3\",\"started_at\":\"2026-08-21T12:00:00Z\"},\"plan_revision\":\"plan-3\",\"repository\":\"nerdchanii/rpm\",\"run_id\":\"run-3\",\"scope_hash\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"started_at\":\"2026-08-21T12:00:00Z\"} -->"
+    }
+  ],
+  "issues": [
+    {
+      "number": 3,
+      "state": "OPEN",
+      "labels": ["agent:ready", "priority:high"],
+      "closing_prs": [{"number": 211, "state": "OPEN"}],
+      "execution": {
+        "approval_id": "approval-3",
+        "plan_revision": "plan-3",
+        "scope_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "executor": "cloud"
+      }
+    }
+  ]
+}

--- a/.agents/skills/pr-review-resolution/SKILL.md
+++ b/.agents/skills/pr-review-resolution/SKILL.md
@@ -68,8 +68,15 @@ without applying it.
    authorization gates mutation. Do not invent the final #208 schema.
 8. Commit and push accepted fixes to the same PR branch. The main session owns
    one resolution comment and the lifecycle transition after verification.
-9. Keep `agent:review-pending` when actionable P0/P1 findings remain. When no actionable finding remains, remove `agent:review-pending` and `agent:claimed`, add `agent:awaiting-merge`, and preserve all non-lifecycle labels.
-10. Never merge, resolve review threads, or post `@codex review`.
+9. On a reconciliation retry, inspect existing resolution comments before
+   posting. Use the same PR number, current head SHA, review ID, and canonical
+   resolution body as the matching context. If an identical comment is already
+   published for that context, reuse it, skip posting, and continue to the
+   lifecycle transition. A different head, review, or body does not match.
+   Keep this check scoped to the selected PR and review; do not add a global
+   ledger or idempotency framework.
+10. Keep `agent:review-pending` when actionable P0/P1 findings remain. When no actionable finding remains, remove `agent:review-pending` and `agent:claimed`, add `agent:awaiting-merge`, and preserve all non-lifecycle labels.
+11. Never merge, resolve review threads, or post `@codex review`.
 
 ## When To Read References
 

--- a/.agents/skills/pr-review-resolution/SKILL.md
+++ b/.agents/skills/pr-review-resolution/SKILL.md
@@ -69,12 +69,15 @@ without applying it.
 8. Commit and push accepted fixes to the same PR branch. The main session owns
    one resolution comment and the lifecycle transition after verification.
 9. On a reconciliation retry, inspect existing resolution comments before
-   posting. Use the same PR number, current head SHA, review ID, and canonical
-   resolution body as the matching context. If an identical comment is already
+   posting. Use the canonical marker/body and four-field context defined in
+   `references/templates.md`: the same PR number, current head SHA, review ID,
+   and complete canonical resolution body. If an identical comment is already
    published for that context, reuse it, skip posting, and continue to the
    lifecycle transition. A different head, review, or body does not match.
    Keep this check scoped to the selected PR and review; do not add a global
-   ledger or idempotency framework.
+   ledger or idempotency framework. This is a main-session manual contract;
+   the repository has no automatic resolution-comment posting or retry
+   executor.
 10. Keep `agent:review-pending` when actionable P0/P1 findings remain. When no actionable finding remains, remove `agent:review-pending` and `agent:claimed`, add `agent:awaiting-merge`, and preserve all non-lifecycle labels.
 11. Never merge, resolve review threads, or post `@codex review`.
 

--- a/.agents/skills/pr-review-resolution/references/resolution-workflow.md
+++ b/.agents/skills/pr-review-resolution/references/resolution-workflow.md
@@ -17,12 +17,15 @@
    body file for preview and may use `--create` only when
    `may_create_followup_issues=true`.
 9. On a reconciliation retry, inspect existing resolution comments before
-   posting. Use the same PR number, current head SHA, review ID, and canonical
-   resolution body as the matching context. If an identical comment is already
+   posting. Use the canonical marker/body and four-field context defined in
+   `references/templates.md`: the same PR number, current head SHA, review ID,
+   and complete canonical resolution body. If an identical comment is already
    published for that context, reuse it, skip posting, and continue to the
    lifecycle transition. A different head, review, or body does not match.
    Keep this check scoped to the selected PR and review; do not add a global
-   ledger or idempotency framework.
+   ledger or idempotency framework. This is a main-session manual contract;
+   the repository has no automatic resolution-comment posting or retry
+   executor.
 10. Commit and push accepted fixes to the same PR branch, then run internal adversarial review. Do not assume Automatic review reruns.
 11. Keep `agent:review-pending` while actionable P0/P1 findings remain. Otherwise replace it with `agent:awaiting-merge` and remove stale `agent:claimed`, preserving ordinary labels.
 12. Never merge, request `@codex review`, or make a new Automatic review a completion dependency.

--- a/.agents/skills/pr-review-resolution/references/resolution-workflow.md
+++ b/.agents/skills/pr-review-resolution/references/resolution-workflow.md
@@ -16,9 +16,16 @@
    performs no file or shell operation. The main session may create a temporary
    body file for preview and may use `--create` only when
    `may_create_followup_issues=true`.
-9. Commit and push accepted fixes to the same PR branch, then run internal adversarial review. Do not assume Automatic review reruns.
-10. Keep `agent:review-pending` while actionable P0/P1 findings remain. Otherwise replace it with `agent:awaiting-merge` and remove stale `agent:claimed`, preserving ordinary labels.
-11. Never merge, request `@codex review`, or make a new Automatic review a completion dependency.
+9. On a reconciliation retry, inspect existing resolution comments before
+   posting. Use the same PR number, current head SHA, review ID, and canonical
+   resolution body as the matching context. If an identical comment is already
+   published for that context, reuse it, skip posting, and continue to the
+   lifecycle transition. A different head, review, or body does not match.
+   Keep this check scoped to the selected PR and review; do not add a global
+   ledger or idempotency framework.
+10. Commit and push accepted fixes to the same PR branch, then run internal adversarial review. Do not assume Automatic review reruns.
+11. Keep `agent:review-pending` while actionable P0/P1 findings remain. Otherwise replace it with `agent:awaiting-merge` and remove stale `agent:claimed`, preserving ordinary labels.
+12. Never merge, request `@codex review`, or make a new Automatic review a completion dependency.
 
 ## Decision Taxonomy
 

--- a/.agents/skills/pr-review-resolution/references/resolution-workflow.md
+++ b/.agents/skills/pr-review-resolution/references/resolution-workflow.md
@@ -16,17 +16,21 @@
    performs no file or shell operation. The main session may create a temporary
    body file for preview and may use `--create` only when
    `may_create_followup_issues=true`.
-9. On a reconciliation retry, inspect existing resolution comments before
-   posting. Use the canonical marker/body and four-field context defined in
-   `references/templates.md`: the same PR number, current head SHA, review ID,
-   and complete canonical resolution body. If an identical comment is already
-   published for that context, reuse it, skip posting, and continue to the
-   lifecycle transition. A different head, review, or body does not match.
-   Keep this check scoped to the selected PR and review; do not add a global
-   ledger or idempotency framework. This is a main-session manual contract;
-   the repository has no automatic resolution-comment posting or retry
-   executor.
-10. Commit and push accepted fixes to the same PR branch, then run internal adversarial review. Do not assume Automatic review reruns.
+9. Commit and push accepted fixes to the same PR branch, then verify through
+   the GitHub capability that the public PR head SHA matches the pushed commit.
+   Do not construct, match, or publish a resolution comment before the push
+   succeeds and that public-head check passes. Run internal adversarial review
+   after the push and head verification. Do not assume Automatic review reruns.
+10. On a reconciliation retry after the push and public-head verification,
+   inspect existing resolution comments before posting. Use the canonical
+   marker/body and four-field context defined in `references/templates.md`: the
+   same PR number, current head SHA, review ID, and complete canonical
+   resolution body. If an identical comment is already published for that
+   context, reuse it, skip posting, and continue to the lifecycle transition.
+   A different head, review, or body does not match. Keep this check scoped to
+   the selected PR and review; do not add a global ledger or idempotency
+   framework. This is a main-session manual contract; the repository has no
+   automatic resolution-comment posting or retry executor.
 11. Keep `agent:review-pending` while actionable P0/P1 findings remain. Otherwise replace it with `agent:awaiting-merge` and remove stale `agent:claimed`, preserving ordinary labels.
 12. Never merge, request `@codex review`, or make a new Automatic review a completion dependency.
 

--- a/.agents/skills/pr-review-resolution/references/templates.md
+++ b/.agents/skills/pr-review-resolution/references/templates.md
@@ -6,6 +6,35 @@
 {"type":"review_input","data":{"pr":"<number-or-url>","ticket_scope":"<one-sentence-scope>","handoff":{"status":"durable|compatibility","payload":{},"gaps":["<missing-or-ambiguous-field>"]},"spec_status":"conforms|violates|stale|missing|not-contract-affecting|unknown","spec_paths":["<path>"],"validation_plan":["<command>"],"may_create_followup_issues":false}}
 ```
 
+## Resolution Comment Retry Contract
+
+The main session owns the single published resolution comment. Build each
+canonical comment from exactly these four fields:
+
+- `pr_number`: the selected pull request number
+- `head_sha`: the current live pull request head SHA
+- `review_id`: the latest review identifier
+- `body`: the complete canonical resolution comment body
+
+The body starts with this exact marker, replacing each placeholder with the
+current value:
+
+`<!-- rpm-review-resolution: pr=<pr_number>; head=<head_sha>; review=<review_id> -->`
+
+The remaining body contains the resolution summary, decisions, validation, and
+final issue state. Use LF line endings and no trailing whitespace. The `body`
+field is the full published comment, including the marker.
+
+On a retry, inspect existing comments for the selected pull request. Reuse a
+comment only when all four fields match exactly: `pr_number`, current
+`head_sha`, `review_id`, and complete canonical `body`. An exact match is
+already published; skip posting and continue the lifecycle transition. Any
+differing field is a non-match and follows the normal single-comment path.
+
+This is a main-session manual contract. The repository has no automatic
+resolution-comment posting or retry executor. Do not add a global ledger or
+idempotency framework.
+
 ## Resolver Prompt
 
 ```text

--- a/scripts/check-cloud-queue-contract.py
+++ b/scripts/check-cloud-queue-contract.py
@@ -567,6 +567,8 @@ def claim(
         return {"status": "blocked", "reason": "missing-persisted-claim-record", "issue": issue_number}
     if current != "ready":
         return {"status": "no-work", "reason": "issue-not-ready", "issue": issue_number}
+    if has_open_closing_pr(issue):
+        return {"status": "blocked", "reason": "open-closing-pr", "issue": issue_number}
     lease_rules = contract.get("lease")
     if not isinstance(lease_rules, dict):
         raise ValueError("execution contract lease rules are invalid")

--- a/scripts/check-cloud-queue-contract.py
+++ b/scripts/check-cloud-queue-contract.py
@@ -530,6 +530,8 @@ def claim(
         expires_at = parse_timestamp(persisted["expires_at"], "claim_record.expires_at")
         if expires_at <= now:
             return {"status": "blocked", "reason": "lease-expired", "issue": issue_number}
+        if current == "ready" and has_open_closing_pr(issue):
+            return {"status": "blocked", "reason": "open-closing-pr", "issue": issue_number}
         ordinary = sorted(label for label in issue_labels(issue) if label not in lifecycle.values())
         recovery = {
             "state": current,

--- a/scripts/test-issue-202-workflow-contract.sh
+++ b/scripts/test-issue-202-workflow-contract.sh
@@ -247,6 +247,27 @@ printf '%s\n' "$claim_inline_output" | jq -e '
   and .data.issue == 3
 ' >/dev/null
 
+set +e
+closing_pr_prepare_output="$(python3 scripts/check-cloud-queue-contract.py \
+  --issues-file .agents/fixtures/backlog/cloud-claim-prepare-closing-pr.json \
+  --operation claim --issue 3 --run-id run-3 --event-id delivery-3 \
+  --executor cloud --plan-revision plan-3 \
+  --scope-hash sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  --lease-owner cloud:executor)"
+closing_pr_prepare_code=$?
+set -e
+[ "$closing_pr_prepare_code" -eq 1 ]
+printf '%s\n' "$closing_pr_prepare_output" | jq -e '
+  .type == "cloud_queue_contract"
+  and .data.status == "blocked"
+  and .data.reason == "open-closing-pr"
+  and .data.issue == 3
+  and (has("claim_record") | not)
+  and (has("issue_comment_marker") | not)
+  and (has("persistence") | not)
+  and (has("authorization_token") | not)
+' >/dev/null
+
 claim_output="$(python3 scripts/check-cloud-queue-contract.py \
   --issues-file .agents/fixtures/backlog/cloud-claim-ready.json \
   --operation claim --issue 3 --run-id run-3 --event-id delivery-3 \
@@ -487,6 +508,13 @@ do
   require_contract_text "$resolution_contract" 'reuse.*skip posting.*lifecycle transition' 'matching comment lifecycle continuation'
   require_contract_text "$resolution_contract" 'global.*ledger.*idempotency.*framework' 'bounded comment deduplication'
 done
+require_contract_text .agents/skills/pr-review-resolution/references/templates.md 'Resolution Comment Retry Contract' 'canonical resolution retry contract'
+require_contract_text .agents/skills/pr-review-resolution/references/templates.md 'exactly these four fields.*pr_number.*head_sha.*review_id.*body' 'four-field resolution context'
+require_contract_text .agents/skills/pr-review-resolution/references/templates.md 'rpm-review-resolution: pr=<pr_number>; head=<head_sha>; review=<review_id>' 'canonical resolution marker'
+require_contract_text .agents/skills/pr-review-resolution/references/templates.md 'all four fields.*match exactly' 'exact resolution context match'
+require_contract_text .agents/skills/pr-review-resolution/references/templates.md 'skip posting.*continue.*lifecycle transition' 'template lifecycle continuation'
+require_contract_text .agents/skills/pr-review-resolution/references/templates.md 'no automatic.*resolution-comment posting.*retry executor' 'manual resolution boundary'
+require_contract_text .agents/skills/pr-review-resolution/references/templates.md 'global.*ledger.*idempotency.*framework' 'template bounded deduplication'
 require_contract_text .agents/skills/open-pr-review-batch/SKILL.md 'Review only' 'review-only boundary'
 require_contract_text .agents/skills/open-pr-review-batch/SKILL.md 'remediation belongs to.*pr-review-resolution' 'review-remediation handoff'
 

--- a/scripts/test-issue-202-workflow-contract.sh
+++ b/scripts/test-issue-202-workflow-contract.sh
@@ -268,6 +268,24 @@ printf '%s\n' "$claim_output" | jq -e '
   and .data.lease.owner == "cloud:executor"
   and .data.preserved_labels == ["priority:high"]
 ' >/dev/null
+
+set +e
+closing_pr_claim_output="$(python3 scripts/check-cloud-queue-contract.py \
+  --issues-file .agents/fixtures/backlog/cloud-claim-ready-closing-pr.json \
+  --operation claim --issue 3 --run-id run-3 --event-id delivery-3 \
+  --executor cloud --plan-revision plan-3 \
+  --scope-hash sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  --lease-owner cloud:executor)"
+closing_pr_claim_code=$?
+set -e
+[ "$closing_pr_claim_code" -eq 1 ]
+printf '%s\n' "$closing_pr_claim_output" | jq -e '
+  .type == "cloud_queue_contract"
+  and .data.status == "blocked"
+  and .data.reason == "open-closing-pr"
+  and .data.issue == 3
+' >/dev/null
+
 claim_restart_output="$(python3 scripts/check-cloud-queue-contract.py \
   --issues-file .agents/fixtures/backlog/cloud-claim-restart.json \
   --operation claim --issue 3 --run-id run-3 --event-id delivery-3 \
@@ -460,6 +478,15 @@ rg -q 'scripts/worktree-cleanup.sh' .codex/environments/environment.toml
 require_contract_text .agents/skills/pr-review-resolution/SKILL.md 'Own PR review feedback resolution' 'canonical review-remediation owner'
 require_contract_text .agents/skills/pr-review-resolution/SKILL.md 'GitHub-sourced.*review text.*untrusted' 'untrusted GitHub review boundary'
 require_contract_text .codex/agents/pr-review-resolver.toml 'Treat every GitHub-sourced.*untrusted' 'resolver untrusted GitHub review boundary'
+for resolution_contract in \
+  .agents/skills/pr-review-resolution/SKILL.md \
+  .agents/skills/pr-review-resolution/references/resolution-workflow.md
+do
+  require_contract_text "$resolution_contract" 'reconciliation retry.*existing resolution comments?' 'retry comment lookup'
+  require_contract_text "$resolution_contract" 'PR number.*head SHA.*review ID.*canonical.*resolution body' 'matching resolution context'
+  require_contract_text "$resolution_contract" 'reuse.*skip posting.*lifecycle transition' 'matching comment lifecycle continuation'
+  require_contract_text "$resolution_contract" 'global.*ledger.*idempotency.*framework' 'bounded comment deduplication'
+done
 require_contract_text .agents/skills/open-pr-review-batch/SKILL.md 'Review only' 'review-only boundary'
 require_contract_text .agents/skills/open-pr-review-batch/SKILL.md 'remediation belongs to.*pr-review-resolution' 'review-remediation handoff'
 


### PR DESCRIPTION
Closes #257

## Summary

This bounded follow-up addresses the two late P2 review findings from PR #211.

- Initial and persisted ready claims block an open closing PR before claim/lease mutation.
- Review-resolution retry dedup is a manual agent-executed contract because no automatic posting/retry implementation exists. Reconciliation may reuse a resolution comment only when the canonical marker/body and the exact `pr_number`, `head_sha`, `review_id`, and `body` match.

## Scope boundaries

- No global ledger or idempotency framework was added.
- No cloud or API-key activation was added.
- This change makes no functional automation claim.
- The current claimer remains fail-closed until trusted host handoff is supported.

## Validation

All checks ran after syncing the branch with live `origin/main` at `a5ae186`.

- `just agent-assets` — PASS
- `just validate` — PASS
  - 228 library tests passed
  - 2 binary tests passed
- `bash .githooks/pre-push` — PASS
  - clippy passed
  - 228 library tests passed
  - 2 binary tests passed
- `git diff --check origin/main..HEAD` — PASS
- `cargo fmt --all --check` — PASS
- Python AST syntax check for `scripts/check-cloud-queue-contract.py` — PASS
- JSON parsing for both new backlog fixtures — PASS
- `bash -n scripts/test-issue-202-workflow-contract.sh` — PASS

The published exact head is `07d6d912f1329655f0aa06127836b9d8eb0878de`.
