### PR TITLE
feat(agent): add Cloud submission and PR event handoff

### DIFF
--- a/.github/codex/README.md
+++ b/.github/codex/README.md
@@ -1,5 +1,9 @@
 # Codex artifact worker
 
+For the subscription Cloud submission / PR event work and its current support
+limits, see [Cloud event handoff](event-handoff.md). This older manual API
+artifact worker is not called by that path.
+
 This adapter is a small, read-only GitHub Actions worker for RPM. Start it
 manually from the Actions page. Enter a positive number in exactly one of the
 two inputs and leave the other at its `none` default:

--- a/.github/codex/event-handoff.md
+++ b/.github/codex/event-handoff.md
@@ -1,0 +1,169 @@
+# Cloud submission and PR event handoff
+
+This change implements two bounded pieces: a submit-only CLI transport and a
+read-only PR event handler. **It does not enable unattended Cloud delivery.**
+Account authentication, automatic PR publication, and host-verifiable claim
+authority still prevent a verified end-to-end rollout.
+
+## Intended flow and current implementation
+
+| Boundary | Current evidence / implementation |
+| --- | --- |
+| Select and claim one issue | Existing queue and claim policy remains authoritative. The current host cannot attest a parent claim handoff; its manual checkpoint remains. |
+| Submit Cloud task, retain task ID, exit | `scripts/submit-codex-cloud-task.py` calls `codex cloud exec` once using an existing ChatGPT login. It does not run `codex exec`, poll Cloud status, download a diff, or wait for implementation. |
+| Cloud implements and publishes a PR | Cloud background work and opening a PR from the result are documented. Automatic publication without a session approval is unverified. No replacement publisher is installed. |
+| PR creation/update starts checks | Existing `Rust` / `verify` and `PR Metadata` / `metadata` workflows remain. Actual workflow behavior depends on the credential used to publish the PR. |
+| PR/review/check event selects next owner | `codex-pr-events.yml` refetches the current PR and reports the existing review or merge route. It performs no external mutation or Cloud submission. |
+| Review and merge | Existing `pr-review-resolution` and top-level `merge-gatekeeper` retain ownership. The event report is preliminary evidence, not an authorization or a replacement for their fresh checks. |
+
+The workflow checks out the handler scripts from the default branch, with read
+permissions only. Event payloads provide identity hints; their check results, text, files,
+caches, and artifacts are not executed or trusted as current evidence. This
+handler starts operating after it exists on the default branch. A local run
+against GitHub before that point proves only the read adapter.
+
+`pull_request_target` covers creation, reopen, push, editing, and review-ready
+events. `pull_request_review` covers feedback arrival and changes. GitHub
+evaluates that event's workflow YAML from the PR merge ref; it is an advisory,
+read-only surface. Its checked-in steps still load the default-branch scripts
+and skip intake if they are not deployed yet. This workflow must not acquire
+mutation credentials or be used as trusted authorization by a downstream writer.
+`workflow_run` covers completion of the two existing check workflows. Empty
+PR associations return `no-work`; existing scheduled owners remain the recovery
+path for missed events and later lifecycle transitions. There is no new
+schedule, Cloud-completion polling loop, lifecycle transition, merge switch,
+or rule about when the next issue starts.
+
+An untracked existing PR is reported as needing authorized adoption. The
+event handler does not infer adoption permission from the existence of a PR.
+This keeps the eventual narrow adoption entry in the common review/merge
+path without importing the separate ledger and merge authority from PR #233.
+
+## Submit-only transport
+
+Run on a trusted, already signed-in machine with CLI 0.152.0. The prompt must
+come from the authorized caller and preserve the issue's scope and the
+repository claim contract; copying issue text into a prompt grants no new
+authority. This command does not select or claim an issue on the caller's behalf.
+
+```sh
+codex login status
+python3 scripts/submit-codex-cloud-task.py \
+  --environment '<verified RPM Cloud environment ID>' \
+  --branch main \
+  --prompt-file /absolute/path/approved-prompt.txt \
+  --receipt /absolute/path/request-receipt.json
+```
+
+The output is `submitted` with a task ID and URL, never `complete`. The receipt
+contains the environment, branch and prompt digest, not the prompt or auth.
+Reuse the same receipt for a retry of the same request. A known submission
+returns the recorded identity without another Cloud call. A timeout, interrupted
+submission, nonzero exit, or unrecognized output leaves an uncertain attempt;
+inspect that attempt in Cloud before deciding what to do. A new receipt is a
+new request and can create another task. This is local duplicate suppression,
+not a claim that the Cloud API offers an idempotency key.
+
+Only the transport's direct call is bounded by a timeout. The remote task's
+lifetime is independent. No task status is fetched by the transport.
+
+## Official support boundary (checked 2026-09-13)
+
+- [Developer commands](https://learn.chatgpt.com/docs/developer-commands?surface=cli)
+  documents `codex cloud exec --env`, best-of-N attempts, shared CLI
+  authentication, and nonzero submission failure. Cloud commands are marked
+  experimental. This does not establish a stable machine-readable submission
+  receipt or automatic PR publication.
+  The pinned [0.152.0 CLI implementation](https://github.com/openai/codex/blob/rust-v0.152.0/codex-rs/cloud-tasks/src/lib.rs#L178-L200)
+  prints the created task URL; its
+  [URL formatter](https://github.com/openai/codex/blob/rust-v0.152.0/codex-rs/cloud-tasks/src/util.rs#L136-L149)
+  supplies the production `/codex/tasks/{task_id}` form parsed by the transport.
+- [Account authentication in CI](https://learn.chatgpt.com/docs/auth/ci-cd-auth)
+  limits the managed `auth.json` pattern to trusted private automation and
+  explicitly says: “Do not use this workflow for public or open-source
+  repositories.” RPM is public. No subscription credential export, CI secret
+  injection workflow, refresh workaround, or API-key fallback is introduced.
+  Moving a runner into a private controller repository has not been verified
+  as an exception for this public target.
+- [Codex Cloud](https://learn.chatgpt.com/docs/cloud) documents independent
+  background work and opening a PR after reviewing the result.
+  [GitHub integration](https://learn.chatgpt.com/docs/third-party/github)
+  describes connected repository access. Neither establishes that this
+  account's background task can create a PR without further interaction,
+  which credential it uses, or whether host approval review will allow it.
+- [GitHub token behavior](https://docs.github.com/en/actions/concepts/security/github_token)
+  currently says `GITHUB_TOKEN`-generated `opened`, `synchronize`, and
+  `reopened` PR events create approval-required runs. Other PR activity types
+  do not create runs. A separate GitHub App installation token or PAT can
+  trigger these runs without that particular approval. An actor name alone
+  does not prove which credential was used. The submit job's `GITHUB_TOKEN`
+  also expires when that job finishes; it is not a durable Cloud credential.
+
+The repository's separate approval gap is concrete:
+`.codex/agents/rpm_ready_ticket_claimer.toml` and
+`.codex/hooks/agent_tool_policy.py:trusted_claim_authorization` stop automatic
+claim mutation until the host supplies verifiable parent authority. Repeating
+approval prose in a task or manufacturing a claim token does not resolve this.
+No authorization hook or previously denied operation is bypassed here.
+
+## Rollout decision still required
+
+The concrete account/host prerequisite is a supported GitHub publication
+capability **inside the background Cloud task**, with verifiable claim
+authority. The live probe below did not expose it despite using an existing
+connected RPM environment. No documented account switch was found that supplies
+these capabilities. Confirm this support with the host before enabling any
+submission workflow; do not ask the owner to paste credentials or repeat an
+approval into each task.
+
+After that prerequisite is met, verify one intended PR's current head and
+matching `pull_request` Actions runs, including any approval-required state.
+A human clicking **Create PR** can validate the PR-to-Actions half; record that
+human step and do not call it autonomous Cloud publication.
+
+This single check will not itself solve the public-CI subscription-auth or
+host claim-authority gaps. Those require a supported product/authentication
+path. One missing secret or repeated user approval is not an evidenced fix.
+
+## Integration with existing work
+
+Inspected base: `main` at `fb7eb380e9484222b44b9316439faa5bcab4b901`.
+PR #246 at `d8afb52e8498770263f5ca9c90c41011b1f40554` and PR #233 at
+`16b7df576fa49104fa1b20a3835de3410e2543fc` were open and conflicting.
+
+PR #246's three result-polling lanes and Actions publisher are not imported.
+PR #233's broad adoption ledger and two-stage merge authorization are not
+imported. Both existing PRs remain available for separate disposition.
+The policy, mandatory `metadata`/`verify` checks, strict protected `main`,
+current merge owner, and unrelated worktree changes remain intact.
+
+## Validation
+
+On 2026-09-13, the owner account's Cloud UI showed an existing `nerdchanii/rpm`
+environment. A bounded read-only capability probe was submitted from the
+already ChatGPT-authenticated local CLI through this transport. It returned
+`submitted`, task `task_e_6aa6a00a5fac8328abb3a6d9b278e373`, and exit 0.
+A separate status read after the submitter exited showed `PENDING` with no
+diff. The [Cloud probe](https://chatgpt.com/codex/tasks/task_e_6aa6a00a5fac8328abb3a6d9b278e373)
+then completed, and its final report and execution logs were inspected in the
+account UI. The report identified only `mcp__make_pr__make_pr` as PR-specific;
+its described function records title/body metadata and does not establish
+authenticated GitHub publication. No dedicated GitHub read/write capability
+or verified parent authorization was exposed to that run. Its shell log showed
+no Git remotes, an installed `gh` binary, and an empty final
+`git status --porcelain=v2`. Authentication and mutations were not attempted.
+
+This verifies local subscription-authenticated submission, independent remote
+execution after local exit, and completion of a read-only probe. It does not
+verify Actions authentication, automatic PR publication, an actual mutation
+approval or rejection, or a Cloud-to-PR-to-Actions cycle.
+
+`just agent-events` runs offline process-boundary and event-routing tests.
+Their fake CLI/GitHub responses prove the code paths and failure handling;
+they are not evidence of a real Cloud task or PR publication. The same checks
+are included in `just validate` and the existing `verify` workflow.
+
+The final task/PR report records actual local gate results and any live
+read-only GitHub checks separately. Actions-based Cloud submission, autonomous PR
+publication, and an end-to-end Cloud-to-Actions run remain unverified unless
+that report includes their actual IDs and outcomes.

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Validate Codex artifact worker
         run: ./scripts/test-agent-loop-artifact.sh
 
+      - name: Validate Codex event handoff
+        run: |
+          python3 scripts/test-codex-cloud-submit.py
+          python3 scripts/test-codex-pr-event.py
+
   post-merge-validation:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: macos-latest
@@ -82,6 +87,11 @@ jobs:
 
       - name: Validate Codex artifact worker
         run: ./scripts/test-agent-loop-artifact.sh
+
+      - name: Validate Codex event handoff
+        run: |
+          python3 scripts/test-codex-cloud-submit.py
+          python3 scripts/test-codex-pr-event.py
 
       - name: Check docs build warning-free
         env:

--- a/.github/workflows/codex-pr-events.yml
+++ b/.github/workflows/codex-pr-events.yml
@@ -1,0 +1,85 @@
+name: Codex PR event intake
+
+# Read-only event intake. Cloud submission and GitHub writes stay with their
+# existing owners until the documented account/host capability gaps are closed.
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  workflow_run:
+    workflows: [Rust, PR Metadata]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to inspect without mutation
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  checks: read
+
+concurrency:
+  group: codex-pr-event-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.workflow_run.id || inputs.pr }}
+  cancel-in-progress: false
+
+jobs:
+  inspect:
+    if: >-
+      (github.event_name != 'workflow_run' || github.event.workflow_run.event == 'pull_request') &&
+      (github.event_name != 'workflow_dispatch' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Never check out a PR head, execute its files, restore its cache, or
+      # download a Cloud/PR artifact in the event handler.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: |
+            scripts
+            .agents/workflows
+
+      # A review event can evaluate this workflow from a PR merge ref before
+      # the default branch has this new handler. Do not execute the PR copy.
+      - name: Check whether the handler is deployed
+        id: deployed
+        shell: bash
+        run: |
+          if [ -f scripts/inspect-codex-pr-event.py ]; then
+            echo 'available=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'available=false' >> "$GITHUB_OUTPUT"
+            echo 'PR event intake is not deployed on the default branch yet.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Refetch PR and evaluate the existing route
+        if: steps.deployed.outputs.available == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR: ${{ inputs.pr }}
+          PYTHONDONTWRITEBYTECODE: "1"
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(--event-file "$GITHUB_EVENT_PATH" --event-name "$EVENT_NAME")
+          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            args+=(--pr "$INPUT_PR")
+          fi
+          intake_status=0
+          python3 scripts/inspect-codex-pr-event.py "${args[@]}" > "$RUNNER_TEMP/pr-route.json" || intake_status=$?
+          {
+            echo '## Current PR route (read-only)'
+            echo 'The named owner must refetch evidence before any action. This report does not grant write or merge permission.'
+            echo '```json'
+            cat "$RUNNER_TEMP/pr-route.json"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$intake_status"

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ build:
     @echo "::rpm::end build"
 
 # Run the strict local validation gate.
-validate: format-check audit-fixtures fixture-smoke agent-assets agent-artifact check lint test docs
+validate: format-check audit-fixtures fixture-smoke agent-assets agent-artifact agent-events check lint test docs
 
 alias verify := validate
 
@@ -100,6 +100,11 @@ agent-artifact:
     @echo "::rpm::begin agent-artifact"
     @./scripts/test-agent-loop-artifact.sh
     @echo "::rpm::end agent-artifact"
+
+# Test the submit-only transport and read-only PR event intake (offline).
+agent-events:
+    @python3 scripts/test-codex-cloud-submit.py
+    @python3 scripts/test-codex-pr-event.py
 
 # Run benchmarks when benchmark targets exist. Extra cargo bench args are forwarded.
 bench *args:

--- a/scripts/inspect-codex-pr-event.py
+++ b/scripts/inspect-codex-pr-event.py
@@ -1,0 +1,964 @@
+#!/usr/bin/env python3
+"""Read and route a GitHub PR event using current read-only evidence.
+
+The event payload is used only to locate a pull request.  The adapter refetches
+the pull request, its linked issue, review state, and the required checks before
+returning a preliminary route.  This command never submits Cloud work, writes
+GitHub state, checks out a PR head, or executes repository-provided content.
+
+``inspect_event`` accepts a small fake-friendly adapter with these read-only
+methods:
+
+* ``get_pull_request(repository, number)``
+* ``get_issue(repository, number)``
+* ``get_checks(repository, head_sha)``
+
+The returned values may use the GraphQL connection shape (``nodes`` plus
+``pageInfo``) or the equivalent already-normalized fixture fields.  Real
+``GhReadAdapter`` responses retain the page information so truncated evidence
+fails closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Mapping, Protocol
+
+
+JSON = dict[str, Any]
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+CODEX_REVIEW_LOGINS = frozenset(
+    {"chatgpt-codex-connector", "chatgpt-codex-connector[bot]"}
+)
+P0_P1_RE = re.compile(
+    r"(?:^|[^A-Za-z0-9])(?:P[01]|priority\s*[:=]?\s*P?[01])(?:$|[^A-Za-z0-9])",
+    re.IGNORECASE,
+)
+
+
+class EvidenceError(ValueError):
+    """A malformed, stale, or incomplete read-only evidence response."""
+
+
+class ReadOnlyGitHub(Protocol):
+    """The injectable read-only boundary used by the evaluator and tests."""
+
+    def get_pull_request(self, repository: str, number: int) -> Mapping[str, Any]: ...
+
+    def get_issue(self, repository: str, number: int) -> Mapping[str, Any]: ...
+
+    def get_checks(self, repository: str, head_sha: str) -> Mapping[str, Any]: ...
+
+
+def _require_mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise EvidenceError(f"{name}-shape")
+    return value
+
+
+def _connection_nodes(value: Any, name: str, *, required: bool = True) -> list[Any]:
+    """Read a bounded GraphQL connection and reject omitted/truncated pages."""
+
+    if value is None:
+        if required:
+            raise EvidenceError(f"{name}-missing")
+        return []
+    if isinstance(value, list):
+        # Injected fixtures are allowed to provide an already-normalized list.
+        return value
+    connection = _require_mapping(value, name)
+    page_info = connection.get("pageInfo")
+    page_info = _require_mapping(page_info, f"{name}-page-info")
+    has_next = page_info.get("hasNextPage")
+    if not isinstance(has_next, bool):
+        raise EvidenceError(f"{name}-page-info-invalid")
+    if has_next:
+        raise EvidenceError(f"{name}-truncated")
+    nodes = connection.get("nodes")
+    if not isinstance(nodes, list):
+        raise EvidenceError(f"{name}-nodes-shape")
+    return nodes
+
+
+def _first(value: Mapping[str, Any], *names: str, default: Any = None) -> Any:
+    for name in names:
+        if name in value:
+            return value[name]
+    return default
+
+
+def _positive_number(value: Any, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise EvidenceError(f"{name}-invalid")
+    return value
+
+
+def _sha(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not SHA_RE.fullmatch(value):
+        raise EvidenceError(f"{name}-invalid")
+    return value
+
+
+def _repository(value: Any, name: str) -> str:
+    if isinstance(value, Mapping):
+        value = _first(value, "full_name", "fullName", "nameWithOwner")
+    if not isinstance(value, str) or not REPOSITORY_RE.fullmatch(value):
+        raise EvidenceError(f"{name}-invalid")
+    return value
+
+
+def _labels(value: Any, name: str) -> list[str]:
+    labels = _connection_nodes(value, name)
+    result: list[str] = []
+    for label in labels:
+        if isinstance(label, str):
+            result.append(label)
+            continue
+        item = _require_mapping(label, f"{name}-item")
+        label_name = item.get("name")
+        if not isinstance(label_name, str):
+            raise EvidenceError(f"{name}-item-invalid")
+        result.append(label_name)
+    return sorted(set(result))
+
+
+def _nested(value: Mapping[str, Any], name: str) -> Mapping[str, Any]:
+    nested = value.get(name)
+    if nested is None:
+        return {}
+    return _require_mapping(nested, name)
+
+
+def _mergeable(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.casefold()
+        if normalized in {"mergeable", "clean", "true"}:
+            return True
+        if normalized in {"conflicting", "dirty", "false"}:
+            return False
+        if normalized in {"unknown", ""}:
+            return None
+    raise EvidenceError("mergeable-invalid")
+
+
+def _normalize_pr(value: Mapping[str, Any], repository: str, *, labels: bool = True) -> JSON:
+    number = _positive_number(value.get("number"), "pull-request-number")
+    state = value.get("state")
+    if not isinstance(state, str) or not state.strip():
+        raise EvidenceError("pull-request-state-invalid")
+    draft = _first(value, "isDraft", "draft")
+    if not isinstance(draft, bool):
+        raise EvidenceError("pull-request-draft-invalid")
+
+    base = _nested(value, "base")
+    head = _nested(value, "head")
+    base_sha = _first(value, "baseRefOid", "base_sha", default=_first(base, "sha"))
+    head_sha = _first(value, "headRefOid", "head_sha", default=_first(head, "sha"))
+    base_ref = _first(value, "baseRefName", "base_ref", default=_first(base, "ref"))
+    head_ref = _first(value, "headRefName", "head_ref", default=_first(head, "ref"))
+    base_repo = _first(
+        value,
+        "base_repository",
+        default=_first(value, "baseRepository", default=_first(base, "repo")),
+    )
+    head_repo = _first(
+        value,
+        "head_repository",
+        default=_first(value, "headRepository", default=_first(head, "repo")),
+    )
+    normalized_base_repo = _repository(base_repo, "base-repository")
+    normalized_head_repo = _repository(head_repo, "head-repository")
+    if not isinstance(base_ref, str) or not base_ref.strip():
+        raise EvidenceError("base-ref-invalid")
+    if not isinstance(head_ref, str) or not head_ref.strip():
+        raise EvidenceError("head-ref-invalid")
+
+    result: JSON = {
+        "number": number,
+        "state": state,
+        "draft": draft,
+        "base": {
+            "sha": _sha(base_sha, "base-sha"),
+            "ref": base_ref,
+            "repository": normalized_base_repo,
+        },
+        "head": {
+            "sha": _sha(head_sha, "head-sha"),
+            "ref": head_ref,
+            "repository": normalized_head_repo,
+        },
+        "same_repository": normalized_base_repo == repository
+        and normalized_head_repo == repository,
+        "mergeable": _mergeable(value.get("mergeable")),
+    }
+    if labels:
+        label_value = value.get("labels")
+        if label_value is None:
+            raise EvidenceError("pull-request-labels-missing")
+        result["labels"] = _labels(label_value, "pull-request-labels")
+    return result
+
+
+def _normalize_closing_pr(value: Mapping[str, Any], repository: str) -> JSON:
+    number = _positive_number(value.get("number"), "closing-pr-number")
+    state = value.get("state")
+    if not isinstance(state, str) or not state.strip():
+        raise EvidenceError("closing-pr-state-invalid")
+    draft = _first(value, "isDraft", "draft", default=False)
+    if not isinstance(draft, bool):
+        raise EvidenceError("closing-pr-draft-invalid")
+    head_repo = _first(
+        value,
+        "head_repository",
+        default=_first(value, "headRepository", default=_first(_nested(value, "head"), "repo")),
+    )
+    # A timeline source must identify its source repository.  An already
+    # normalized fake may provide ``repository`` instead.
+    source_repo = _first(value, "repository", default=head_repo)
+    normalized_repo = _repository(source_repo, "closing-pr-repository")
+    if normalized_repo != repository:
+        raise EvidenceError("closing-pr-repository-mismatch")
+    return {
+        "number": number,
+        "state": state,
+        "draft": draft,
+        "repository": normalized_repo,
+        "mergeable": _mergeable(value.get("mergeable")),
+    }
+
+
+def _normalize_issue(value: Mapping[str, Any], repository: str) -> JSON:
+    number = _positive_number(value.get("number"), "issue-number")
+    issue_repository = _repository(
+        _first(value, "repository", "repository_name", default=repository),
+        "issue-repository",
+    )
+    if issue_repository != repository:
+        raise EvidenceError("issue-repository-mismatch")
+    state = value.get("state")
+    if not isinstance(state, str) or not state.strip():
+        raise EvidenceError("issue-state-invalid")
+    if "labels" not in value:
+        raise EvidenceError("issue-labels-missing")
+    labels = _labels(value["labels"], "issue-labels")
+
+    if "closing_prs" in value:
+        closing_source = value["closing_prs"]
+    elif "closingPullRequests" in value:
+        closing_source = value["closingPullRequests"]
+    else:
+        timeline = value.get("timelineItems")
+        if timeline is None:
+            raise EvidenceError("closing-prs-missing")
+        closing_source = []
+        for item in _connection_nodes(timeline, "closing-prs-timeline"):
+            event = _require_mapping(item, "closing-pr-event")
+            will_close = event.get("willCloseTarget")
+            if not isinstance(will_close, bool):
+                raise EvidenceError("closing-pr-event-invalid")
+            if not will_close:
+                continue
+            source = event.get("source")
+            if source is None:
+                raise EvidenceError("closing-pr-source-missing")
+            closing_source.append(source)
+    closing_prs = []
+    for item in _connection_nodes(closing_source, "closing-prs"):
+        closing_prs.append(_normalize_closing_pr(_require_mapping(item, "closing-pr"), repository))
+    return {
+        "number": number,
+        "state": state,
+        "labels": labels,
+        "closing_prs": closing_prs,
+    }
+
+
+def _review_login(value: Mapping[str, Any]) -> str | None:
+    author = value.get("author")
+    if author is None:
+        return None
+    author = _require_mapping(author, "review-author")
+    login = author.get("login")
+    return login if isinstance(login, str) else None
+
+
+def _has_codex_review(value: Any) -> bool:
+    reviews = _connection_nodes(value, "reviews")
+    for review in reviews:
+        item = _require_mapping(review, "review")
+        if _review_login(item) in CODEX_REVIEW_LOGINS:
+            return True
+    return False
+
+
+def _thread_has_p0_p1(thread: Mapping[str, Any]) -> bool:
+    resolved = thread.get("isResolved")
+    outdated = thread.get("isOutdated")
+    if not isinstance(resolved, bool) or not isinstance(outdated, bool):
+        raise EvidenceError("review-thread-state-invalid")
+    comments_value = thread.get("comments", [])
+    comments = _connection_nodes(comments_value, "review-thread-comments")
+    if resolved:
+        return False
+    for comment in comments:
+        comment_map = _require_mapping(comment, "review-comment")
+        body = comment_map.get("body", "")
+        if not isinstance(body, str):
+            raise EvidenceError("review-comment-body-invalid")
+        if P0_P1_RE.search(body):
+            return True
+    return False
+
+
+def _unresolved_p0_p1(value: Mapping[str, Any]) -> bool | None:
+    direct = value.get("unresolved_p0_p1")
+    if direct is not None:
+        if not isinstance(direct, bool):
+            raise EvidenceError("unresolved-p0-p1-invalid")
+        return direct
+    threads_value = _first(value, "review_threads", "reviewThreads")
+    if threads_value is None:
+        return None
+    threads = _connection_nodes(threads_value, "review-threads")
+    return any(_thread_has_p0_p1(_require_mapping(thread, "review-thread")) for thread in threads)
+
+
+def _conclusion(value: Any) -> str:
+    if value is None:
+        return "pending"
+    if not isinstance(value, str) or not value.strip():
+        raise EvidenceError("check-conclusion-invalid")
+    normalized = value.casefold()
+    if normalized in {"success", "passed", "pass"}:
+        return "success"
+    if normalized in {"failure", "failed", "cancelled", "timed_out", "action_required"}:
+        return normalized
+    if normalized in {"pending", "queued", "in_progress", "expected", "waiting"}:
+        return "pending"
+    return normalized
+
+
+def _required_checks(value: Any, policy: Mapping[str, Any]) -> dict[str, str]:
+    gate = policy.get("merge_gate")
+    gate = _require_mapping(gate, "policy-merge-gate")
+    required_value = gate.get("required_checks")
+    if not isinstance(required_value, list) or not required_value or not all(
+        isinstance(name, str) and name.strip() for name in required_value
+    ):
+        raise EvidenceError("required-checks-policy-invalid")
+    required = [str(name) for name in required_value]
+    if len(set(required)) != len(required):
+        raise EvidenceError("required-checks-policy-ambiguous")
+
+    check_map: dict[str, str] = {}
+    if "checks" in value:
+        direct = value["checks"]
+        if not isinstance(direct, Mapping):
+            raise EvidenceError("checks-shape")
+        for name, conclusion in direct.items():
+            if not isinstance(name, str):
+                raise EvidenceError("check-name-invalid")
+            if name in required:
+                if name in check_map:
+                    raise EvidenceError("ambiguous-required-checks")
+                check_map[name] = _conclusion(conclusion)
+    else:
+        contexts_value = value.get("contexts")
+        if contexts_value is None:
+            raise EvidenceError("checks-missing")
+        for context in _connection_nodes(contexts_value, "check-contexts"):
+            item = _require_mapping(context, "check-context")
+            name = _first(item, "name", "context")
+            if not isinstance(name, str) or not name.strip():
+                raise EvidenceError("check-name-invalid")
+            if name not in required:
+                continue
+            if name in check_map:
+                raise EvidenceError("ambiguous-required-checks")
+            check_map[name] = _conclusion(_first(item, "conclusion", "state"))
+    return {name: check_map.get(name, "pending") for name in required}
+
+
+def _policy_labels(policy: Mapping[str, Any]) -> dict[str, str]:
+    labels = policy.get("labels")
+    labels = _require_mapping(labels, "policy-labels")
+    result = {str(state): label for state, label in labels.items() if isinstance(label, str)}
+    if len(result) != len(labels):
+        raise EvidenceError("policy-labels-invalid")
+    return result
+
+
+def _issue_state(issue: Mapping[str, Any], labels: Mapping[str, str]) -> tuple[str, list[str]]:
+    issue_labels = issue.get("labels")
+    if not isinstance(issue_labels, list):
+        raise EvidenceError("issue-labels-invalid")
+    matched = sorted(state for state, label in labels.items() if label in issue_labels)
+    if len(matched) == 0:
+        return "untracked", matched
+    if len(matched) == 1:
+        return matched[0], matched
+    return "invalid", matched
+
+
+def _event_repository(event: Mapping[str, Any]) -> str:
+    repository = event.get("repository")
+    if not isinstance(repository, Mapping):
+        raise EvidenceError("event-repository-missing")
+    return _repository(repository.get("full_name"), "event-repository")
+
+
+def _event_head(event: Mapping[str, Any], event_name: str) -> str | None:
+    if event_name in {"pull_request_target", "pull_request_review"}:
+        payload = event.get("pull_request")
+        if not isinstance(payload, Mapping):
+            raise EvidenceError("event-pull-request-missing")
+        head = payload.get("head")
+        if head is None:
+            return None
+        head = _require_mapping(head, "event-head")
+        value = head.get("sha")
+    elif event_name == "workflow_run":
+        payload = event.get("workflow_run")
+        if not isinstance(payload, Mapping):
+            raise EvidenceError("event-workflow-run-missing")
+        value = payload.get("head_sha")
+    else:
+        return None
+    if value is None:
+        return None
+    return _sha(value, "event-head-sha")
+
+
+def _event_pr_number(
+    event: Mapping[str, Any], event_name: str, dispatch_pr: int | None
+) -> tuple[int | None, str | None]:
+    if event_name == "workflow_dispatch":
+        if dispatch_pr is None:
+            raise EvidenceError("workflow-dispatch-pr-required")
+        return _positive_number(dispatch_pr, "dispatch-pr"), None
+    if event_name in {"pull_request_target", "pull_request_review"}:
+        payload = event.get("pull_request")
+        if not isinstance(payload, Mapping):
+            raise EvidenceError("event-pull-request-missing")
+        return _positive_number(payload.get("number"), "event-pr-number"), None
+    workflow_run = event.get("workflow_run")
+    if not isinstance(workflow_run, Mapping):
+        raise EvidenceError("event-workflow-run-missing")
+    pull_requests = workflow_run.get("pull_requests")
+    if not isinstance(pull_requests, list):
+        raise EvidenceError("workflow-run-pull-requests-invalid")
+    if not pull_requests:
+        return None, "workflow-run-without-pull-request"
+    if len(pull_requests) != 1:
+        raise EvidenceError("workflow-run-pull-requests-ambiguous")
+    hint = _require_mapping(pull_requests[0], "workflow-run-pull-request")
+    return _positive_number(hint.get("number"), "workflow-run-pr-number"), None
+
+
+def _base_result(
+    event_name: str, repository: str | None, event_repository: str | None
+) -> JSON:
+    return {
+        "type": "codex_pr_event",
+        "version": 1,
+        "event_name": event_name,
+        "repository": repository,
+        "event_repository": event_repository,
+        "pr": None,
+        "issue": None,
+        "current_head": None,
+        "current_head_sha": None,
+        "head_sha": None,
+        "event_head": None,
+        "head_stale": False,
+        "same_repository": None,
+        "status": "blocked",
+        "route": "blocked",
+        "reason": "uninitialized",
+        "next": None,
+        "merge_authorized": False,
+        "preliminary": {"select_review": None, "select_merge": None},
+    }
+
+
+def _blocked(result: JSON, reason: str) -> JSON:
+    result.update(status="blocked", route="blocked", reason=reason, next=None)
+    result["merge_authorized"] = False
+    return result
+
+
+def _queue_verdicts(
+    fixture: JSON, policy: Mapping[str, Any], labels: Mapping[str, str]
+) -> dict[str, JSON]:
+    queue = _load_source_module(Path(__file__).with_name("check-cloud-queue-contract.py"))
+    merge = _load_source_module(Path(__file__).with_name("check-merge-gate.py"))
+    review_data = queue.select_review(fixture, labels)
+    merge_data = merge.select_merge(
+        fixture,
+        merge.lifecycle_labels(policy),
+        merge.merge_gate(policy),
+    )
+    return {
+        "select_review": {"type": "cloud_queue_contract", "data": review_data},
+        "select_merge": {"type": "merge_gate_contract", "data": merge_data},
+    }
+
+
+def _load_source_module(path: Path) -> SimpleNamespace:
+    """Load an existing validator without creating ``__pycache__`` files."""
+
+    namespace: dict[str, Any] = {
+        "__name__": path.stem.replace("-", "_"),
+        "__file__": str(path),
+        "__package__": None,
+    }
+    try:
+        source = path.read_text(encoding="utf-8")
+        exec(compile(source, str(path), "exec"), namespace)
+    except (OSError, SyntaxError) as exc:
+        raise EvidenceError("validator-unavailable") from exc
+    return SimpleNamespace(**namespace)
+
+
+def inspect_event(
+    event: Mapping[str, Any],
+    event_name: str,
+    policy: Mapping[str, Any],
+    github: ReadOnlyGitHub,
+    *,
+    pr_number: int | None = None,
+) -> JSON:
+    """Evaluate one event with a read-only adapter and return JSON-safe data."""
+
+    policy_repository = policy.get("repository")
+    try:
+        repository = _repository(policy_repository, "policy-repository")
+    except EvidenceError as exc:
+        result = _base_result(event_name, None, None)
+        return _blocked(result, str(exc))
+
+    result = _base_result(event_name, repository, None)
+    try:
+        if not isinstance(event, Mapping):
+            raise EvidenceError("event-shape")
+        event_repository = _event_repository(event)
+        result["event_repository"] = event_repository
+        if event_repository != repository:
+            return _blocked(result, "event-repository-mismatch")
+        event_head = _event_head(event, event_name)
+        result["event_head"] = event_head
+        selected_number, no_work_reason = _event_pr_number(event, event_name, pr_number)
+        if selected_number is None:
+            result.update(status="no-work", route="no-work", reason=no_work_reason)
+            return result
+        result["pr"] = selected_number
+        current_raw = github.get_pull_request(repository, selected_number)
+        current = _normalize_pr(_require_mapping(current_raw, "pull-request"), repository)
+        if current["number"] != selected_number:
+            raise EvidenceError("pull-request-number-mismatch")
+        result["current_head"] = current["head"]
+        result["current_head_sha"] = current["head"]["sha"]
+        result["head_sha"] = current["head"]["sha"]
+        result["same_repository"] = current["same_repository"]
+        result["head_stale"] = event_head is not None and event_head != current["head"]["sha"]
+        result["current"] = {
+            "state": current["state"],
+            "draft": current["draft"],
+            "base": current["base"],
+            "head": current["head"],
+            "labels": current["labels"],
+            "same_repository": current["same_repository"],
+        }
+
+        if current["state"].casefold() != "open":
+            return result | {
+                "status": "no-work",
+                "route": "no-work",
+                "reason": "pr-not-open",
+                "next": None,
+            }
+        if current["draft"]:
+            return result | {
+                "status": "no-work",
+                "route": "no-work",
+                "reason": "draft-pr",
+                "next": None,
+            }
+        if not current["same_repository"]:
+            return _blocked(result, "head-repository-mismatch")
+
+        # These reads remain current-head evidence even when no linked issue is
+        # available.  An untracked PR still needs a bounded report before the
+        # eventual authorized-adoption path can consider it.
+        checks_raw = github.get_checks(repository, current["head"]["sha"])
+        checks = _required_checks(
+            _require_mapping(checks_raw, "checks"), policy
+        )
+        codex_review_value = _first(current_raw, "reviews")
+        if codex_review_value is None:
+            raise EvidenceError("reviews-missing")
+        codex_review_present = _has_codex_review(codex_review_value)
+        unresolved = _unresolved_p0_p1(_require_mapping(current_raw, "pull-request"))
+
+        closing_issues_value = _first(
+            _require_mapping(current_raw, "pull-request"),
+            "closing_issues",
+            "closingIssuesReferences",
+        )
+        closing_issues = _connection_nodes(closing_issues_value, "closing-issues")
+        if len(closing_issues) == 0:
+            result.update(
+                status="no-work",
+                route="publication-state-pending",
+                reason="authorized-adoption-required",
+                next="authorized-adoption-required",
+                source_state="untracked",
+            )
+            result["evidence"] = {
+                "pr_labels": current["labels"],
+                "closing_issues": [],
+                "required_checks": checks,
+                "codex_review_present": codex_review_present,
+                "unresolved_p0_p1": unresolved,
+            }
+            return result
+        if len(closing_issues) > 1:
+            return _blocked(result, "multiple-closing-issues")
+        issue_hint = _require_mapping(closing_issues[0], "closing-issue")
+        issue_number = _positive_number(issue_hint.get("number"), "closing-issue-number")
+        issue_repository = _repository(
+            _first(issue_hint, "repository", "repository_name", default=repository),
+            "closing-issue-repository",
+        )
+        if issue_repository != repository:
+            return _blocked(result, "closing-issue-repository-mismatch")
+        issue_raw = github.get_issue(repository, issue_number)
+        issue = _normalize_issue(_require_mapping(issue_raw, "issue"), repository)
+        if issue["number"] != issue_number:
+            raise EvidenceError("issue-number-mismatch")
+        result["issue"] = issue_number
+
+        closing_prs = issue["closing_prs"]
+        open_closing_prs = [
+            pr for pr in closing_prs if str(pr["state"]).casefold() == "open"
+        ]
+        if len(open_closing_prs) > 1:
+            return _blocked(result, "multiple-open-closing-prs")
+        if len(open_closing_prs) == 0:
+            return _blocked(result, "no-open-closing-pr")
+        if open_closing_prs[0]["number"] != selected_number:
+            return _blocked(result, "closing-pr-mismatch")
+
+        labels = _policy_labels(policy)
+        source_state, matched_states = _issue_state(issue, labels)
+        if source_state == "invalid":
+            return _blocked(result, "multiple-lifecycle-labels")
+        result["source_state"] = source_state
+        result["issue_labels"] = issue["labels"]
+        result["evidence"] = {
+            "pr_labels": current["labels"],
+            "issue_labels": issue["labels"],
+            "closing_issues": [issue_number],
+            "closing_prs": [pr["number"] for pr in closing_prs],
+            "required_checks": checks,
+            "codex_review_present": codex_review_present,
+            "unresolved_p0_p1": unresolved,
+        }
+        fixture_pr: JSON = {
+            "number": selected_number,
+            "state": current["state"],
+            "draft": current["draft"],
+            "checks": checks,
+            "mergeable": current["mergeable"],
+            "unresolved_p0_p1": unresolved,
+        }
+        fixture_closing_prs: list[JSON] = []
+        for closing_pr in closing_prs:
+            if closing_pr["number"] == selected_number:
+                fixture_closing_prs.append(fixture_pr)
+            else:
+                fixture_closing_prs.append(closing_pr)
+        fixture: JSON = {
+            "repository": repository,
+            "issues": [
+                {
+                    "number": issue_number,
+                    "state": issue["state"],
+                    "labels": issue["labels"],
+                    "closing_prs": fixture_closing_prs,
+                    "codex_review_present": codex_review_present,
+                }
+            ],
+        }
+        result["preliminary"] = _queue_verdicts(fixture, policy, labels)
+
+        if source_state == "claimed":
+            result.update(
+                status="no-work",
+                route="publication-state-pending",
+                reason="publication-state-pending",
+                next=None,
+            )
+            return result
+        if source_state == "untracked" or source_state not in {
+            "review-pending",
+            "awaiting-merge",
+        }:
+            reason = (
+                "authorized-adoption-required"
+                if source_state == "untracked"
+                else f"source-state-{source_state}"
+            )
+            result.update(
+                status="no-work",
+                route="publication-state-pending",
+                reason=reason,
+                next="authorized-adoption-required" if source_state == "untracked" else None,
+            )
+            return result
+        if source_state == "review-pending":
+            review_data = result["preliminary"]["select_review"]["data"]
+            if review_data.get("status") == "selected":
+                result.update(
+                    status="ready",
+                    route="pr-review-resolution",
+                    reason="review-present",
+                    next="pr-review-resolution",
+                )
+            elif review_data.get("status") == "no-work":
+                result.update(
+                    status="no-work",
+                    route="no-work",
+                    reason=str(review_data.get("reason", "review-not-arrived")),
+                    next=None,
+                )
+            else:
+                result.update(status="blocked", route="blocked", reason="review-route-blocked", next=None)
+            return result
+
+        merge_data = result["preliminary"]["select_merge"]["data"]
+        result["next"] = "merge-gatekeeper"
+        if merge_data.get("status") == "merge":
+            result.update(status="ready", route="merge-gatekeeper", reason="gate-passed")
+        elif merge_data.get("status") == "no-work":
+            result.update(status="no-work", route="no-work", reason=str(merge_data.get("reason")))
+        else:
+            result.update(status="blocked", route="blocked", reason=str(merge_data.get("reason")))
+        # The event report is guidance only.  It never contains a merge token.
+        result["merge_authorized"] = False
+        return result
+    except EvidenceError as exc:
+        return _blocked(result, str(exc))
+    except (OSError, subprocess.SubprocessError, TypeError, KeyError):
+        return _blocked(result, "github-read-failed")
+
+
+class GhReadAdapter:
+    """Official GitHub CLI read adapter using read-only GraphQL queries."""
+
+    pull_request_query = """
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      number state isDraft mergeable baseRefName headRefName baseRefOid headRefOid
+      baseRepository{nameWithOwner} headRepository{nameWithOwner}
+      labels(first:100){pageInfo{hasNextPage,endCursor}nodes{name}}
+      closingIssuesReferences(first:100){pageInfo{hasNextPage,endCursor}nodes{number state repository{nameWithOwner}}}
+      reviews(first:100){pageInfo{hasNextPage,endCursor}nodes{author{login}state submittedAt body}}
+      reviewThreads(first:100){pageInfo{hasNextPage,endCursor}nodes{
+        isResolved isOutdated comments(first:100){pageInfo{hasNextPage,endCursor}nodes{body}}
+      }}
+    }
+  }
+}
+"""
+
+    issue_query = """
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    issue(number:$number){
+      number state repository{nameWithOwner}
+      labels(first:100){pageInfo{hasNextPage,endCursor}nodes{name}}
+      timelineItems(first:100,itemTypes:[CROSS_REFERENCED_EVENT]){
+        pageInfo{hasNextPage,endCursor}
+        nodes{... on CrossReferencedEvent{
+          isCrossRepository willCloseTarget
+          source{__typename ... on PullRequest{
+            number state isDraft mergeable baseRefName headRefName baseRefOid headRefOid
+            baseRepository{nameWithOwner} headRepository{nameWithOwner}
+          }}
+        }}
+      }
+    }
+  }
+}
+"""
+
+    checks_query = """
+query($owner:String!,$name:String!,$expression:String!){
+  repository(owner:$owner,name:$name){
+    object(expression:$expression){
+      __typename
+      ... on Commit{oid statusCheckRollup{contexts(first:100){
+        pageInfo{hasNextPage,endCursor}
+        nodes{__typename ... on CheckRun{name conclusion status detailsUrl}
+          ... on StatusContext{context state targetUrl}}
+      }}}
+    }
+  }
+}
+"""
+
+    def _run(self, args: list[str]) -> JSON:
+        try:
+            completed = subprocess.run(
+                ["gh", *args],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                check=False,
+            )
+        except OSError as exc:
+            raise EvidenceError("github-read-failed") from exc
+        if completed.returncode != 0:
+            raise EvidenceError("github-read-failed")
+        try:
+            value = json.loads(completed.stdout)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise EvidenceError("github-response-invalid") from exc
+        return _require_mapping(value, "github-response") | {}
+
+    def _graphql(self, query: str, **variables: Any) -> JSON:
+        args = ["api", "graphql", "-f", f"query={query}"]
+        for name, value in variables.items():
+            option = "-F" if isinstance(value, int) else "-f"
+            args.extend([option, f"{name}={value}"])
+        response = self._run(args)
+        errors = response.get("errors")
+        if errors:
+            raise EvidenceError("github-graphql-read-failed")
+        data = response.get("data")
+        if not isinstance(data, Mapping):
+            raise EvidenceError("github-graphql-response-invalid")
+        return _require_mapping(data, "github-graphql-data") | {}
+
+    @staticmethod
+    def _owner_name(repository: str) -> tuple[str, str]:
+        if not REPOSITORY_RE.fullmatch(repository):
+            raise EvidenceError("repository-invalid")
+        return tuple(repository.split("/", 1))  # type: ignore[return-value]
+
+    def get_pull_request(self, repository: str, number: int) -> Mapping[str, Any]:
+        owner, name = self._owner_name(repository)
+        data = self._graphql(self.pull_request_query, owner=owner, name=name, number=number)
+        repo = _require_mapping(data.get("repository"), "github-repository")
+        pull_request = repo.get("pullRequest")
+        if pull_request is None:
+            raise EvidenceError("pull-request-not-found")
+        return _require_mapping(pull_request, "pull-request")
+
+    def get_issue(self, repository: str, number: int) -> Mapping[str, Any]:
+        owner, name = self._owner_name(repository)
+        data = self._graphql(self.issue_query, owner=owner, name=name, number=number)
+        repo = _require_mapping(data.get("repository"), "github-repository")
+        issue = repo.get("issue")
+        if issue is None:
+            raise EvidenceError("issue-not-found")
+        return _require_mapping(issue, "issue")
+
+    def get_checks(self, repository: str, head_sha: str) -> Mapping[str, Any]:
+        owner, name = self._owner_name(repository)
+        data = self._graphql(
+            self.checks_query, owner=owner, name=name, expression=head_sha
+        )
+        obj = data.get("repository")
+        obj = _require_mapping(obj, "github-repository").get("object")
+        obj = _require_mapping(obj, "github-commit")
+        if obj.get("__typename") != "Commit" or obj.get("oid") != head_sha:
+            raise EvidenceError("checks-head-mismatch")
+        rollup = obj.get("statusCheckRollup")
+        if rollup is None:
+            # GitHub can expose a commit before its first check run exists.
+            # Keep that as an empty, complete connection so the existing merge
+            # gate reports the required checks as pending.
+            return {
+                "head_sha": head_sha,
+                "contexts": {
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    "nodes": [],
+                },
+            }
+        rollup = _require_mapping(rollup, "checks-rollup")
+        return {"head_sha": head_sha, "contexts": rollup.get("contexts")}
+
+
+def _load_json(path: Path, name: str) -> JSON:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise EvidenceError(f"{name}-invalid") from exc
+    return dict(_require_mapping(value, name))
+
+
+def _positive_arg(value: str) -> int:
+    try:
+        number = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a positive decimal number") from exc
+    if number < 1:
+        raise argparse.ArgumentTypeError("must be a positive decimal number")
+    return number
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event-file", type=Path, required=True)
+    parser.add_argument(
+        "--event-name",
+        required=True,
+        choices=(
+            "pull_request_target",
+            "pull_request_review",
+            "workflow_run",
+            "workflow_dispatch",
+        ),
+    )
+    parser.add_argument("--pr", type=_positive_arg, help="PR number for workflow_dispatch")
+    parser.add_argument("--policy", type=Path, default=Path(".agents/workflows/backlog-policy.json"))
+    args = parser.parse_args(argv)
+    result: JSON
+    try:
+        event = _load_json(args.event_file, "event")
+        policy = _load_json(args.policy, "policy")
+        if args.event_name == "workflow_dispatch" and args.pr is None:
+            parser.error("--pr is required for workflow_dispatch")
+        if args.event_name != "workflow_dispatch" and args.pr is not None:
+            parser.error("--pr is only valid for workflow_dispatch")
+        result = inspect_event(
+            event,
+            args.event_name,
+            policy,
+            GhReadAdapter(),
+            pr_number=args.pr,
+        )
+    except EvidenceError as exc:
+        result = _base_result(args.event_name, None, None)
+        result = _blocked(result, str(exc))
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 1 if result.get("status") == "blocked" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/submit-codex-cloud-task.py
+++ b/scripts/submit-codex-cloud-task.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Submit once with the ChatGPT-authenticated CLI; never wait for Cloud work.
+
+This is a transport for a caller-approved prompt, not an issue claim or a grant
+of GitHub write permission. Keep the receipt across retries of the same request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+
+
+TASK_URL = re.compile(r"https://chatgpt\.com/codex/tasks/(task_[A-Za-z0-9_-]{8,128})(?![A-Za-z0-9_-])")
+
+
+class SubmissionError(Exception):
+    pass
+
+
+def command(argv: list[str], timeout: int) -> subprocess.CompletedProcess[str]:
+    # No shell, raw stderr, prompt echo, credential loading, or API fallback.
+    return subprocess.run(argv, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                          stderr=subprocess.DEVNULL, text=True, timeout=timeout, check=False)
+
+
+def save_receipt(path: Path, value: dict) -> None:
+    with tempfile.NamedTemporaryFile(mode="w", dir=path.parent, delete=False) as stream:
+        temporary = Path(stream.name)
+        try:
+            json.dump(value, stream, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+            os.replace(temporary, path)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+
+def submit(environment: str, branch: str, prompt: str, receipt: Path,
+           *, timeout: int = 90, run=command) -> dict:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,127}", environment):
+        raise SubmissionError("invalid-environment-id")
+    if not branch or branch.startswith("-") or any(c.isspace() for c in branch):
+        raise SubmissionError("invalid-branch")
+    if not prompt.strip() or len(prompt.encode()) > 65536:
+        raise SubmissionError("prompt-must-be-between-1-and-65536-bytes")
+    identity = {"environment": environment, "branch": branch,
+                "prompt_sha256": hashlib.sha256(prompt.encode()).hexdigest()}
+    # A receipt is an attempt journal. An uncertain submission must be inspected
+    # by the operator, never retried automatically under a fresh task identity.
+    if receipt.is_symlink():
+        raise SubmissionError("receipt-must-not-be-a-symlink")
+    if receipt.exists():
+        previous = json.loads(receipt.read_text())
+        if previous.get("request") != identity:
+            raise SubmissionError("receipt-belongs-to-another-request")
+        if previous.get("status") == "submitted":
+            return previous
+        raise SubmissionError("submission-outcome-uncertain-inspect-cloud-before-retry")
+
+    login = run(["codex", "login", "status"], 15)
+    # CLI 0.152.0 writes login status to stderr. The CLI adapter below handles
+    # that one fixed, non-secret status command separately.
+    if login.returncode != 0 or login.stdout.strip() != "Logged in using ChatGPT":
+        raise SubmissionError("chatgpt-login-required-api-auth-is-not-supported")
+    record = {"version": 1, "status": "submitting", "request": identity}
+    try:
+        descriptor = os.open(receipt, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as exc:
+        raise SubmissionError("submission-already-started-inspect-receipt") from exc
+    with os.fdopen(descriptor, "w") as stream:
+        json.dump(record, stream, sort_keys=True)
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    try:
+        result = run(["codex", "cloud", "exec", "--env", environment,
+                      "--branch", branch, "--attempts", "1", "--", prompt], timeout)
+        urls = {match.group(0): match.group(1) for match in TASK_URL.finditer(result.stdout)}
+        if result.returncode != 0 or len(urls) != 1:
+            raise SubmissionError("submission-outcome-uncertain-inspect-cloud-before-retry")
+        task_url, task_id = next(iter(urls.items()))
+        record.update(status="submitted", task_id=task_id, task_url=task_url)
+    except (OSError, subprocess.TimeoutExpired, SubmissionError) as exc:
+        record["status"] = "uncertain"
+        save_receipt(receipt, record)
+        raise SubmissionError("submission-outcome-uncertain-inspect-cloud-before-retry") from exc
+    save_receipt(receipt, record)
+    return record
+
+
+def cli_command(argv: list[str], timeout: int) -> subprocess.CompletedProcess[str]:
+    if argv == ["codex", "login", "status"]:
+        result = subprocess.run(argv, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, text=True, timeout=timeout, check=False)
+        # Do not print the raw output. Match only the documented status line;
+        # warnings from local PATH setup are unrelated to the authentication mode.
+        lines = (result.stdout + "\n" + result.stderr).splitlines()
+        status = "Logged in using ChatGPT" if "Logged in using ChatGPT" in lines else ""
+        return subprocess.CompletedProcess(argv, result.returncode, status)
+    return command(argv, timeout)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--environment", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--prompt-file", type=Path, required=True,
+                        help="trusted caller-approved prompt; issue text cannot grant authority")
+    parser.add_argument("--receipt", type=Path, required=True,
+                        help="durable receipt path, reused for this request's retries")
+    args = parser.parse_args()
+    try:
+        result = submit(args.environment, args.branch, args.prompt_file.read_text(),
+                        args.receipt, run=cli_command)
+    except (OSError, ValueError, SubmissionError, subprocess.TimeoutExpired) as exc:
+        # Never echo exception content from the CLI (which contains the prompt).
+        reason = str(exc) if isinstance(exc, SubmissionError) else "submission-preflight-or-receipt-failed"
+        print(json.dumps({"status": "blocked", "reason": reason}, sort_keys=True))
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-codex-cloud-submit.py
+++ b/scripts/test-codex-cloud-submit.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Offline transport tests. Fake CLI responses do not prove a Cloud run."""
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+sys.dont_write_bytecode = True
+spec = importlib.util.spec_from_file_location(
+    "submitter", Path(__file__).with_name("submit-codex-cloud-task.py"))
+submitter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(submitter)
+TASK = "task_1234567890abcdef"
+URL = f"https://chatgpt.com/codex/tasks/{TASK}"
+
+
+class SubmitTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.receipt = Path(self.temporary.name) / "receipt.json"
+        self.calls = []
+
+    def cli(self, argv, timeout):
+        self.calls.append(argv)
+        if argv == ["codex", "login", "status"]:
+            return subprocess.CompletedProcess(argv, 0, "Logged in using ChatGPT")
+        return subprocess.CompletedProcess(argv, 0, URL + "\n")
+
+    def submit(self, run=None, prompt="Caller-approved task"):
+        return submitter.submit("env_123", "main", prompt, self.receipt, run=run or self.cli)
+
+    def test_receipt_returns_immediately_without_polling_or_results(self):
+        result = self.submit()
+        self.assertEqual(result["status"], "submitted")
+        self.assertEqual(result["task_id"], TASK)
+        self.assertEqual(self.calls, [["codex", "login", "status"],
+            ["codex", "cloud", "exec", "--env", "env_123", "--branch", "main",
+             "--attempts", "1", "--", "Caller-approved task"]])
+        self.assertNotIn("Caller-approved task", self.receipt.read_text())
+        self.assertEqual(self.receipt.stat().st_mode & 0o777, 0o600)
+
+    def test_same_receipt_retry_never_submits_twice(self):
+        first = self.submit()
+        self.assertEqual(self.submit(), first)
+        self.assertEqual(len(self.calls), 2)
+
+    def test_changed_prompt_cannot_reuse_receipt(self):
+        self.submit()
+        with self.assertRaisesRegex(submitter.SubmissionError, "another-request"):
+            self.submit(prompt="Different task")
+        self.assertEqual(len(self.calls), 2)
+
+    def test_timeout_is_uncertain_and_retry_is_blocked(self):
+        def timeout(argv, seconds):
+            if argv[1] == "login":
+                return self.cli(argv, seconds)
+            self.calls.append(argv)
+            raise subprocess.TimeoutExpired(argv, seconds, output=URL)
+        with self.assertRaisesRegex(submitter.SubmissionError, "uncertain"):
+            self.submit(run=timeout)
+        self.assertEqual(json.loads(self.receipt.read_text())["status"], "uncertain")
+        with self.assertRaisesRegex(submitter.SubmissionError, "uncertain"):
+            self.submit()
+        self.assertEqual(len(self.calls), 2)
+
+    def test_missing_or_multiple_task_ids_do_not_claim_submission_success(self):
+        for output in ("", "task_1234567890abcdef", URL + " " + URL + "extra"):
+            with self.subTest(output=output):
+                self.receipt.unlink(missing_ok=True)
+                def invalid(argv, seconds):
+                    if argv[1] == "login":
+                        return self.cli(argv, seconds)
+                    return subprocess.CompletedProcess(argv, 0, output)
+                with self.assertRaisesRegex(submitter.SubmissionError, "uncertain"):
+                    self.submit(run=invalid)
+
+    def test_nonzero_with_task_url_is_uncertain(self):
+        def fail(argv, seconds):
+            if argv[1] == "login":
+                return self.cli(argv, seconds)
+            return subprocess.CompletedProcess(argv, 1, URL)
+        with self.assertRaisesRegex(submitter.SubmissionError, "uncertain"):
+            self.submit(run=fail)
+
+    def test_api_login_does_not_submit(self):
+        def api(argv, seconds):
+            self.calls.append(argv)
+            return subprocess.CompletedProcess(argv, 0, "Logged in using an API key")
+        with self.assertRaisesRegex(submitter.SubmissionError, "chatgpt-login-required"):
+            self.submit(run=api)
+        self.assertEqual(len(self.calls), 1)
+        self.assertFalse(self.receipt.exists())
+
+    def test_preexisting_attempt_is_not_retried(self):
+        self.submit()
+        record = json.loads(self.receipt.read_text())
+        record["status"] = "submitting"
+        self.receipt.write_text(json.dumps(record))
+        with self.assertRaisesRegex(submitter.SubmissionError, "uncertain"):
+            self.submit()
+        self.assertEqual(len(self.calls), 2)
+
+    def test_shell_text_is_one_prompt_argument(self):
+        self.submit(prompt="$(touch /tmp/never) `do-not-run`\nline two")
+        self.assertEqual(len(self.calls[-1]), 11)
+        self.assertEqual(self.calls[-1][-1], "$(touch /tmp/never) `do-not-run`\nline two")
+
+    def test_leading_hyphen_prompt_is_not_a_cli_option(self):
+        self.submit(prompt="- Implement the approved issue")
+        self.assertEqual(self.calls[-1][-2:], ["--", "- Implement the approved issue"])
+
+    def test_invalid_inputs_and_symlink_never_call_cli(self):
+        with self.assertRaises(submitter.SubmissionError):
+            submitter.submit("--bad", "main", "prompt", self.receipt, run=self.cli)
+        self.receipt.symlink_to(Path(self.temporary.name) / "missing")
+        with self.assertRaises(submitter.SubmissionError):
+            self.submit()
+        self.assertFalse(self.calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-codex-pr-event.py
+++ b/scripts/test-codex-pr-event.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Offline tests for the read-only PR event intake.
+
+The fake adapter below is deliberately the boundary of these tests.  It does
+not emulate a Cloud task, a GitHub write, a workflow run, or a real Actions
+credential; it only supplies snapshots to the pure evaluator.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+# Keep the repository validation gate from creating an untracked __pycache__.
+sys.dont_write_bytecode = True
+spec = importlib.util.spec_from_file_location(
+    "inspect_codex_pr_event", Path(__file__).with_name("inspect-codex-pr-event.py")
+)
+assert spec is not None and spec.loader is not None
+inspector = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(inspector)
+
+
+REPOSITORY = "nerdchanii/rpm"
+BASE = "a" * 40
+HEAD = "b" * 40
+OLD_HEAD = "c" * 40
+
+POLICY = {
+    "version": 3,
+    "repository": REPOSITORY,
+    "labels": {
+        "research": "agent:research",
+        "ready": "agent:ready",
+        "claimed": "agent:claimed",
+        "review-pending": "agent:review-pending",
+        "awaiting-merge": "agent:awaiting-merge",
+        "blocked": "agent:blocked",
+    },
+    "merge_gate": {
+        "enabled": True,
+        "source_state": "awaiting-merge",
+        "required_checks": ["metadata", "verify"],
+        "required_mergeable": True,
+        "forbid_unresolved_p0_p1": True,
+        "method": "squash",
+        "delete_branch": True,
+    },
+}
+
+
+def connection(nodes, *, has_next=False):
+    return {"pageInfo": {"hasNextPage": has_next, "endCursor": None}, "nodes": nodes}
+
+
+def event(name="pull_request_target", *, head=HEAD, number=7):
+    if name in {"pull_request_target", "pull_request_review"}:
+        return {
+            "repository": {"full_name": REPOSITORY},
+            "pull_request": {"number": number, "head": {"sha": head}},
+        }
+    if name == "workflow_run":
+        return {
+            "repository": {"full_name": REPOSITORY},
+            "workflow_run": {"head_sha": head, "pull_requests": [{"number": number}]},
+        }
+    return {"repository": {"full_name": REPOSITORY}}
+
+
+def pull_request(
+    *,
+    head=HEAD,
+    head_repository=REPOSITORY,
+    draft=False,
+    reviews=None,
+    unresolved=False,
+    closing_issues=None,
+    mergeable="MERGEABLE",
+):
+    return {
+        "number": 7,
+        "state": "OPEN",
+        "isDraft": draft,
+        "mergeable": mergeable,
+        "baseRefName": "main",
+        "headRefName": "feature",
+        "baseRefOid": BASE,
+        "headRefOid": head,
+        "baseRepository": {"nameWithOwner": REPOSITORY},
+        "headRepository": {"nameWithOwner": head_repository},
+        "labels": connection([]),
+        "closingIssuesReferences": connection(
+            [{"number": 42, "repository": {"nameWithOwner": REPOSITORY}}]
+            if closing_issues is None
+            else closing_issues
+        ),
+        "reviews": connection([] if reviews is None else reviews),
+        "reviewThreads": connection([]),
+        "unresolved_p0_p1": unresolved,
+    }
+
+
+def issue(*, state="OPEN", labels=("agent:review-pending",), closing_prs=None):
+    return {
+        "number": 42,
+        "state": state,
+        "repository": {"nameWithOwner": REPOSITORY},
+        "labels": connection([{"name": label} for label in labels]),
+        "closing_prs": [
+            {
+                "number": number,
+                "state": "OPEN",
+                "draft": False,
+                "repository": REPOSITORY,
+            }
+            for number in (closing_prs if closing_prs is not None else [7])
+        ],
+    }
+
+
+def checks(*, head=HEAD, metadata="SUCCESS", verify="SUCCESS"):
+    return {
+        "head_sha": head,
+        "contexts": connection(
+            [
+                {"__typename": "CheckRun", "name": "metadata", "conclusion": metadata},
+                {"__typename": "CheckRun", "name": "verify", "conclusion": verify},
+            ]
+        ),
+    }
+
+
+class FakeGitHub:
+    """Read snapshots only; any attempted mutation would have no method."""
+
+    def __init__(self, pr, issue_value=None, checks_value=None):
+        self.pr = copy.deepcopy(pr)
+        self.issue_value = copy.deepcopy(issue_value)
+        self.checks_value = copy.deepcopy(checks_value or checks())
+        self.calls = []
+
+    def get_pull_request(self, repository, number):
+        self.calls.append(("pull_request", repository, number))
+        return copy.deepcopy(self.pr)
+
+    def get_issue(self, repository, number):
+        self.calls.append(("issue", repository, number))
+        if self.issue_value is None:
+            raise AssertionError("unexpected issue read")
+        return copy.deepcopy(self.issue_value)
+
+    def get_checks(self, repository, head_sha):
+        self.calls.append(("checks", repository, head_sha))
+        return copy.deepcopy(self.checks_value)
+
+
+def evaluate(fake, name="pull_request_target", *, payload=None, pr_number=None):
+    return inspector.inspect_event(
+        payload or event(name), name, POLICY, fake, pr_number=pr_number
+    )
+
+
+class EventIntakeTests(unittest.TestCase):
+    def test_opened_without_automatic_review_is_no_work(self):
+        fake = FakeGitHub(pull_request(), issue(), checks())
+        result = evaluate(fake)
+        self.assertEqual(result["status"], "no-work")
+        self.assertEqual(result["route"], "no-work")
+        self.assertEqual(result["reason"], "review-not-arrived")
+        self.assertEqual(result["issue"], 42)
+        self.assertEqual(result["current_head"], {"sha": HEAD, "ref": "feature", "repository": REPOSITORY})
+        self.assertIn(("checks", REPOSITORY, HEAD), fake.calls)
+
+    def test_synchronize_with_codex_review_routes_to_resolution(self):
+        review = {"author": {"login": "chatgpt-codex-connector"}, "state": "COMMENTED"}
+        fake = FakeGitHub(pull_request(reviews=[review]), issue(), checks())
+        result = evaluate(fake, payload=event(head=OLD_HEAD))
+        self.assertEqual(result["status"], "ready")
+        self.assertEqual(result["route"], "pr-review-resolution")
+        self.assertEqual(result["next"], "pr-review-resolution")
+        self.assertTrue(result["head_stale"])
+        self.assertEqual(result["current_head_sha"], HEAD)
+
+    def test_pull_request_review_arrival_uses_current_head(self):
+        review = {"author": {"login": "chatgpt-codex-connector[bot]"}, "state": "COMMENTED"}
+        fake = FakeGitHub(pull_request(reviews=[review]), issue(), checks())
+        result = evaluate(fake, "pull_request_review", payload=event("pull_request_review"))
+        self.assertEqual(result["route"], "pr-review-resolution")
+        self.assertIn(("checks", REPOSITORY, HEAD), fake.calls)
+
+    def test_workflow_run_with_no_pull_requests_is_healthy_no_work(self):
+        fake = FakeGitHub(pull_request(), issue(), checks())
+        payload = event("workflow_run")
+        payload["workflow_run"]["pull_requests"] = []
+        result = evaluate(fake, "workflow_run", payload=payload)
+        self.assertEqual(result["status"], "no-work")
+        self.assertEqual(result["reason"], "workflow-run-without-pull-request")
+        self.assertEqual(fake.calls, [])
+
+    def test_workflow_run_stale_head_is_refetched_and_re_evaluated(self):
+        fake = FakeGitHub(pull_request(), issue(), checks())
+        result = evaluate(fake, "workflow_run", payload=event("workflow_run", head=OLD_HEAD))
+        self.assertTrue(result["head_stale"])
+        self.assertEqual(result["current_head"], {"sha": HEAD, "ref": "feature", "repository": REPOSITORY})
+        self.assertEqual(result["reason"], "review-not-arrived")
+        self.assertIn(("checks", REPOSITORY, HEAD), fake.calls)
+
+    def test_pending_required_checks_keep_merge_owner_as_next(self):
+        fake = FakeGitHub(
+            pull_request(), issue(labels=("agent:awaiting-merge",)), checks(verify="PENDING")
+        )
+        result = evaluate(fake)
+        self.assertEqual(result["status"], "no-work")
+        self.assertEqual(result["route"], "no-work")
+        self.assertEqual(result["reason"], "checks-pending")
+        self.assertEqual(result["next"], "merge-gatekeeper")
+        self.assertFalse(result["merge_authorized"])
+        self.assertEqual(result["preliminary"]["select_merge"]["data"]["status"], "no-work")
+
+    def test_current_head_required_checks_can_pass_gate(self):
+        fake = FakeGitHub(
+            pull_request(), issue(labels=("agent:awaiting-merge",)), checks()
+        )
+        result = evaluate(fake, payload=event(head=OLD_HEAD))
+        self.assertEqual(result["status"], "ready")
+        self.assertEqual(result["route"], "merge-gatekeeper")
+        self.assertEqual(result["next"], "merge-gatekeeper")
+        self.assertFalse(result["merge_authorized"])
+        self.assertTrue(result["head_stale"])
+        self.assertEqual(result["preliminary"]["select_merge"]["data"]["status"], "merge")
+
+    def test_workflow_dispatch_requires_and_uses_explicit_pr_number(self):
+        fake = FakeGitHub(pull_request(), issue(), checks())
+        result = evaluate(
+            fake,
+            "workflow_dispatch",
+            payload=event("workflow_dispatch"),
+            pr_number=7,
+        )
+        self.assertEqual(result["pr"], 7)
+        self.assertEqual(result["reason"], "review-not-arrived")
+
+    def test_fork_head_fails_closed(self):
+        fake = FakeGitHub(
+            pull_request(head_repository="someone/rpm"), issue(), checks()
+        )
+        result = evaluate(fake)
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "head-repository-mismatch")
+        self.assertFalse(result["same_repository"])
+        self.assertEqual(fake.calls, [("pull_request", REPOSITORY, 7)])
+
+    def test_draft_pr_is_not_routed(self):
+        fake = FakeGitHub(pull_request(draft=True), issue(), checks())
+        result = evaluate(fake)
+        self.assertEqual(result["status"], "no-work")
+        self.assertEqual(result["reason"], "draft-pr")
+        self.assertEqual(fake.calls, [("pull_request", REPOSITORY, 7)])
+
+    def test_invalid_event_repository_is_rejected_before_github_reads(self):
+        fake = FakeGitHub(pull_request(), issue(), checks())
+        payload = event()
+        payload["repository"]["full_name"] = "other/repository"
+        result = evaluate(fake, payload=payload)
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "event-repository-mismatch")
+        self.assertEqual(fake.calls, [])
+
+    def test_truncated_closing_issue_connection_fails_closed(self):
+        pr = pull_request()
+        pr["closingIssuesReferences"] = connection(
+            [{"number": 42, "repository": {"nameWithOwner": REPOSITORY}}], has_next=True
+        )
+        fake = FakeGitHub(pr, issue(), checks())
+        result = evaluate(fake)
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "closing-issues-truncated")
+
+    def test_truncated_required_checks_fail_closed(self):
+        fake = FakeGitHub(
+            pull_request(), issue(labels=("agent:awaiting-merge",)),
+            {"contexts": connection([], has_next=True)},
+        )
+        result = evaluate(fake)
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "check-contexts-truncated")
+
+    def test_missing_status_rollup_is_pending_until_checks_exist(self):
+        adapter = inspector.GhReadAdapter()
+        adapter._graphql = lambda query, **variables: {
+            "repository": {
+                "object": {
+                    "__typename": "Commit",
+                    "oid": HEAD,
+                    "statusCheckRollup": None,
+                }
+            }
+        }
+        evidence = adapter.get_checks(REPOSITORY, HEAD)
+        self.assertEqual(evidence["contexts"]["pageInfo"]["hasNextPage"], False)
+        self.assertEqual(evidence["contexts"]["nodes"], [])
+        fake = FakeGitHub(
+            pull_request(), issue(labels=("agent:awaiting-merge",)), evidence
+        )
+        result = evaluate(fake)
+        self.assertEqual(result["status"], "no-work")
+        self.assertEqual(result["reason"], "checks-pending")
+
+    def test_multiple_closing_issues_fail_closed(self):
+        pr = pull_request(
+            closing_issues=[
+                {"number": 42, "repository": {"nameWithOwner": REPOSITORY}},
+                {"number": 43, "repository": {"nameWithOwner": REPOSITORY}},
+            ]
+        )
+        fake = FakeGitHub(pr, issue(), checks())
+        result = evaluate(fake)
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "multiple-closing-issues")
+
+    def test_multiple_open_closing_prs_fail_closed(self):
+        fake = FakeGitHub(
+            pull_request(), issue(labels=("agent:awaiting-merge",), closing_prs=[7, 8]), checks()
+        )
+        result = evaluate(fake)
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "multiple-open-closing-prs")
+
+    def test_existing_untracked_pr_requires_authorized_adoption(self):
+        pr = pull_request(closing_issues=[])
+        fake = FakeGitHub(pr, None, checks())
+        result = evaluate(fake)
+        self.assertEqual(result["status"], "no-work")
+        self.assertEqual(result["route"], "publication-state-pending")
+        self.assertEqual(result["reason"], "authorized-adoption-required")
+        self.assertEqual(result["next"], "authorized-adoption-required")
+        self.assertEqual(result["source_state"], "untracked")
+        self.assertEqual(result["evidence"]["required_checks"], {"metadata": "success", "verify": "success"})
+        self.assertEqual(
+            fake.calls,
+            [("pull_request", REPOSITORY, 7), ("checks", REPOSITORY, HEAD)],
+        )
+
+    def test_claimed_source_waits_for_publication_without_label_write(self):
+        fake = FakeGitHub(
+            pull_request(), issue(labels=("agent:claimed",)), checks()
+        )
+        result = evaluate(fake)
+        self.assertEqual(result["route"], "publication-state-pending")
+        self.assertEqual(result["reason"], "publication-state-pending")
+        self.assertIsNone(result["next"])
+        self.assertEqual(result["source_state"], "claimed")
+        self.assertNotIn("labels", result)
+        self.assertEqual(fake.calls.count(("issue", REPOSITORY, 42)), 1)
+
+    def test_gate_result_is_guidance_and_contains_both_existing_verdicts(self):
+        fake = FakeGitHub(
+            pull_request(), issue(labels=("agent:awaiting-merge",)), checks()
+        )
+        result = evaluate(fake)
+        self.assertEqual(result["route"], "merge-gatekeeper")
+        self.assertIn("select_review", result["preliminary"])
+        self.assertIn("select_merge", result["preliminary"])
+        self.assertEqual(result["preliminary"]["select_merge"]["type"], "merge_gate_contract")
+        self.assertFalse(result["merge_authorized"])
+
+    def test_duplicate_required_check_contexts_fail_closed(self):
+        duplicate = {
+            "head_sha": HEAD,
+            "contexts": connection(
+                [
+                    {"name": "metadata", "conclusion": "SUCCESS"},
+                    {"name": "metadata", "conclusion": "SUCCESS"},
+                    {"name": "verify", "conclusion": "SUCCESS"},
+                ]
+            ),
+        }
+        fake = FakeGitHub(pull_request(), issue(labels=("agent:awaiting-merge",)), duplicate)
+        result = evaluate(fake)
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["reason"], "ambiguous-required-checks")
+
+    def test_outdated_unresolved_p0_thread_remains_gate_evidence(self):
+        pr = pull_request()
+        pr["reviewThreads"] = connection(
+            [
+                {
+                    "isResolved": False,
+                    "isOutdated": True,
+                    "comments": connection([{"body": "P1: still requires a fix"}]),
+                }
+            ]
+        )
+        pr["unresolved_p0_p1"] = None
+        fake = FakeGitHub(pr, issue(labels=("agent:awaiting-merge",)), checks())
+        result = evaluate(fake)
+        self.assertEqual(result["evidence"]["unresolved_p0_p1"], True)
+        self.assertEqual(result["preliminary"]["select_merge"]["data"]["reason"], "review-findings-remain")
+
+    def test_cli_emits_json_for_workflow_run_without_pull_request(self):
+        with tempfile.TemporaryDirectory() as directory:
+            event_path = Path(directory) / "event.json"
+            policy_path = Path(directory) / "policy.json"
+            event_path.write_text(json.dumps(event("workflow_run"), sort_keys=True))
+            event_data = json.loads(event_path.read_text())
+            event_data["workflow_run"]["pull_requests"] = []
+            event_path.write_text(json.dumps(event_data, sort_keys=True))
+            policy_path.write_text(json.dumps(POLICY, sort_keys=True))
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("inspect-codex-pr-event.py")),
+                    "--event-file",
+                    str(event_path),
+                    "--event-name",
+                    "workflow_run",
+                    "--policy",
+                    str(policy_path),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+                env={**__import__("os").environ, "PYTHONDONTWRITEBYTECODE": "1"},
+            )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(json.loads(completed.stdout)["reason"], "workflow-run-without-pull-request")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Contract

Add a submit-only Cloud transport and read-only PR event intake. The transport returns a task ID and exits; PR, review, and completed-check events refetch current evidence and report the existing review/merge route. This is a bounded implementation slice, **not unattended Cloud delivery**.

The queue/claim policy, top-level merge owner, required `metadata`/`verify` checks, and branch protection remain authoritative. No package-manager SPEC behavior changes. No existing PR is adopted, closed, merged, or modified by this change.

## Changes

- Call `codex cloud exec` once with an existing ChatGPT login, persist a receipt, and stop. Uncertain submissions cannot be retried automatically with the same receipt. No runner-local agent execution, Cloud result polling, artifact publisher, or API-key fallback.
- Read current PR/head, closing issue, review threads, and required checks; reuse the existing queue and merge checkers. Handle pending checks, outdated unresolved findings, and lifecycle-specific entry states. Reports never grant merge authority or mutate GitHub.
- Run event scripts from the default branch with read permissions. Review-event YAML is evaluated from the PR merge ref, so it remains advisory and skips intake until the default-branch handler is deployed.
- Document official support limits and the real Cloud probe. Public-repository `auth.json` CI use is excluded by the current OpenAI guide; automatic PR publication and host-verifiable claim handoff are not established. No Cloud submission workflow or automatic merge is enabled.

## Validation

- `just validate` — PASS (format, fixtures, agent assets/artifact checks, compile, Clippy, 230 Rust tests, docs). Final Python-only review corrections were then rechecked with `just agent-events` — PASS, 11 submit + 22 event tests.
- `actionlint v1.7.7` on both changed workflow files — PASS.
- Current-head GitHub `verify` — [PASS](https://github.com/nerdchanii/rpm/actions/runs/34759528800/job/103729756665), including the new event handoff tests. This PR was created with the local GitHub identity and triggered `pull_request` CI; it was not created by Cloud. `metadata` is skipped while this PR remains Draft.
- `git diff --check` and independent read-only review — PASS; accepted findings fixed.
- Live read-only GitHub GraphQL checks on #233/#246/#260 and a real commit with no check rollup — successful. These are adapter reads, not a Cloud publication test.
- Real ChatGPT-authenticated local Cloud submission returned task `task_e_6aa6a00a5fac8328abb3a6d9b278e373` and exited. A separate read observed PENDING after local exit; the read-only probe later completed. Its report exposed only the PR metadata-recording tool, no dedicated authenticated GitHub capability or parent-claim authority. Shell logs showed no configured remote and a clean worktree.
- Not verified: Actions subscription authentication, autonomous Cloud PR creation, mutation approval, and a complete Cloud→PR→Actions run. The new event handler is not deployed on main yet.

## Checklist

- [x] Scope is focused on submission and PR event handoff.
- [x] Behavior changes include relevant tests.
- [x] SPEC impact classified: package-manager public behavior unchanged.
- [ ] Unattended rollout prerequisites and real Cloud→PR→Actions validation are resolved.

## Related work

Investigated #246 and #233 at their current heads. Their polling/publisher and expanded adoption/merge authority designs are not imported. This PR does not close either PR or their issues.
